### PR TITLE
fix(cli): display progressing for `run` command

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,9 +1,11 @@
+import assert from "node:assert";
 import { cp, mkdir, rm } from "node:fs/promises";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import { type Agent, ExecutionEngine } from "@aigne/core";
 import { loadModel } from "@aigne/core/loader/index.js";
 import { isNonNullable } from "@aigne/core/utils/type-utils.js";
+import { Listr, PRESET_TIMER } from "@aigne/listr2";
 import { Command, type OptionValues } from "commander";
 import { isV1Package, toAIGNEPackage } from "../utils/agent-v1.js";
 import { downloadAndExtract } from "../utils/download.js";
@@ -34,20 +36,85 @@ export function createRunCommand(): Command {
       "Model name to use, available models depend on the provider (defaults to the aigne.yaml definition or gpt-4o-mini)",
     )
     .action(async (path: string, options: RunOptions) => {
-      if (path.startsWith("http")) {
-        await downloadAndRunPackage(path, options);
-        return;
-      }
+      const { downloadDir, dir } = prepareDirs(path, options);
 
-      const absolutePath = isAbsolute(path) ? path : resolve(process.cwd(), path);
+      const { engine, agent } = await new Listr<{
+        engine: ExecutionEngine;
+        agent: Agent;
+      }>(
+        [
+          {
+            title: "Prepare environment",
+            task: (_, task) => {
+              if (downloadDir) {
+                return task.newListr([
+                  {
+                    title: "Download package",
+                    task: () => downloadPackage(path, downloadDir),
+                  },
+                  {
+                    title: "Extract package",
+                    task: () => extractPackage(downloadDir, dir),
+                  },
+                ]);
+              }
+            },
+          },
+          {
+            title: "Initialize execution engine",
+            task: async (ctx) => {
+              const engine = await runEngine(dir, options);
+              ctx.engine = engine;
+            },
+          },
+          {
+            task: (ctx) => {
+              const { engine } = ctx;
+              assert(engine);
 
-      await runEngine(path, absolutePath, options);
+              let agent: Agent | undefined;
+
+              if (options.agent) {
+                agent = engine.agents[options.agent];
+                if (!agent) {
+                  console.error(`Agent "${options.agent}" not found in ${path}`);
+                  console.log("Available agents:");
+                  for (const agent of engine.agents) {
+                    console.log(`- ${agent.name}`);
+                  }
+                  throw new Error(`Agent "${options.agent}" not found in ${path}`);
+                }
+              } else {
+                agent = engine.agents[0];
+                if (!agent) throw new Error(`No agents found in ${path}`);
+              }
+
+              ctx.agent = agent;
+            },
+          },
+        ],
+        {
+          rendererOptions: {
+            collapseSubtasks: false,
+            timer: PRESET_TIMER,
+          },
+        },
+      ).run();
+
+      assert(engine);
+      assert(agent);
+
+      const user = engine.call(agent);
+
+      await runChatLoopInTerminal(user, {});
+
+      await engine.shutdown();
     })
     .showHelpAfterError(true)
     .showSuggestionAfterError(true);
 }
 
-async function runEngine(originalPath: string, path: string, options: RunOptions) {
+async function runEngine(path: string, options: RunOptions) {
   if (options.modelName && !options.modelProvider) {
     throw new Error("please specify --model-provider when using the --model-name option");
   }
@@ -55,57 +122,43 @@ async function runEngine(originalPath: string, path: string, options: RunOptions
   const model = options.modelProvider
     ? await loadModel({ provider: options.modelProvider, name: options.modelName })
     : undefined;
-  const engine = await ExecutionEngine.load({ path, model });
 
-  let agent: Agent | undefined;
-  if (options.agent) {
-    agent = engine.agents[options.agent];
-    if (!agent) {
-      console.error(`Agent "${options.agent}" not found in ${originalPath}`);
-      console.log("Available agents:");
-      for (const agent of engine.agents) {
-        console.log(`- ${agent.name}`);
-      }
-      throw new Error(`Agent "${options.agent}" not found in ${originalPath}`);
-    }
-  } else {
-    agent = engine.agents[0];
-    if (!agent) throw new Error(`No agents found in ${originalPath}`);
-  }
-
-  const user = engine.call(agent);
-
-  await runChatLoopInTerminal(user, {});
+  return await ExecutionEngine.load({ path, model });
 }
 
-async function downloadAndRunPackage(url: string, options: RunOptions) {
-  let dir: string;
-  let downloadDir: string;
-  if (options.downloadDir) {
-    dir = isAbsolute(options.downloadDir)
-      ? options.downloadDir
-      : resolve(process.cwd(), options.downloadDir);
-    downloadDir = join(dir, ".download");
-  } else {
-    dir = getLocalPackagePathFromUrl(url);
-    downloadDir = getLocalPackagePathFromUrl(url, { subdir: ".download" });
-  }
-
-  // clean up the download directory
+async function downloadPackage(url: string, downloadDir: string) {
   await rm(downloadDir, { recursive: true, force: true });
 
-  await mkdir(dir, { recursive: true });
   await mkdir(downloadDir, { recursive: true });
 
   await downloadAndExtract(url, downloadDir);
+}
 
+async function extractPackage(downloadDir: string, dir: string) {
   if (await isV1Package(downloadDir)) {
     await toAIGNEPackage(downloadDir, dir);
   } else {
     await cp(downloadDir, dir, { recursive: true, force: true });
   }
+}
 
-  await runEngine(url, dir, options);
+function prepareDirs(path: string, options: RunOptions) {
+  let dir: string;
+  let downloadDir: string | undefined;
+
+  if (!path.startsWith("http")) {
+    dir = isAbsolute(path) ? path : resolve(process.cwd(), path);
+  } else if (options.downloadDir) {
+    dir = isAbsolute(options.downloadDir)
+      ? options.downloadDir
+      : resolve(process.cwd(), options.downloadDir);
+    downloadDir = join(dir, ".download");
+  } else {
+    dir = getLocalPackagePathFromUrl(path);
+    downloadDir = getLocalPackagePathFromUrl(path, { subdir: ".download" });
+  }
+
+  return { downloadDir, dir };
 }
 
 function getLocalPackagePathFromUrl(url: string, { subdir }: { subdir?: string } = {}) {

--- a/packages/cli/src/utils/run-chat-loop.ts
+++ b/packages/cli/src/utils/run-chat-loop.ts
@@ -75,7 +75,6 @@ async function callAgent(userAgent: input, input: Message | string, options: Cha
 
   console.log(
     `
-${chalk.grey(figures.tick)} 💬 ${inspect(input, { colors: true })}
 ${chalk.grey(figures.tick)} 🤖 ${tracer.formatTokenUsage(context.usage)}
 ${formatAIResponse(result)}
 `,


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. display progressing for `run` command

![cli](https://github.com/user-attachments/assets/45d3c8a8-af9a-4bf8-993f-44baf9ba8323)


### Checklist

### Summary by AIGNE

### Release Notes

- Refactor: Enhanced CLI initialization with visual progress indicators for package downloads and setup
- Style: Simplified chat output by removing redundant input message display

These changes improve the user experience by providing clearer feedback during agent initialization and streamlining the chat interface. Users will now see a progress bar when downloading and setting up packages, making it easier to track the startup process.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->