### PR TITLE
fix(cli): ensure dir exists before extract package

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -135,6 +135,8 @@ async function downloadPackage(url: string, downloadDir: string) {
 }
 
 async function extractPackage(downloadDir: string, dir: string) {
+  await mkdir(dir, { recursive: true });
+
   if (await isV1Package(downloadDir)) {
     await toAIGNEPackage(downloadDir, dir);
   } else {

--- a/packages/cli/test/commands/run.test.ts
+++ b/packages/cli/test/commands/run.test.ts
@@ -77,7 +77,7 @@ test("run command should download package and run correctly", async () => {
 
   const command = createRunCommand();
 
-  const url = new URL("https://www.aigne.io/projects/xxx/test-agents.tgz");
+  const url = new URL(`https://www.aigne.io/${randomUUID()}/test-agents.tgz`);
 
   await command.parseAsync(["", "run", url.toString()]);
 
@@ -103,7 +103,7 @@ test("run command should convert package from v1 and run correctly", async () =>
 
   const command = createRunCommand();
 
-  const url = new URL("https://www.aigne.io/projects/xxx/test-agents.tgz");
+  const url = new URL(`https://www.aigne.io/${randomUUID()}/test-agents.tgz`);
 
   await command.parseAsync(["", "run", url.toString()]);
 
@@ -129,7 +129,7 @@ test("run command should download package to a special folder", async () => {
 
   const command = createRunCommand();
 
-  const url = "https://www.aigne.io/projects/xxx/test-agents.tgz";
+  const url = `https://www.aigne.io/${randomUUID()}/test-agents.tgz`;
   const dir = join(tmpdir(), randomUUID());
 
   try {


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(cli): ensure dir exists before extract package

### Checklist

- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

**Release Notes**

- Bug Fix: Improved package extraction reliability by ensuring target directories exist before extraction
- Test: Enhanced test stability by using dynamic UUIDs instead of hardcoded paths

These changes improve the robustness of the package extraction process, preventing potential failures when target directories don't exist. The testing improvements help maintain reliable test execution in CI/CD pipelines.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->