### PR TITLE
feat(cli): support model and download customization for aigne run

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,6 +42,9 @@ aigne run [path] [options]
 #### Options
 
 - `--agent <agent>`: Name of the agent to use (defaults to the first agent found)
+- `--download-dir <dir>`: Directory to download the package to (when using a URL)
+- `--model-provider <provider>`: Model provider to use, available providers: openai, claude, xai (defaults to the aigne.yaml definition or openai)
+- `--model <model>`: Model name to use, available models depend on the provider (defaults to the aigne.yaml definition or gpt-4o-mini)
 - `--help`: Display help for the command
 
 #### Examples

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,7 +44,7 @@ aigne run [path] [options]
 - `--agent <agent>`: Name of the agent to use (defaults to the first agent found)
 - `--download-dir <dir>`: Directory to download the package to (when using a URL)
 - `--model-provider <provider>`: Model provider to use, available providers: openai, claude, xai (defaults to the aigne.yaml definition or openai)
-- `--model <model>`: Model name to use, available models depend on the provider (defaults to the aigne.yaml definition or gpt-4o-mini)
+- `--model-name <model>`: Model name to use, available models depend on the provider (defaults to the aigne.yaml definition or gpt-4o-mini)
 - `--help`: Display help for the command
 
 #### Examples

--- a/docs/cli.zh.md
+++ b/docs/cli.zh.md
@@ -42,6 +42,9 @@ aigne run [路径] [选项]
 #### 选项
 
 - `--agent <代理>`：要使用的代理名称（默认为找到的第一个代理）
+- `--download-dir <目录>`：下载包的目录（使用URL时）
+- `--model-provider <提供商>`：要使用的模型提供商，可用提供商：openai、claude、xai（默认为aigne.yaml定义或openai）
+- `--model <模型>`：要使用的模型名称，可用模型取决于提供商（默认为aigne.yaml定义或gpt-4o-mini）
 - `--help`：显示命令帮助
 
 #### 示例

--- a/docs/cli.zh.md
+++ b/docs/cli.zh.md
@@ -44,7 +44,7 @@ aigne run [路径] [选项]
 - `--agent <代理>`：要使用的代理名称（默认为找到的第一个代理）
 - `--download-dir <目录>`：下载包的目录（使用URL时）
 - `--model-provider <提供商>`：要使用的模型提供商，可用提供商：openai、claude、xai（默认为aigne.yaml定义或openai）
-- `--model <模型>`：要使用的模型名称，可用模型取决于提供商（默认为aigne.yaml定义或gpt-4o-mini）
+- `--model-name <模型>`：要使用的模型名称，可用模型取决于提供商（默认为aigne.yaml定义或gpt-4o-mini）
 - `--help`：显示命令帮助
 
 #### 示例

--- a/examples/mcp-github/package.json
+++ b/examples/mcp-github/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aigne/cli": "workspace:^",
     "@aigne/core": "workspace:^",
-    "openai": "^4.93.0",
+    "openai": "^4.94.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/mcp-puppeteer/package.json
+++ b/examples/mcp-puppeteer/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aigne/cli": "workspace:^",
     "@aigne/core": "workspace:^",
-    "openai": "^4.93.0",
+    "openai": "^4.94.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/mcp-sqlite/package.json
+++ b/examples/mcp-sqlite/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aigne/cli": "workspace:^",
     "@aigne/core": "workspace:^",
-    "openai": "^4.93.0",
+    "openai": "^4.94.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/workflow-code-execution/package.json
+++ b/examples/workflow-code-execution/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aigne/cli": "workspace:^",
     "@aigne/core": "workspace:^",
-    "openai": "^4.93.0",
+    "openai": "^4.94.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/workflow-concurrency/package.json
+++ b/examples/workflow-concurrency/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aigne/cli": "workspace:^",
     "@aigne/core": "workspace:^",
-    "openai": "^4.93.0",
+    "openai": "^4.94.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/workflow-group-chat/package.json
+++ b/examples/workflow-group-chat/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aigne/cli": "workspace:^",
     "@aigne/core": "workspace:^",
-    "openai": "^4.93.0",
+    "openai": "^4.94.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/workflow-handoff/package.json
+++ b/examples/workflow-handoff/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aigne/cli": "workspace:^",
     "@aigne/core": "workspace:^",
-    "openai": "^4.93.0",
+    "openai": "^4.94.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/workflow-orchestrator/package.json
+++ b/examples/workflow-orchestrator/package.json
@@ -23,7 +23,7 @@
     "@aigne/agent-library": "workspace:^",
     "@aigne/cli": "workspace:^",
     "@aigne/core": "workspace:^",
-    "openai": "^4.93.0",
+    "openai": "^4.94.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/workflow-reflection/package.json
+++ b/examples/workflow-reflection/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aigne/cli": "workspace:^",
     "@aigne/core": "workspace:^",
-    "openai": "^4.93.0",
+    "openai": "^4.94.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/workflow-router/package.json
+++ b/examples/workflow-router/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aigne/cli": "workspace:^",
     "@aigne/core": "workspace:^",
-    "openai": "^4.93.0",
+    "openai": "^4.94.0",
     "zod": "^3.24.2"
   }
 }

--- a/examples/workflow-sequential/package.json
+++ b/examples/workflow-sequential/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aigne/cli": "workspace:^",
     "@aigne/core": "workspace:^",
-    "openai": "^4.93.0",
+    "openai": "^4.94.0",
     "zod": "^3.24.2"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
     "express": "^5.1.0",
     "gradient-string": "^3.0.0",
     "inquirer": "^12.5.2",
-    "openai": "^4.93.0",
+    "openai": "^4.94.0",
     "pretty-error": "^4.0.0",
     "tar": "^7.4.3",
     "zod": "^3.24.2"
@@ -64,7 +64,7 @@
     "@types/bun": "^1.2.9",
     "@types/express": "^5.0.1",
     "@types/gradient-string": "^1.1.6",
-    "@types/node": "^22.14.0",
+    "@types/node": "^22.14.1",
     "archiver": "^7.0.1",
     "detect-port": "^2.1.0",
     "npm-run-all": "^4.1.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,6 +47,9 @@
       "execution-engine/*": [
         "./lib/dts/execution-engine/*"
       ],
+      "loader/*": [
+        "./lib/dts/loader/*"
+      ],
       "models/*": [
         "./lib/dts/models/*"
       ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -95,11 +95,11 @@
     "@types/bun": "^1.2.9",
     "@types/express": "^5.0.1",
     "@types/mustache": "^4.2.5",
-    "@types/node": "^22.14.0",
+    "@types/node": "^22.14.1",
     "detect-port": "^2.1.0",
     "express": "^5.1.0",
     "npm-run-all": "^4.1.5",
-    "openai": "^4.93.0",
+    "openai": "^4.94.0",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.3"
   }

--- a/packages/core/src/execution-engine/execution-engine.ts
+++ b/packages/core/src/execution-engine/execution-engine.ts
@@ -27,8 +27,8 @@ export class ExecutionEngine {
   }: { path: string } & ExecutionEngineOptions): Promise<ExecutionEngine> {
     const { model, agents, tools, ...aigne } = await load({ path });
     return new ExecutionEngine({
-      model,
       ...options,
+      model: options.model || model,
       name: options.name || aigne.name || undefined,
       description: options.description || aigne.description || undefined,
       agents: agents.concat(options.agents ?? []),

--- a/packages/core/src/loader/agent-js.ts
+++ b/packages/core/src/loader/agent-js.ts
@@ -32,7 +32,7 @@ export async function loadAgentFromJsFile(path: string) {
   return tryOrThrow(
     () =>
       agentJsFileSchema.parse({
-        name: agent.name,
+        name: agent.agent_name || agent.name,
         description: agent.description,
         input_schema: agent.input_schema,
         output_schema: agent.output_schema,

--- a/packages/core/src/loader/agent-yaml.ts
+++ b/packages/core/src/loader/agent-yaml.ts
@@ -31,6 +31,10 @@ const agentFileSchema = z.discriminatedUnion("type", [
       .array(z.string())
       .nullish()
       .transform((v) => v ?? undefined),
+    tool_choice: z
+      .union([z.literal("auto"), z.literal("none"), z.literal("required"), z.literal("router")])
+      .nullish()
+      .transform((v) => v ?? undefined),
   }),
   z.object({
     type: z.literal("mcp"),

--- a/packages/core/src/loader/index.ts
+++ b/packages/core/src/loader/index.ts
@@ -91,13 +91,13 @@ export async function loadAgent(path: string): Promise<Agent> {
   throw new Error(`Unsupported agent file type: ${path}`);
 }
 
-async function loadModel(
+export async function loadModel(
   model: z.infer<typeof aigneFileSchema>["chat_model"],
 ): Promise<ChatModel | undefined> {
-  if (!model?.name) return undefined;
+  if (!model) return undefined;
 
   const params = {
-    model: model.name,
+    model: model.name ?? undefined,
     temperature: model.temperature ?? undefined,
     topP: model.top_p ?? undefined,
     frequencyPenalty: model.frequent_penalty ?? undefined,

--- a/packages/core/src/loader/index.ts
+++ b/packages/core/src/loader/index.ts
@@ -69,6 +69,7 @@ export async function loadAgent(path: string): Promise<Agent> {
         tools: await Promise.all(
           (agent.tools ?? []).map((filename) => loadAgent(join(dirname(path), filename))),
         ),
+        toolChoice: agent.tool_choice,
       });
     }
     if (agent.type === "mcp") {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.93.0
-        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.94.0
+        version: 4.94.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -72,8 +72,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.93.0
-        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.94.0
+        version: 4.94.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -87,8 +87,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.93.0
-        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.94.0
+        version: 4.94.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -102,8 +102,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.93.0
-        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.94.0
+        version: 4.94.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -117,8 +117,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.93.0
-        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.94.0
+        version: 4.94.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -132,8 +132,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.93.0
-        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.94.0
+        version: 4.94.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -147,8 +147,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.93.0
-        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.94.0
+        version: 4.94.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -165,8 +165,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.93.0
-        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.94.0
+        version: 4.94.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -180,8 +180,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.93.0
-        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.94.0
+        version: 4.94.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -195,8 +195,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.93.0
-        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.94.0
+        version: 4.94.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -210,8 +210,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
       openai:
-        specifier: ^4.93.0
-        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.94.0
+        version: 4.94.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -266,10 +266,10 @@ importers:
         version: 3.0.0
       inquirer:
         specifier: ^12.5.2
-        version: 12.5.2(@types/node@22.14.0)
+        version: 12.5.2(@types/node@22.14.1)
       openai:
-        specifier: ^4.93.0
-        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.94.0
+        version: 4.94.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       pretty-error:
         specifier: ^4.0.0
         version: 4.0.0
@@ -293,8 +293,8 @@ importers:
         specifier: ^1.1.6
         version: 1.1.6
       '@types/node':
-        specifier: ^22.14.0
-        version: 22.14.0
+        specifier: ^22.14.1
+        version: 22.14.1
       archiver:
         specifier: ^7.0.1
         version: 7.0.1
@@ -330,7 +330,7 @@ importers:
         version: 4.4.0
       inquirer:
         specifier: ^12.5.2
-        version: 12.5.2(@types/node@22.14.0)
+        version: 12.5.2(@types/node@22.14.1)
       mustache:
         specifier: ^4.2.0
         version: 4.2.0
@@ -369,8 +369,8 @@ importers:
         specifier: ^4.2.5
         version: 4.2.5
       '@types/node':
-        specifier: ^22.14.0
-        version: 22.14.0
+        specifier: ^22.14.1
+        version: 22.14.1
       detect-port:
         specifier: ^2.1.0
         version: 2.1.0
@@ -381,8 +381,8 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5
       openai:
-        specifier: ^4.93.0
-        version: 4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
+        specifier: ^4.94.0
+        version: 4.94.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -640,8 +640,8 @@ packages:
   '@types/node@18.19.71':
     resolution: {integrity: sha512-evXpcgtZm8FY4jqBSN8+DmOTcVkkvTmAayeo4Wf3m1xAruyVGzGuDh/Fb/WWX2yLItUiho42ozyJjB0dw//Tkw==}
 
-  '@types/node@22.14.0':
-    resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
+  '@types/node@22.14.1':
+    resolution: {integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==}
 
   '@types/qs@6.9.18':
     resolution: {integrity: sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==}
@@ -1576,8 +1576,8 @@ packages:
     resolution: {integrity: sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==}
     engines: {node: '>=18'}
 
-  openai@4.93.0:
-    resolution: {integrity: sha512-2kONcISbThKLfm7T9paVzg+QCE1FOZtNMMUfXyXckUAoXRRS/mTP89JSDHPMp8uM5s0bz28RISbvQjArD6mgUQ==}
+  openai@4.94.0:
+    resolution: {integrity: sha512-WVmr9HWcwfouLJ7R3UHd2A93ClezTPuJljQxkCYQAL15Sjyt+FBNoqEz5MHSdH/ebQrVyvRhFyn/bvdqtSPyIA==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -2177,27 +2177,27 @@ snapshots:
 
   '@google/generative-ai@0.24.0': {}
 
-  '@inquirer/checkbox@4.1.5(@types/node@22.14.0)':
+  '@inquirer/checkbox@4.1.5(@types/node@22.14.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.1)
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.6(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.1)
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
-  '@inquirer/confirm@5.1.9(@types/node@22.14.0)':
+  '@inquirer/confirm@5.1.9(@types/node@22.14.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.14.0)
-      '@inquirer/type': 3.0.6(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.1)
+      '@inquirer/type': 3.0.6(@types/node@22.14.1)
     optionalDependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
-  '@inquirer/core@10.1.10(@types/node@22.14.0)':
+  '@inquirer/core@10.1.10(@types/node@22.14.1)':
     dependencies:
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.6(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.1)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -2205,93 +2205,93 @@ snapshots:
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
-  '@inquirer/editor@4.2.10(@types/node@22.14.0)':
+  '@inquirer/editor@4.2.10(@types/node@22.14.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.14.0)
-      '@inquirer/type': 3.0.6(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.1)
+      '@inquirer/type': 3.0.6(@types/node@22.14.1)
       external-editor: 3.1.0
     optionalDependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
-  '@inquirer/expand@4.0.12(@types/node@22.14.0)':
+  '@inquirer/expand@4.0.12(@types/node@22.14.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.14.0)
-      '@inquirer/type': 3.0.6(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.1)
+      '@inquirer/type': 3.0.6(@types/node@22.14.1)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
   '@inquirer/figures@1.0.11': {}
 
-  '@inquirer/input@4.1.9(@types/node@22.14.0)':
+  '@inquirer/input@4.1.9(@types/node@22.14.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.14.0)
-      '@inquirer/type': 3.0.6(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.1)
+      '@inquirer/type': 3.0.6(@types/node@22.14.1)
     optionalDependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
-  '@inquirer/number@3.0.12(@types/node@22.14.0)':
+  '@inquirer/number@3.0.12(@types/node@22.14.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.14.0)
-      '@inquirer/type': 3.0.6(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.1)
+      '@inquirer/type': 3.0.6(@types/node@22.14.1)
     optionalDependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
-  '@inquirer/password@4.0.12(@types/node@22.14.0)':
+  '@inquirer/password@4.0.12(@types/node@22.14.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.14.0)
-      '@inquirer/type': 3.0.6(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.1)
+      '@inquirer/type': 3.0.6(@types/node@22.14.1)
       ansi-escapes: 4.3.2
     optionalDependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
-  '@inquirer/prompts@7.4.1(@types/node@22.14.0)':
+  '@inquirer/prompts@7.4.1(@types/node@22.14.1)':
     dependencies:
-      '@inquirer/checkbox': 4.1.5(@types/node@22.14.0)
-      '@inquirer/confirm': 5.1.9(@types/node@22.14.0)
-      '@inquirer/editor': 4.2.10(@types/node@22.14.0)
-      '@inquirer/expand': 4.0.12(@types/node@22.14.0)
-      '@inquirer/input': 4.1.9(@types/node@22.14.0)
-      '@inquirer/number': 3.0.12(@types/node@22.14.0)
-      '@inquirer/password': 4.0.12(@types/node@22.14.0)
-      '@inquirer/rawlist': 4.0.12(@types/node@22.14.0)
-      '@inquirer/search': 3.0.12(@types/node@22.14.0)
-      '@inquirer/select': 4.1.1(@types/node@22.14.0)
+      '@inquirer/checkbox': 4.1.5(@types/node@22.14.1)
+      '@inquirer/confirm': 5.1.9(@types/node@22.14.1)
+      '@inquirer/editor': 4.2.10(@types/node@22.14.1)
+      '@inquirer/expand': 4.0.12(@types/node@22.14.1)
+      '@inquirer/input': 4.1.9(@types/node@22.14.1)
+      '@inquirer/number': 3.0.12(@types/node@22.14.1)
+      '@inquirer/password': 4.0.12(@types/node@22.14.1)
+      '@inquirer/rawlist': 4.0.12(@types/node@22.14.1)
+      '@inquirer/search': 3.0.12(@types/node@22.14.1)
+      '@inquirer/select': 4.1.1(@types/node@22.14.1)
     optionalDependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
-  '@inquirer/rawlist@4.0.12(@types/node@22.14.0)':
+  '@inquirer/rawlist@4.0.12(@types/node@22.14.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.14.0)
-      '@inquirer/type': 3.0.6(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.1)
+      '@inquirer/type': 3.0.6(@types/node@22.14.1)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
-  '@inquirer/search@3.0.12(@types/node@22.14.0)':
+  '@inquirer/search@3.0.12(@types/node@22.14.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.1)
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.6(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.1)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
-  '@inquirer/select@4.1.1(@types/node@22.14.0)':
+  '@inquirer/select@4.1.1(@types/node@22.14.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.1)
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.6(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.1)
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
-  '@inquirer/type@3.0.6(@types/node@22.14.0)':
+  '@inquirer/type@3.0.6(@types/node@22.14.1)':
     optionalDependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -2331,7 +2331,7 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
   '@types/bun@1.2.9':
     dependencies:
@@ -2339,7 +2339,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
   '@types/debug@4.1.12':
     dependencies:
@@ -2347,7 +2347,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.0.6':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
       '@types/qs': 6.9.18
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -2372,14 +2372,14 @@ snapshots:
 
   '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
       form-data: 4.0.1
 
   '@types/node@18.19.71':
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@22.14.0':
+  '@types/node@22.14.1':
     dependencies:
       undici-types: 6.21.0
 
@@ -2389,26 +2389,26 @@ snapshots:
 
   '@types/readdir-glob@1.1.5':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
   '@types/retry@0.12.2': {}
 
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
       '@types/send': 0.17.4
 
   '@types/tinycolor2@1.4.6': {}
 
   '@types/ws@8.5.13':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
   abort-controller@3.0.0:
     dependencies:
@@ -2535,7 +2535,7 @@ snapshots:
 
   bun-types@1.2.9:
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
       '@types/ws': 8.5.13
 
   bundle-name@4.1.0:
@@ -3074,17 +3074,17 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  inquirer@12.5.2(@types/node@22.14.0):
+  inquirer@12.5.2(@types/node@22.14.1):
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.14.0)
-      '@inquirer/prompts': 7.4.1(@types/node@22.14.0)
-      '@inquirer/type': 3.0.6(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.1)
+      '@inquirer/prompts': 7.4.1(@types/node@22.14.1)
+      '@inquirer/type': 3.0.6(@types/node@22.14.1)
       ansi-escapes: 4.3.2
       mute-stream: 2.0.0
       run-async: 3.0.0
       rxjs: 7.8.2
     optionalDependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
   internal-slot@1.1.0:
     dependencies:
@@ -3422,7 +3422,7 @@ snapshots:
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
 
-  openai@4.93.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2):
+  openai@4.94.0(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2):
     dependencies:
       '@types/node': 18.19.71
       '@types/node-fetch': 2.6.12


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. feat(cli): add `--download-dir` save agents to special folder for `run` command
2. feat(cli): support setting model by `--mode-provider` & `--model-name` option for `run` command
3. fix(loader): allow setting tool choice in yaml agent file
4. fix(loader): allow setting agent name through `agent.agent_name` in js agent file

![cli](https://github.com/user-attachments/assets/c7dfa866-6fa1-4996-9da1-5e36278ada3e)



### Checklist

- [x] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [x] I have updated ArcBlock dependencies to the latest version: `pnpm update:deps`

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

Release Notes:

- New Feature: Added `--download-dir` CLI option to specify custom directory for agent package downloads
- New Feature: Introduced `tool_choice` configuration in YAML to control tool selection behavior with options "auto", "none", "required", or "router"
- Enhancement: Improved agent name resolution with better fallback handling for backward compatibility

These updates provide more flexibility in managing agent downloads and configuration, while maintaining compatibility with existing setups. Users can now better control where agent packages are stored and how tools are selected during agent execution.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->