### PR TITLE
fix(core): use system message as user message for claude model if needed

### DIFF
--- a/packages/core/src/models/openai-chat-model.ts
+++ b/packages/core/src/models/openai-chat-model.ts
@@ -1,6 +1,7 @@
 import { nanoid } from "nanoid";
 import OpenAI from "openai";
 import type { ChatCompletionMessageParam, ChatCompletionTool } from "openai/resources";
+import { parseJSON } from "../utils/json-schema.js";
 import { isNonNullable } from "../utils/type-utils.js";
 import {
   ChatModel,
@@ -82,7 +83,7 @@ export class OpenAIChatModel extends ChatModel {
     const result: ChatModelOutput = {};
 
     if (input.responseFormat?.type === "json_schema" && text) {
-      result.json = JSON.parse(text);
+      result.json = parseJSON(text);
     } else {
       result.text = text;
     }
@@ -90,7 +91,7 @@ export class OpenAIChatModel extends ChatModel {
     if (toolCalls.length) {
       result.toolCalls = toolCalls.map(({ args, ...c }) => ({
         ...c,
-        function: { ...c.function, arguments: JSON.parse(args) },
+        function: { ...c.function, arguments: parseJSON(args) },
       }));
     }
 

--- a/packages/core/src/utils/json-schema.ts
+++ b/packages/core/src/utils/json-schema.ts
@@ -2,6 +2,7 @@ import { isObject } from "lodash-es";
 import type { ZodType } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import type { Message } from "../agents/agent.js";
+import { logger } from "./logger.js";
 
 export function outputSchemaToResponseFormatSchema(
   agentOutput: ZodType<Message>,
@@ -26,4 +27,13 @@ function setAdditionPropertiesDeep<T>(schema: T, additionalProperties: boolean):
     ) as T;
   }
   return schema;
+}
+
+export function parseJSON(json: string) {
+  try {
+    return JSON.parse(json);
+  } catch (error) {
+    logger.debug("Failed to parse JSON", { json, error });
+    throw error;
+  }
 }

--- a/packages/core/src/utils/json-schema.ts
+++ b/packages/core/src/utils/json-schema.ts
@@ -34,6 +34,6 @@ export function parseJSON(json: string) {
     return JSON.parse(json);
   } catch (error) {
     logger.debug("Failed to parse JSON", { json, error });
-    throw error;
+    throw new Error(`Failed to parse JSON ${error.message}`);
   }
 }


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(core): use system message as user message for claude model if user message is not provided (claude model requirements)
2. cath and log errors for JSON.parse

### Checklist

- [x] The newly added code logic is also covered by tests




<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

### Release Notes

- **New Feature**: Introduced dynamic schema generation for `OrchestratorAgent`, enhancing flexibility in schema definitions.
- **Refactor**: Updated `Agent` class to use function-based schemas, improving validation and encapsulation.
- **Error Handling**: Enhanced JSON parsing with safer methods and added error logging for better debugging.
- **Testing**: Added tests for chat models and utility functions to ensure robust message handling and schema validation.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->