### PR TITLE
fix: remove usage of new Node.js exists API for compatibility

### DIFF
--- a/examples/mcp-github/package.json
+++ b/examples/mcp-github/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@aigne/core": "workspace:^",
-    "openai": "^4.91.1",
+    "openai": "^4.93.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/mcp-puppeteer/package.json
+++ b/examples/mcp-puppeteer/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@aigne/core": "workspace:^",
-    "openai": "^4.91.1",
+    "openai": "^4.93.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/mcp-sqlite/package.json
+++ b/examples/mcp-sqlite/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@aigne/core": "workspace:^",
-    "openai": "^4.91.1",
+    "openai": "^4.93.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/workflow-code-execution/package.json
+++ b/examples/workflow-code-execution/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@aigne/core": "workspace:^",
-    "openai": "^4.91.1",
+    "openai": "^4.93.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/workflow-concurrency/package.json
+++ b/examples/workflow-concurrency/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@aigne/core": "workspace:^",
-    "openai": "^4.91.1",
+    "openai": "^4.93.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/workflow-group-chat/package.json
+++ b/examples/workflow-group-chat/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@aigne/core": "workspace:^",
-    "openai": "^4.91.1",
+    "openai": "^4.93.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/workflow-handoff/package.json
+++ b/examples/workflow-handoff/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@aigne/core": "workspace:^",
-    "openai": "^4.91.1",
+    "openai": "^4.93.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/workflow-orchestrator/package.json
+++ b/examples/workflow-orchestrator/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aigne/agent-library": "workspace:^",
     "@aigne/core": "workspace:^",
-    "openai": "^4.91.1",
+    "openai": "^4.93.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/workflow-reflection/package.json
+++ b/examples/workflow-reflection/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@aigne/core": "workspace:^",
-    "openai": "^4.91.1",
+    "openai": "^4.93.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/workflow-router/package.json
+++ b/examples/workflow-router/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@aigne/core": "workspace:^",
-    "openai": "^4.91.1",
+    "openai": "^4.93.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/workflow-sequential/package.json
+++ b/examples/workflow-sequential/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@aigne/core": "workspace:^",
-    "openai": "^4.91.1",
+    "openai": "^4.93.0",
     "zod": "^3.24.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "simple-git-hooks": "^2.12.1",
-    "typescript": "^5.8.2",
-    "zx": "^8.5.0"
+    "typescript": "^5.8.3",
+    "zx": "^8.5.2"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"

--- a/packages/agent-library/package.json
+++ b/packages/agent-library/package.json
@@ -53,9 +53,9 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "@types/bun": "^1.2.8",
+    "@types/bun": "^1.2.9",
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.0.1",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.3"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,25 +47,25 @@
   },
   "dependencies": {
     "@aigne/core": "workspace:^",
-    "@modelcontextprotocol/sdk": "^1.8.0",
+    "@modelcontextprotocol/sdk": "^1.9.0",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
     "express": "^5.1.0",
     "gradient-string": "^3.0.0",
-    "inquirer": "^12.5.0",
-    "openai": "^4.91.1",
+    "inquirer": "^12.5.2",
+    "openai": "^4.93.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {
     "@aigne/test-utils": "workspace:^",
-    "@types/bun": "^1.2.8",
+    "@types/bun": "^1.2.9",
     "@types/express": "^5.0.1",
     "@types/gradient-string": "^1.1.6",
     "@types/node": "^22.14.0",
     "detect-port": "^2.1.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.0.1",
-    "typescript": "^5.8.2",
-    "ufo": "^1.6.0"
+    "typescript": "^5.8.3",
+    "ufo": "^1.6.1"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,10 +69,10 @@
   },
   "dependencies": {
     "@aigne/json-schema-to-zod": "^1.3.3",
-    "@modelcontextprotocol/sdk": "^1.8.0",
+    "@modelcontextprotocol/sdk": "^1.9.0",
     "@types/debug": "^4.1.12",
     "debug": "^4.4.0",
-    "inquirer": "^12.5.0",
+    "inquirer": "^12.5.2",
     "mustache": "^4.2.0",
     "nanoid": "^5.1.5",
     "ora": "^8.2.0",
@@ -90,15 +90,15 @@
     "@aigne/test-utils": "workspace:^",
     "@anthropic-ai/sdk": "^0.39.0",
     "@google/generative-ai": "^0.24.0",
-    "@types/bun": "^1.2.8",
+    "@types/bun": "^1.2.9",
     "@types/express": "^5.0.1",
     "@types/mustache": "^4.2.5",
     "@types/node": "^22.14.0",
     "detect-port": "^2.1.0",
     "express": "^5.1.0",
     "npm-run-all": "^4.1.5",
-    "openai": "^4.91.1",
+    "openai": "^4.93.0",
     "rimraf": "^6.0.1",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.3"
   }
 }

--- a/packages/core/src/loader/index.ts
+++ b/packages/core/src/loader/index.ts
@@ -1,4 +1,4 @@
-import { exists, readFile, stat } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import { dirname, extname, join } from "node:path";
 import { parse } from "yaml";
 import { z } from "zod";
@@ -157,7 +157,7 @@ async function getAIGNEFilePath(path: string) {
   if (s.isDirectory()) {
     for (const file of AIGNE_FILE_NAME) {
       const filePath = join(path, file);
-      if (await exists(filePath)) return filePath;
+      if ((await stat(filePath)).isFile()) return filePath;
     }
   }
 

--- a/packages/core/src/utils/mcp-utils.ts
+++ b/packages/core/src/utils/mcp-utils.ts
@@ -52,15 +52,7 @@ export function resourceFromMCPResource(
   options: MCPBaseOptions,
 ) {
   const [uri, variables] = isResourceTemplate(resource)
-    ? [
-        resource.uriTemplate,
-        // TODO: use template.variableNames when it's available https://github.com/modelcontextprotocol/typescript-sdk/pull/188
-        (
-          new UriTemplate(resource.uriTemplate) as unknown as {
-            parts: (string | { names: string[] })[];
-          }
-        ).parts.flatMap((i) => (typeof i === "object" ? i.names : [])),
-      ]
+    ? [resource.uriTemplate, new UriTemplate(resource.uriTemplate).variableNames]
     : [resource.uri, []];
 
   return new MCPResource({

--- a/packages/core/test/loader/loader.test.ts
+++ b/packages/core/test/loader/loader.test.ts
@@ -85,10 +85,9 @@ test("loader should error if agent file is not supported", async () => {
 
 test("load should process path correctly", async () => {
   const stat = mock();
-  const exists = mock();
   const readFile = mock();
 
-  await using _ = await mockModule("node:fs/promises", () => ({ stat, exists, readFile }));
+  await using _ = await mockModule("node:fs/promises", () => ({ stat, readFile }));
 
   // mock a non-existing file
   stat.mockReturnValueOnce(Promise.reject(new Error("no such file or directory")));
@@ -110,7 +109,7 @@ test("load should process path correctly", async () => {
 
   // mock a directory with a .yaml file
   stat.mockReturnValueOnce(Promise.resolve({ isDirectory: () => true }));
-  exists.mockReturnValueOnce(Promise.resolve(true));
+  stat.mockReturnValueOnce(Promise.resolve({ isFile: () => true }));
   readFile.mockReturnValueOnce("chat_model: gpt-4o-mini");
   expect(load({ path: "foo" })).resolves.toEqual(
     expect.objectContaining({
@@ -123,7 +122,9 @@ test("load should process path correctly", async () => {
 
   // mock a directory with a .yml file
   stat.mockReturnValueOnce(Promise.resolve({ isDirectory: () => true }));
-  exists.mockReturnValueOnce(Promise.resolve(false)).mockReturnValueOnce(Promise.resolve(true));
+  stat
+    .mockReturnValueOnce(Promise.resolve({ isFile: () => false }))
+    .mockReturnValueOnce(Promise.resolve({ isFile: () => true }));
   readFile.mockReturnValueOnce("chat_model: gpt-4o-mini");
   expect(load({ path: "bar" })).resolves.toEqual(
     expect.objectContaining({

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -30,8 +30,8 @@
     "@aigne/core": "workspace:^"
   },
   "devDependencies": {
-    "@types/bun": "^1.2.8",
+    "@types/bun": "^1.2.9",
     "@types/node": "^22.14.0",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: ^2.12.1
         version: 2.12.1
       typescript:
-        specifier: ^5.8.2
-        version: 5.8.2
+        specifier: ^5.8.3
+        version: 5.8.3
       zx:
-        specifier: ^8.5.0
-        version: 8.5.0
+        specifier: ^8.5.2
+        version: 8.5.2
 
   examples/chat-bot:
     dependencies:
@@ -33,8 +33,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.91.1
-        version: 4.91.1(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.93.0
+        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -45,8 +45,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.91.1
-        version: 4.91.1(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.93.0
+        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -57,8 +57,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.91.1
-        version: 4.91.1(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.93.0
+        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -69,8 +69,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.91.1
-        version: 4.91.1(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.93.0
+        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -81,8 +81,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.91.1
-        version: 4.91.1(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.93.0
+        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -93,8 +93,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.91.1
-        version: 4.91.1(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.93.0
+        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -105,8 +105,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.91.1
-        version: 4.91.1(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.93.0
+        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -120,8 +120,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.91.1
-        version: 4.91.1(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.93.0
+        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -132,8 +132,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.91.1
-        version: 4.91.1(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.93.0
+        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -144,8 +144,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.91.1
-        version: 4.91.1(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.93.0
+        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -156,8 +156,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.91.1
-        version: 4.91.1(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.93.0
+        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -175,8 +175,8 @@ importers:
         version: 3.24.2
     devDependencies:
       '@types/bun':
-        specifier: ^1.2.8
-        version: 1.2.8
+        specifier: ^1.2.9
+        version: 1.2.9
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -184,8 +184,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       typescript:
-        specifier: ^5.8.2
-        version: 5.8.2
+        specifier: ^5.8.3
+        version: 5.8.3
 
   packages/cli:
     dependencies:
@@ -193,8 +193,8 @@ importers:
         specifier: workspace:^
         version: link:../core
       '@modelcontextprotocol/sdk':
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^1.9.0
+        version: 1.9.0
       chalk:
         specifier: ^5.4.1
         version: 5.4.1
@@ -208,11 +208,11 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       inquirer:
-        specifier: ^12.5.0
-        version: 12.5.0(@types/node@22.14.0)
+        specifier: ^12.5.2
+        version: 12.5.2(@types/node@22.14.0)
       openai:
-        specifier: ^4.91.1
-        version: 4.91.1(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.93.0
+        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -221,8 +221,8 @@ importers:
         specifier: workspace:^
         version: link:../test-utils
       '@types/bun':
-        specifier: ^1.2.8
-        version: 1.2.8
+        specifier: ^1.2.9
+        version: 1.2.9
       '@types/express':
         specifier: ^5.0.1
         version: 5.0.1
@@ -242,11 +242,11 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       typescript:
-        specifier: ^5.8.2
-        version: 5.8.2
+        specifier: ^5.8.3
+        version: 5.8.3
       ufo:
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.6.1
+        version: 1.6.1
 
   packages/core:
     dependencies:
@@ -254,8 +254,8 @@ importers:
         specifier: ^1.3.3
         version: 1.3.3(zod@3.24.2)
       '@modelcontextprotocol/sdk':
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^1.9.0
+        version: 1.9.0
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -263,8 +263,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.0
       inquirer:
-        specifier: ^12.5.0
-        version: 12.5.0(@types/node@22.14.0)
+        specifier: ^12.5.2
+        version: 12.5.2(@types/node@22.14.0)
       mustache:
         specifier: ^4.2.0
         version: 4.2.0
@@ -297,8 +297,8 @@ importers:
         specifier: ^0.24.0
         version: 0.24.0
       '@types/bun':
-        specifier: ^1.2.8
-        version: 1.2.8
+        specifier: ^1.2.9
+        version: 1.2.9
       '@types/express':
         specifier: ^5.0.1
         version: 5.0.1
@@ -318,14 +318,14 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5
       openai:
-        specifier: ^4.91.1
-        version: 4.91.1(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.93.0
+        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
       typescript:
-        specifier: ^5.8.2
-        version: 5.8.2
+        specifier: ^5.8.3
+        version: 5.8.3
 
   packages/test-utils:
     dependencies:
@@ -334,14 +334,14 @@ importers:
         version: link:../core
     devDependencies:
       '@types/bun':
-        specifier: ^1.2.8
-        version: 1.2.8
+        specifier: ^1.2.9
+        version: 1.2.9
       '@types/node':
         specifier: ^22.14.0
         version: 22.14.0
       typescript:
-        specifier: ^5.8.2
-        version: 5.8.2
+        specifier: ^5.8.3
+        version: 5.8.3
 
 packages:
 
@@ -410,8 +410,8 @@ packages:
     resolution: {integrity: sha512-fnEITCGEB7NdX0BhoYZ/cq/7WPZ1QS5IzJJfC3Tg/OwkvBetMiVJciyaan297OvE4B9Jg1xvo0zIazX/9sGu1Q==}
     engines: {node: '>=18.0.0'}
 
-  '@inquirer/checkbox@4.1.4':
-    resolution: {integrity: sha512-d30576EZdApjAMceijXA5jDzRQHT/MygbC+J8I7EqA6f/FRpYxlRtRJbHF8gHeWYeSdOuTEJqonn7QLB1ELezA==}
+  '@inquirer/checkbox@4.1.5':
+    resolution: {integrity: sha512-swPczVU+at65xa5uPfNP9u3qx/alNwiaykiI/ExpsmMSQW55trmZcwhYWzw/7fj+n6Q8z1eENvR7vFfq9oPSAQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -419,8 +419,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/confirm@5.1.8':
-    resolution: {integrity: sha512-dNLWCYZvXDjO3rnQfk2iuJNL4Ivwz/T2+C3+WnNfJKsNGSuOs3wAo2F6e0p946gtSAk31nZMfW+MRmYaplPKsg==}
+  '@inquirer/confirm@5.1.9':
+    resolution: {integrity: sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -428,8 +428,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/core@10.1.9':
-    resolution: {integrity: sha512-sXhVB8n20NYkUBfDYgizGHlpRVaCRjtuzNZA6xpALIUbkgfd2Hjz+DfEN6+h1BRnuxw0/P4jCIMjMsEOAMwAJw==}
+  '@inquirer/core@10.1.10':
+    resolution: {integrity: sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -437,8 +437,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/editor@4.2.9':
-    resolution: {integrity: sha512-8HjOppAxO7O4wV1ETUlJFg6NDjp/W2NP5FB9ZPAcinAlNT4ZIWOLe2pUVwmmPRSV0NMdI5r/+lflN55AwZOKSw==}
+  '@inquirer/editor@4.2.10':
+    resolution: {integrity: sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -446,8 +446,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/expand@4.0.11':
-    resolution: {integrity: sha512-OZSUW4hFMW2TYvX/Sv+NnOZgO8CHT2TU1roUCUIF2T+wfw60XFRRp9MRUPCT06cRnKL+aemt2YmTWwt7rOrNEA==}
+  '@inquirer/expand@4.0.12':
+    resolution: {integrity: sha512-jV8QoZE1fC0vPe6TnsOfig+qwu7Iza1pkXoUJ3SroRagrt2hxiL+RbM432YAihNR7m7XnU0HWl/WQ35RIGmXHw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -459,8 +459,8 @@ packages:
     resolution: {integrity: sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==}
     engines: {node: '>=18'}
 
-  '@inquirer/input@4.1.8':
-    resolution: {integrity: sha512-WXJI16oOZ3/LiENCAxe8joniNp8MQxF6Wi5V+EBbVA0ZIOpFcL4I9e7f7cXse0HJeIPCWO8Lcgnk98juItCi7Q==}
+  '@inquirer/input@4.1.9':
+    resolution: {integrity: sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -468,8 +468,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/number@3.0.11':
-    resolution: {integrity: sha512-pQK68CsKOgwvU2eA53AG/4npRTH2pvs/pZ2bFvzpBhrznh8Mcwt19c+nMO7LHRr3Vreu1KPhNBF3vQAKrjIulw==}
+  '@inquirer/number@3.0.12':
+    resolution: {integrity: sha512-7HRFHxbPCA4e4jMxTQglHJwP+v/kpFsCf2szzfBHy98Wlc3L08HL76UDiA87TOdX5fwj2HMOLWqRWv9Pnn+Z5Q==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -477,8 +477,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/password@4.0.11':
-    resolution: {integrity: sha512-dH6zLdv+HEv1nBs96Case6eppkRggMe8LoOTl30+Gq5Wf27AO/vHFgStTVz4aoevLdNXqwE23++IXGw4eiOXTg==}
+  '@inquirer/password@4.0.12':
+    resolution: {integrity: sha512-FlOB0zvuELPEbnBYiPaOdJIaDzb2PmJ7ghi/SVwIHDDSQ2K4opGBkF+5kXOg6ucrtSUQdLhVVY5tycH0j0l+0g==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -486,8 +486,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/prompts@7.4.0':
-    resolution: {integrity: sha512-EZiJidQOT4O5PYtqnu1JbF0clv36oW2CviR66c7ma4LsupmmQlUwmdReGKRp456OWPWMz3PdrPiYg3aCk3op2w==}
+  '@inquirer/prompts@7.4.1':
+    resolution: {integrity: sha512-UlmM5FVOZF0gpoe1PT/jN4vk8JmpIWBlMvTL8M+hlvPmzN89K6z03+IFmyeu/oFCenwdwHDr2gky7nIGSEVvlA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -495,8 +495,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/rawlist@4.0.11':
-    resolution: {integrity: sha512-uAYtTx0IF/PqUAvsRrF3xvnxJV516wmR6YVONOmCWJbbt87HcDHLfL9wmBQFbNJRv5kCjdYKrZcavDkH3sVJPg==}
+  '@inquirer/rawlist@4.0.12':
+    resolution: {integrity: sha512-wNPJZy8Oc7RyGISPxp9/MpTOqX8lr0r+lCCWm7hQra+MDtYRgINv1hxw7R+vKP71Bu/3LszabxOodfV/uTfsaA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -504,8 +504,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/search@3.0.11':
-    resolution: {integrity: sha512-9CWQT0ikYcg6Ls3TOa7jljsD7PgjcsYEM0bYE+Gkz+uoW9u8eaJCRHJKkucpRE5+xKtaaDbrND+nPDoxzjYyew==}
+  '@inquirer/search@3.0.12':
+    resolution: {integrity: sha512-H/kDJA3kNlnNIjB8YsaXoQI0Qccgf0Na14K1h8ExWhNmUg2E941dyFPrZeugihEa9AZNW5NdsD/NcvUME83OPQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -513,8 +513,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/select@4.1.0':
-    resolution: {integrity: sha512-z0a2fmgTSRN+YBuiK1ROfJ2Nvrpij5lVN3gPDkQGhavdvIVGHGW29LwYZfM/j42Ai2hUghTI/uoBuTbrJk42bA==}
+  '@inquirer/select@4.1.1':
+    resolution: {integrity: sha512-IUXzzTKVdiVNMA+2yUvPxWsSgOG4kfX93jOM4Zb5FgujeInotv5SPIJVeXQ+fO4xu7tW8VowFhdG5JRmmCyQ1Q==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -522,8 +522,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/type@3.0.5':
-    resolution: {integrity: sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==}
+  '@inquirer/type@3.0.6':
+    resolution: {integrity: sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -535,15 +535,15 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
-  '@modelcontextprotocol/sdk@1.8.0':
-    resolution: {integrity: sha512-e06W7SwrontJDHwCawNO5SGxG+nU9AAx+jpHHZqGl/WrDBdWOpvirC+s58VpJTB5QemI4jTRcjWT4Pt3Q1NPQQ==}
+  '@modelcontextprotocol/sdk@1.9.0':
+    resolution: {integrity: sha512-Jq2EUCQpe0iyO5FGpzVYDNFR6oR53AIrwph9yWl7uSc7IWUMsrmpmSaTGra5hQNunXpM+9oit85p924jWuHzUA==}
     engines: {node: '>=18'}
 
   '@types/body-parser@1.19.5':
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
 
-  '@types/bun@1.2.8':
-    resolution: {integrity: sha512-t8L1RvJVUghW5V+M/fL3Thbxcs0HwNsXsnTEBEfEVqGteiJToOlZ/fyOEaR1kZsNqnu+3XA4RI/qmnX4w6+S+w==}
+  '@types/bun@1.2.9':
+    resolution: {integrity: sha512-epShhLGQYc4Bv/aceHbmBhOz1XgUnuTZgcxjxk+WXwNyDXavv5QHD1QEFV0FwbTSQtNq6g4ZcV6y0vZakTjswg==}
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
@@ -670,8 +670,8 @@ packages:
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
 
-  bun-types@1.2.7:
-    resolution: {integrity: sha512-P4hHhk7kjF99acXqKvltyuMQ2kf/rzIw3ylEDpCxDS9Xa0X0Yp/gJu/vDCucmWpiur5qJ0lwB2bWzOXa2GlHqA==}
+  bun-types@1.2.9:
+    resolution: {integrity: sha512-dk/kOEfQbajENN/D6FyiSgOKEuUi9PWfqKQJEgwKrCMWbjS/S6tEXp178mWvWAcUSYm9ArDlWHZKO3T/4cLXiw==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1023,8 +1023,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  inquirer@12.5.0:
-    resolution: {integrity: sha512-aiBBq5aKF1k87MTxXDylLfwpRwToShiHrSv4EmB07EYyLgmnjEz5B3rn0aGw1X3JA/64Ngf2T54oGwc+BCsPIQ==}
+  inquirer@12.5.2:
+    resolution: {integrity: sha512-qoDk/vdSTIaXNXAoNnlg7ubexpJfUo7t8GT2vylxvE49BrLhToFuPPdMViidG2boHV7+AcP1TCkJs/+PPoF2QQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -1293,8 +1293,8 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  openai@4.91.1:
-    resolution: {integrity: sha512-DbjrR0hIMQFbxz8+3qBsfPJnh3+I/skPgoSlT7f9eiZuhGBUissPQULNgx6gHNkLoZ3uS0uYS6eXPUdtg4nHzw==}
+  openai@4.93.0:
+    resolution: {integrity: sha512-2kONcISbThKLfm7T9paVzg+QCE1FOZtNMMUfXyXckUAoXRRS/mTP89JSDHPMp8uM5s0bz28RISbvQjArD6mgUQ==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -1364,8 +1364,8 @@ packages:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
 
-  pkce-challenge@4.1.0:
-    resolution: {integrity: sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==}
+  pkce-challenge@5.0.0:
+    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
     engines: {node: '>=16.20.0'}
 
   possible-typed-array-names@1.0.0:
@@ -1634,13 +1634,13 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typescript@5.8.2:
-    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ufo@1.6.0:
-    resolution: {integrity: sha512-AkgU2cV/+Xb4Uz6cic0kMZbtM42nbltnGvTVOt/8gMCbO2/z64nE47TOygh7HjgFPkUkVRBEyNFqpqi3zo+BJA==}
+  ufo@1.6.1:
+    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -1742,8 +1742,8 @@ packages:
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
-  zx@8.5.0:
-    resolution: {integrity: sha512-XS5/oKOQxKNfG2sVO6TQQjZF5RqWGE5QGSUOCZZVTnvYr3RDBTdbX3IFmV9CrnycCAQWcY0hAD3DDUa4RJE4+w==}
+  zx@8.5.2:
+    resolution: {integrity: sha512-eIxjTkCtlzvDNRhw3RD1gGBPA4nxOTn6PafpKl+MW4eE2jR/u/R6mqq7oyUCXwarM5DSP96kWtq6XkrL2kSFrg==}
     engines: {node: '>= 12.17.0'}
     hasBin: true
 
@@ -1802,27 +1802,27 @@ snapshots:
 
   '@google/generative-ai@0.24.0': {}
 
-  '@inquirer/checkbox@4.1.4(@types/node@22.14.0)':
+  '@inquirer/checkbox@4.1.5(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/confirm@5.1.8(@types/node@22.14.0)':
+  '@inquirer/confirm@5.1.9(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/core@10.1.9(@types/node@22.14.0)':
+  '@inquirer/core@10.1.10(@types/node@22.14.0)':
     dependencies:
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -1832,89 +1832,89 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/editor@4.2.9(@types/node@22.14.0)':
+  '@inquirer/editor@4.2.10(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       external-editor: 3.1.0
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/expand@4.0.11(@types/node@22.14.0)':
+  '@inquirer/expand@4.0.12(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 22.14.0
 
   '@inquirer/figures@1.0.11': {}
 
-  '@inquirer/input@4.1.8(@types/node@22.14.0)':
+  '@inquirer/input@4.1.9(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/number@3.0.11(@types/node@22.14.0)':
+  '@inquirer/number@3.0.12(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/password@4.0.11(@types/node@22.14.0)':
+  '@inquirer/password@4.0.12(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       ansi-escapes: 4.3.2
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/prompts@7.4.0(@types/node@22.14.0)':
+  '@inquirer/prompts@7.4.1(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/checkbox': 4.1.4(@types/node@22.14.0)
-      '@inquirer/confirm': 5.1.8(@types/node@22.14.0)
-      '@inquirer/editor': 4.2.9(@types/node@22.14.0)
-      '@inquirer/expand': 4.0.11(@types/node@22.14.0)
-      '@inquirer/input': 4.1.8(@types/node@22.14.0)
-      '@inquirer/number': 3.0.11(@types/node@22.14.0)
-      '@inquirer/password': 4.0.11(@types/node@22.14.0)
-      '@inquirer/rawlist': 4.0.11(@types/node@22.14.0)
-      '@inquirer/search': 3.0.11(@types/node@22.14.0)
-      '@inquirer/select': 4.1.0(@types/node@22.14.0)
+      '@inquirer/checkbox': 4.1.5(@types/node@22.14.0)
+      '@inquirer/confirm': 5.1.9(@types/node@22.14.0)
+      '@inquirer/editor': 4.2.10(@types/node@22.14.0)
+      '@inquirer/expand': 4.0.12(@types/node@22.14.0)
+      '@inquirer/input': 4.1.9(@types/node@22.14.0)
+      '@inquirer/number': 3.0.12(@types/node@22.14.0)
+      '@inquirer/password': 4.0.12(@types/node@22.14.0)
+      '@inquirer/rawlist': 4.0.12(@types/node@22.14.0)
+      '@inquirer/search': 3.0.12(@types/node@22.14.0)
+      '@inquirer/select': 4.1.1(@types/node@22.14.0)
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/rawlist@4.0.11(@types/node@22.14.0)':
+  '@inquirer/rawlist@4.0.12(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/search@3.0.11(@types/node@22.14.0)':
+  '@inquirer/search@3.0.12(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/select@4.1.0(@types/node@22.14.0)':
+  '@inquirer/select@4.1.1(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/type@3.0.5(@types/node@22.14.0)':
+  '@inquirer/type@3.0.6(@types/node@22.14.0)':
     optionalDependencies:
       '@types/node': 22.14.0
 
@@ -1927,7 +1927,7 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@modelcontextprotocol/sdk@1.8.0':
+  '@modelcontextprotocol/sdk@1.9.0':
     dependencies:
       content-type: 1.0.5
       cors: 2.8.5
@@ -1935,7 +1935,7 @@ snapshots:
       eventsource: 3.0.5
       express: 5.1.0
       express-rate-limit: 7.5.0(express@5.1.0)
-      pkce-challenge: 4.1.0
+      pkce-challenge: 5.0.0
       raw-body: 3.0.0
       zod: 3.24.2
       zod-to-json-schema: 3.24.5(zod@3.24.2)
@@ -1947,9 +1947,9 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 22.14.0
 
-  '@types/bun@1.2.8':
+  '@types/bun@1.2.9':
     dependencies:
-      bun-types: 1.2.7
+      bun-types: 1.2.9
 
   '@types/connect@3.4.38':
     dependencies:
@@ -2099,7 +2099,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  bun-types@1.2.7:
+  bun-types@1.2.9:
     dependencies:
       '@types/node': 22.14.0
       '@types/ws': 8.5.13
@@ -2539,11 +2539,11 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  inquirer@12.5.0(@types/node@22.14.0):
+  inquirer@12.5.2(@types/node@22.14.0):
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
-      '@inquirer/prompts': 7.4.0(@types/node@22.14.0)
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/prompts': 7.4.1(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       ansi-escapes: 4.3.2
       mute-stream: 2.0.0
       run-async: 3.0.0
@@ -2791,7 +2791,7 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openai@4.91.1(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2):
+  openai@4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2):
     dependencies:
       '@types/node': 18.19.71
       '@types/node-fetch': 2.6.12
@@ -2862,7 +2862,7 @@ snapshots:
 
   pify@3.0.0: {}
 
-  pkce-challenge@4.1.0: {}
+  pkce-challenge@5.0.0: {}
 
   possible-typed-array-names@1.0.0: {}
 
@@ -3206,9 +3206,9 @@ snapshots:
       possible-typed-array-names: 1.0.0
       reflect.getprototypeof: 1.0.10
 
-  typescript@5.8.2: {}
+  typescript@5.8.3: {}
 
-  ufo@1.6.0: {}
+  ufo@1.6.1: {}
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -3320,4 +3320,4 @@ snapshots:
 
   zod@3.24.2: {}
 
-  zx@8.5.0: {}
+  zx@8.5.2: {}


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. remove usage of new Node.js exists API for compatibility
2. update deps

### Checklist

- [x] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
- [x] I have updated ArcBlock dependencies to the latest version: `pnpm update:deps`

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

## Release Notes

### Chore
- Updated file existence checking to use modern Node.js APIs, ensuring better compatibility with current Node.js versions
- Improved internal URI template handling for more reliable resource management

These changes are internal improvements that maintain existing functionality while modernizing the codebase. Users should experience no changes in behavior, but the updates provide better stability and compatibility with current Node.js environments.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->