### PR TITLE
fix(dx): custom error message for agent input/output validation

### DIFF
--- a/packages/core/src/agents/agent.ts
+++ b/packages/core/src/agents/agent.ts
@@ -6,6 +6,7 @@ import { logger } from "../utils/logger.js";
 import {
   type Nullish,
   type PromiseOrValue,
+  checkArguments,
   createAccessorArray,
   orArrayToArray,
 } from "../utils/type-utils.js";
@@ -161,7 +162,11 @@ export abstract class Agent<I extends Message = Message, O extends Message = Mes
     if (!this.disableEvents) ctx.emit("agentStarted", { agent: this, input: message });
 
     try {
-      const parsedInput = this.inputSchema.parse(message) as I;
+      const parsedInput = checkArguments(
+        `Agent ${this.name} input`,
+        this.inputSchema,
+        message,
+      ) as I;
 
       this.preprocess(parsedInput, ctx);
 
@@ -169,7 +174,11 @@ export abstract class Agent<I extends Message = Message, O extends Message = Mes
 
       const output = await this.process(parsedInput, ctx)
         .then((output) => {
-          const parsedOutput = this.outputSchema.parse(output) as O;
+          const parsedOutput = checkArguments(
+            `Agent ${this.name} output`,
+            this.outputSchema,
+            output,
+          ) as O;
           return this.includeInputInOutput ? { ...parsedInput, ...parsedOutput } : parsedOutput;
         })
         .then((output) => {

--- a/packages/core/src/utils/type-utils.ts
+++ b/packages/core/src/utils/type-utils.ts
@@ -56,9 +56,9 @@ export function createAccessorArray<T>(
   }) as T[] & { [key: string]: T };
 }
 
-export function checkArguments<T>(prefix: string, schema: ZodType<T>, args: T) {
+export function checkArguments<T>(prefix: string, schema: ZodType<T>, args: T): T {
   try {
-    schema.parse(args, {
+    return schema.parse(args, {
       errorMap: (issue, ctx) => {
         if (issue.code === "invalid_union") {
           // handle all issues that are not invalid_type

--- a/packages/core/test/agents/agent.test.ts
+++ b/packages/core/test/agents/agent.test.ts
@@ -1,9 +1,39 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import { inspect } from "node:util";
-import { AIAgent } from "@aigne/core";
+import { AIAgent, FunctionAgent } from "@aigne/core";
+import { z } from "zod";
 
 test("Agent inspect should return it's name", async () => {
   expect(inspect(AIAgent.from({}))).toBe("AIAgent");
 
   expect(inspect(AIAgent.from({ name: "test_agent" }))).toBe("test_agent");
+});
+
+test("Agent should check input and output schema", async () => {
+  const plus = FunctionAgent.from({
+    name: "test-agent-plus",
+    inputSchema: z.object({
+      a: z.number(),
+      b: z.number(),
+    }),
+    outputSchema: z.object({
+      sum: z.number(),
+    }),
+    fn: async (input) => {
+      return {
+        sum: input.a + input.b,
+      };
+    },
+  });
+
+  expect(
+    plus.call({ a: "foo" as unknown as number, b: "bar" as unknown as number }),
+  ).rejects.toThrow(
+    "Agent test-agent-plus input check arguments error: a: Expected number, received string, b: Expected number, received string",
+  );
+
+  spyOn(plus, "fn").mockReturnValueOnce({ sum: "3" as unknown as number });
+  expect(plus.call({ a: 1, b: 2 })).rejects.toThrow(
+    "Agent test-agent-plus output check arguments error: sum: Expected number, received string",
+  );
 });


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(dx): custom error message for agent input/output validation

Example:
```
ERROR: Agent test-agent-plus input check arguments error: a: Expected number, received string, b: Expected number, received string
```

### Checklist

- [x] The newly added code logic is also covered by tests

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

**Release Notes**

- New Feature: Enhanced schema validation for agent inputs/outputs with clearer error messages
- Test: Added comprehensive validation test coverage for agent parameters
- Refactor: Improved type checking system using Zod for more robust parameter validation

These changes provide developers with better feedback when agent parameters don't match expected schemas, making it easier to identify and fix type mismatches, especially for numeric values. Error messages are now more descriptive and actionable.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->