### PR TITLE
fix: use bunwrapper launch examples

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -94,7 +94,10 @@ jobs:
         run: pnpm install
 
       - name: Build
-        run: pnpm build
+        run: |
+          pnpm build
+          # run pnpm install again to make binaries (@aigne/cli: aigne,bunwrapper) available in node_modules/.bin
+          pnpm install
 
       - name: Chmod examples/chat-bot aigne
         run: chmod +x examples/chat-bot/node_modules/@aigne/cli/dist/cli.js

--- a/examples/chat-bot/README.md
+++ b/examples/chat-bot/README.md
@@ -1,18 +1,19 @@
 # Chatbot Example
 
-This is a demonstration of using [AIGNE Framework](https://github.com/AIGNE-io/aigne-framework) and [AIGNE CLI](https://github.com/AIGNE-io/aigne-framework/blob/main/docs/cli.md) to create and run a agent-based chatbot.
+This example demonstrates how to create and run an agent-based chatbot using the [AIGNE Framework](https://github.com/AIGNE-io/aigne-framework) and [AIGNE CLI](https://github.com/AIGNE-io/aigne-framework/blob/main/docs/cli.md).
 
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) and npm installed on your machine
-- [Bun](https://bun.sh) installed on your machine
-- [OpenAI API key](https://platform.openai.com/api-keys) used to interact with OpenAI API
-- [Pnpm](https://pnpm.io) [Optional] if you want to run the example from source code
+- An [OpenAI API key](https://platform.openai.com/api-keys) for interacting with OpenAI's services
+- Optional dependencies (if running the example from source code):
+  - [Pnpm](https://pnpm.io) for package management
+  - [Bun](https://bun.sh) for running unit tests & examples
 
-## Try without Installation
+## Quick Start (No Installation Required)
 
 ```bash
-export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # Setup your OpenAI API key
+export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # Set your OpenAI API key
 
 npx -y @aigne/example-chat-bot # Run the example
 ```

--- a/examples/chat-bot/index.ts
+++ b/examples/chat-bot/index.ts
@@ -1,9 +1,8 @@
-#!/usr/bin/env npx -y bun
+#!/usr/bin/env bunwrapper
 
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 
-spawnSync("npx", ["aigne", "run", join(import.meta.dirname, "agents")], {
-  stdio: "inherit",
-  env: process.env,
-});
+const path = join(import.meta.dirname, "agents");
+
+spawnSync("aigne", ["run", path], { stdio: "inherit" });

--- a/examples/mcp-blocklet/README.md
+++ b/examples/mcp-blocklet/README.md
@@ -1,20 +1,21 @@
 # MCP Blocklet Demo
 
-This is a demonstration of using [AIGNE Framework](https://github.com/AIGNE-io/aigne-framework) and MCP to interact with apps hosted on the [Blocklet platform](https://github.com/blocklet).
+This demo demonstrates how to use [AIGNE Framework](https://github.com/AIGNE-io/aigne-framework) and MCP to interact with apps hosted on the [Blocklet platform](https://github.com/blocklet).
 
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) and npm installed on your machine
-- [Bun](https://bun.sh) installed on your machine
-- [OpenAI API key](https://platform.openai.com/api-keys) used to interact with OpenAI API
-- [Pnpm](https://pnpm.io) [Optional] if you want to run the example from source code
+- An [OpenAI API key](https://platform.openai.com/api-keys) for interacting with OpenAI's services
+- Optional dependencies (if running the example from source code):
+  - [Bun](https://bun.sh) for running unit tests & examples
+  - [Pnpm](https://pnpm.io) for package management
 
-## Try without Installation
+## Quick Start (No Installation Required)
 
 ```bash
-export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # setup your OpenAI API key
+export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # Set your OpenAI API key
 
-npx -y @aigne/example-mcp-blocklet # run the example
+npx -y @aigne/example-mcp-blocklet # Run the example
 ```
 
 ## Installation
@@ -38,8 +39,8 @@ pnpm install
 Setup your OpenAI API key in the `.env.local` file:
 
 ```bash
-OPENAI_API_KEY="" # setup your OpenAI API key here
-BLOCKLET_APP_URL="" # setup your Blocklet app URL here
+OPENAI_API_KEY="" # Set your OpenAI API key here
+BLOCKLET_APP_URL="" # Set your Blocklet app URL here
 ```
 
 ### Run the Example

--- a/examples/mcp-blocklet/index.ts
+++ b/examples/mcp-blocklet/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx -y bun
+#!/usr/bin/env bunwrapper
 
 import assert from "node:assert";
 import { runChatLoopInTerminal } from "@aigne/cli/utils/run-chat-loop.js";

--- a/examples/mcp-github/README.md
+++ b/examples/mcp-github/README.md
@@ -65,16 +65,17 @@ AI ->> User: Here's the README content: ...
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) and npm installed on your machine
-- [Bun](https://bun.sh) installed on your machine
-- [OpenAI API key](https://platform.openai.com/api-keys) used to interact with OpenAI API
+- An [OpenAI API key](https://platform.openai.com/api-keys) for interacting with OpenAI's services
 - [GitHub Personal Access Token](https://github.com/settings/tokens) with appropriate permissions
-- [Pnpm](https://pnpm.io) [Optional] if you want to run the example from source code
+- Optional dependencies (if running the example from source code):
+  - [Bun](https://bun.sh) for running unit tests & examples
+  - [Pnpm](https://pnpm.io) for package management
 
-## Try without Installation
+## Quick Start (No Installation Required)
 
 ```bash
-export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # Setup your OpenAI API key
-export GITHUB_TOKEN=YOUR_GITHUB_TOKEN # Setup your GitHub token
+export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # Set your OpenAI API key
+export GITHUB_TOKEN=YOUR_GITHUB_TOKEN # Set your GitHub token
 
 npx -y @aigne/example-mcp-github # Run the example
 ```
@@ -100,8 +101,8 @@ pnpm install
 Setup your API keys in the `.env.local` file:
 
 ```bash
-OPENAI_API_KEY="" # Your OpenAI API key
-GITHUB_TOKEN="" # Your GitHub Personal Access Token
+OPENAI_API_KEY="" # Set your OpenAI API key here
+GITHUB_TOKEN="" # Set your GitHub Personal Access Token here
 ```
 
 ### Run the Example

--- a/examples/mcp-github/index.ts
+++ b/examples/mcp-github/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx -y bun
+#!/usr/bin/env bunwrapper
 
 import assert from "node:assert";
 import { runChatLoopInTerminal } from "@aigne/cli/utils/run-chat-loop.js";

--- a/examples/mcp-puppeteer/README.md
+++ b/examples/mcp-puppeteer/README.md
@@ -56,16 +56,17 @@ AI ->> User: The content is as follows: ...
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) and npm installed on your machine
-- [Bun](https://bun.sh) installed on your machine
-- [OpenAI API key](https://platform.openai.com/api-keys) used to interact with OpenAI API
-- [Pnpm](https://pnpm.io) [Optional] if you want to run the example from source code
+- An [OpenAI API key](https://platform.openai.com/api-keys) for interacting with OpenAI's services
+- Optional dependencies (if running the example from source code):
+  - [Bun](https://bun.sh) for running unit tests & examples
+  - [Pnpm](https://pnpm.io) for package management
 
-## Try without Installation
+## Quick Start (No Installation Required)
 
 ```bash
-export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # setup your OpenAI API key
+export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # Set your OpenAI API key
 
-npx -y @aigne/example-mcp-puppeteer # run the example
+npx -y @aigne/example-mcp-puppeteer # Run the example
 ```
 
 ## Installation
@@ -89,7 +90,7 @@ pnpm install
 Setup your OpenAI API key in the `.env.local` file:
 
 ```bash
-OPENAI_API_KEY="" # setup your OpenAI API key here
+OPENAI_API_KEY="" # Set your OpenAI API key here
 ```
 
 ### Run the Example

--- a/examples/mcp-puppeteer/index.ts
+++ b/examples/mcp-puppeteer/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx -y bun
+#!/usr/bin/env bunwrapper
 
 import { runChatLoopInTerminal } from "@aigne/cli/utils/run-chat-loop.js";
 import { AIAgent, ExecutionEngine, MCPAgent } from "@aigne/core";

--- a/examples/mcp-sqlite/README.md
+++ b/examples/mcp-sqlite/README.md
@@ -60,17 +60,18 @@ AI ->> User: There are 10 products in the database.
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) and npm installed on your machine
-- [Bun](https://bun.sh) installed on your machine
-- [OpenAI API key](https://platform.openai.com/api-keys) used to interact with OpenAI API
+- An [OpenAI API key](https://platform.openai.com/api-keys) for interacting with OpenAI's services
 - [uv](https://github.com/astral-sh/uv) python environment for running [MCP Server SQlite](https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite)
-- [Pnpm](https://pnpm.io) [Optional] if you want to run the example from source code
+- Optional dependencies (if running the example from source code):
+  - [Bun](https://bun.sh) for running unit tests & examples
+  - [Pnpm](https://pnpm.io) for package management
 
-## Try without Installation
+## Quick Start (No Installation Required)
 
 ```bash
-export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # setup your OpenAI API key
+export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # Set your OpenAI API key
 
-npx -y @aigne/example-mcp-sqlite # run the example
+npx -y @aigne/example-mcp-sqlite # Run the example
 ```
 
 ## Installation
@@ -94,7 +95,7 @@ pnpm install
 Setup your OpenAI API key in the `.env.local` file:
 
 ```bash
-OPENAI_API_KEY="" # setup your OpenAI API key here
+OPENAI_API_KEY="" # Set your OpenAI API key here
 ```
 
 ### Run the Example

--- a/examples/mcp-sqlite/index.ts
+++ b/examples/mcp-sqlite/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx -y bun
+#!/usr/bin/env bunwrapper
 
 import { join } from "node:path";
 import { runChatLoopInTerminal } from "@aigne/cli/utils/run-chat-loop.js";

--- a/examples/workflow-code-execution/README.md
+++ b/examples/workflow-code-execution/README.md
@@ -43,16 +43,17 @@ Coder ->> User: The value of \(10!\) (10 factorial) is 3,628,800.
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) and npm installed on your machine
-- [Bun](https://bun.sh) installed on your machine
-- [OpenAI API key](https://platform.openai.com/api-keys) used to interact with OpenAI API
-- [Pnpm](https://pnpm.io) [Optional] if you want to run the example from source code
+- An [OpenAI API key](https://platform.openai.com/api-keys) for interacting with OpenAI's services
+- Optional dependencies (if running the example from source code):
+  - [Bun](https://bun.sh) for running unit tests & examples
+  - [Pnpm](https://pnpm.io) for package management
 
-## Try without Installation
+## Quick Start (No Installation Required)
 
 ```bash
-export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # setup your OpenAI API key
+export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # Set your OpenAI API key
 
-npx -y @aigne/example-workflow-code-execution # run the example
+npx -y @aigne/example-workflow-code-execution # Run the example
 ```
 
 ## Installation
@@ -76,7 +77,7 @@ pnpm install
 Setup your OpenAI API key in the `.env.local` file:
 
 ```bash
-OPENAI_API_KEY="" # setup your OpenAI API key here
+OPENAI_API_KEY="" # Set your OpenAI API key here
 ```
 
 ### Run the Example

--- a/examples/workflow-code-execution/index.ts
+++ b/examples/workflow-code-execution/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx -y bun
+#!/usr/bin/env bunwrapper
 
 import { runChatLoopInTerminal } from "@aigne/cli/utils/run-chat-loop.js";
 import { AIAgent, ExecutionEngine, FunctionAgent } from "@aigne/core";

--- a/examples/workflow-concurrency/README.md
+++ b/examples/workflow-concurrency/README.md
@@ -27,16 +27,17 @@ class aggregator processing
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) and npm installed on your machine
-- [Bun](https://bun.sh) installed on your machine
-- [OpenAI API key](https://platform.openai.com/api-keys) used to interact with OpenAI API
-- [Pnpm](https://pnpm.io) [Optional] if you want to run the example from source code
+- An [OpenAI API key](https://platform.openai.com/api-keys) for interacting with OpenAI's services
+- Optional dependencies (if running the example from source code):
+  - [Bun](https://bun.sh) for running unit tests & examples
+  - [Pnpm](https://pnpm.io) for package management
 
-## Try without Installation
+## Quick Start (No Installation Required)
 
 ```bash
-export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # setup your OpenAI API key
+export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # Set your OpenAI API key
 
-npx -y @aigne/example-workflow-concurrency # run the example
+npx -y @aigne/example-workflow-concurrency # Run the example
 ```
 
 ## Installation
@@ -60,7 +61,7 @@ pnpm install
 Setup your OpenAI API key in the `.env.local` file:
 
 ```bash
-OPENAI_API_KEY="" # setup your OpenAI API key here
+OPENAI_API_KEY="" # Set your OpenAI API key here
 ```
 
 ### Run the Example

--- a/examples/workflow-concurrency/index.ts
+++ b/examples/workflow-concurrency/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx -y bun
+#!/usr/bin/env bunwrapper
 
 import { runChatLoopInTerminal } from "@aigne/cli/utils/run-chat-loop.js";
 import { AIAgent, ExecutionEngine, parallel } from "@aigne/core";

--- a/examples/workflow-group-chat/README.md
+++ b/examples/workflow-group-chat/README.md
@@ -33,16 +33,17 @@ class illustrator processing
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) and npm installed on your machine
-- [Bun](https://bun.sh) installed on your machine
-- [OpenAI API key](https://platform.openai.com/api-keys) used to interact with OpenAI API
-- [Pnpm](https://pnpm.io) [Optional] if you want to run the example from source code
+- An [OpenAI API key](https://platform.openai.com/api-keys) for interacting with OpenAI's services
+- Optional dependencies (if running the example from source code):
+  - [Bun](https://bun.sh) for running unit tests & examples
+  - [Pnpm](https://pnpm.io) for package management
 
-## Try without Installation
+## Quick Start (No Installation Required)
 
 ```bash
-export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # setup your OpenAI API key
+export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # Set your OpenAI API key
 
-npx -y @aigne/example-workflow-group-chat # run the example
+npx -y @aigne/example-workflow-group-chat # Run the example
 ```
 
 ## Installation
@@ -66,7 +67,7 @@ pnpm install
 Setup your OpenAI API key in the `.env.local` file:
 
 ```bash
-OPENAI_API_KEY="" # setup your OpenAI API key here
+OPENAI_API_KEY="" # Set your OpenAI API key here
 ```
 
 ### Run the Example

--- a/examples/workflow-group-chat/index.ts
+++ b/examples/workflow-group-chat/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx -y bun
+#!/usr/bin/env bunwrapper
 
 import assert from "node:assert";
 import { randomUUID } from "node:crypto";

--- a/examples/workflow-handoff/README.md
+++ b/examples/workflow-handoff/README.md
@@ -43,16 +43,17 @@ end
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) and npm installed on your machine
-- [Bun](https://bun.sh) installed on your machine
-- [OpenAI API key](https://platform.openai.com/api-keys) used to interact with OpenAI API
-- [Pnpm](https://pnpm.io) [Optional] if you want to run the example from source code
+- An [OpenAI API key](https://platform.openai.com/api-keys) for interacting with OpenAI's services
+- Optional dependencies (if running the example from source code):
+  - [Bun](https://bun.sh) for running unit tests & examples
+  - [Pnpm](https://pnpm.io) for package management
 
-## Try without Installation
+## Quick Start (No Installation Required)
 
 ```bash
-export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # setup your OpenAI API key
+export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # Set your OpenAI API key
 
-npx -y @aigne/example-workflow-handoff # run the example
+npx -y @aigne/example-workflow-handoff # Run the example
 ```
 
 ## Installation
@@ -76,7 +77,7 @@ pnpm install
 Setup your OpenAI API key in the `.env.local` file:
 
 ```bash
-OPENAI_API_KEY="" # setup your OpenAI API key here
+OPENAI_API_KEY="" # Set your OpenAI API key here
 ```
 
 ### Run the Example

--- a/examples/workflow-handoff/index.ts
+++ b/examples/workflow-handoff/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx -y bun
+#!/usr/bin/env bunwrapper
 
 import { runChatLoopInTerminal } from "@aigne/cli/utils/run-chat-loop.js";
 import { AIAgent, type Agent, ExecutionEngine, FunctionAgent } from "@aigne/core";

--- a/examples/workflow-orchestrator/README.md
+++ b/examples/workflow-orchestrator/README.md
@@ -40,16 +40,17 @@ class style_enforcer processing
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) and npm installed on your machine
-- [Bun](https://bun.sh) installed on your machine
-- [OpenAI API key](https://platform.openai.com/api-keys) used to interact with OpenAI API
-- [Pnpm](https://pnpm.io) [Optional] if you want to run the example from source code
+- An [OpenAI API key](https://platform.openai.com/api-keys) for interacting with OpenAI's services
+- Optional dependencies (if running the example from source code):
+  - [Bun](https://bun.sh) for running unit tests & examples
+  - [Pnpm](https://pnpm.io) for package management
 
-## Try without Installation
+## Quick Start (No Installation Required)
 
 ```bash
-export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # setup your OpenAI API key
+export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # Set your OpenAI API key
 
-npx -y @aigne/example-workflow-orchestrator # run the example
+npx -y @aigne/example-workflow-orchestrator # Run the example
 ```
 
 ## Installation
@@ -73,7 +74,7 @@ pnpm install
 Setup your OpenAI API key in the `.env.local` file:
 
 ```bash
-OPENAI_API_KEY="" # setup your OpenAI API key here
+OPENAI_API_KEY="" # Set your OpenAI API key here
 ```
 
 When running Puppeteer inside a Docker container, set the following environment variable:

--- a/examples/workflow-orchestrator/index.ts
+++ b/examples/workflow-orchestrator/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx -y bun
+#!/usr/bin/env bunwrapper
 
 import { OrchestratorAgent } from "@aigne/agent-library/orchestrator/index.js";
 import { runChatLoopInTerminal } from "@aigne/cli/utils/run-chat-loop.js";

--- a/examples/workflow-reflection/README.md
+++ b/examples/workflow-reflection/README.md
@@ -24,16 +24,17 @@ class reviewer processing
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) and npm installed on your machine
-- [Bun](https://bun.sh) installed on your machine
-- [OpenAI API key](https://platform.openai.com/api-keys) used to interact with OpenAI API
-- [Pnpm](https://pnpm.io) [Optional] if you want to run the example from source code
+- An [OpenAI API key](https://platform.openai.com/api-keys) for interacting with OpenAI's services
+- Optional dependencies (if running the example from source code):
+  - [Bun](https://bun.sh) for running unit tests & examples
+  - [Pnpm](https://pnpm.io) for package management
 
-## Try without Installation
+## Quick Start (No Installation Required)
 
 ```bash
-export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # setup your OpenAI API key
+export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # Set your OpenAI API key
 
-npx -y @aigne/example-workflow-reflection # run the example
+npx -y @aigne/example-workflow-reflection # Run the example
 ```
 
 ## Installation
@@ -57,7 +58,7 @@ pnpm install
 Setup your OpenAI API key in the `.env.local` file:
 
 ```bash
-OPENAI_API_KEY="" # setup your OpenAI API key here
+OPENAI_API_KEY="" # Set your OpenAI API key here
 ```
 
 ### Run the Example

--- a/examples/workflow-reflection/index.ts
+++ b/examples/workflow-reflection/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx -y bun
+#!/usr/bin/env bunwrapper
 
 import { runChatLoopInTerminal } from "@aigne/cli/utils/run-chat-loop.js";
 import { AIAgent, ExecutionEngine, UserAgent, UserInputTopic, UserOutputTopic } from "@aigne/core";

--- a/examples/workflow-router/README.md
+++ b/examples/workflow-router/README.md
@@ -30,16 +30,17 @@ class other processing
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) and npm installed on your machine
-- [Bun](https://bun.sh) installed on your machine
-- [OpenAI API key](https://platform.openai.com/api-keys) used to interact with OpenAI API
-- [Pnpm](https://pnpm.io) [Optional] if you want to run the example from source code
+- An [OpenAI API key](https://platform.openai.com/api-keys) for interacting with OpenAI's services
+- Optional dependencies (if running the example from source code):
+  - [Bun](https://bun.sh) for running unit tests & examples
+  - [Pnpm](https://pnpm.io) for package management
 
-## Try without Installation
+## Quick Start (No Installation Required)
 
 ```bash
-export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # setup your OpenAI API key
+export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # Set your OpenAI API key
 
-npx -y @aigne/example-workflow-router # run the example
+npx -y @aigne/example-workflow-router # Run the example
 ```
 
 ## Installation
@@ -63,7 +64,7 @@ pnpm install
 Setup your OpenAI API key in the `.env.local` file:
 
 ```bash
-OPENAI_API_KEY="" # setup your OpenAI API key here
+OPENAI_API_KEY="" # Set your OpenAI API key here
 ```
 
 ### Run the Example

--- a/examples/workflow-router/index.ts
+++ b/examples/workflow-router/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx -y bun
+#!/usr/bin/env bunwrapper
 
 import { runChatLoopInTerminal } from "@aigne/cli/utils/run-chat-loop.js";
 import { AIAgent, ExecutionEngine } from "@aigne/core";

--- a/examples/workflow-sequential/README.md
+++ b/examples/workflow-sequential/README.md
@@ -25,16 +25,17 @@ class formatProof processing
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) and npm installed on your machine
-- [Bun](https://bun.sh) installed on your machine
-- [OpenAI API key](https://platform.openai.com/api-keys) used to interact with OpenAI API
-- [Pnpm](https://pnpm.io) [Optional] if you want to run the example from source code
+- An [OpenAI API key](https://platform.openai.com/api-keys) for interacting with OpenAI's services
+- Optional dependencies (if running the example from source code):
+  - [Bun](https://bun.sh) for running unit tests & examples
+  - [Pnpm](https://pnpm.io) for package management
 
-## Try without Installation
+## Quick Start (No Installation Required)
 
 ```bash
-export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # setup your OpenAI API key
+export OPENAI_API_KEY=YOUR_OPENAI_API_KEY # Set your OpenAI API key
 
-npx -y @aigne/example-workflow-sequential # run the example
+npx -y @aigne/example-workflow-sequential # Run the example
 ```
 
 ## Installation
@@ -58,7 +59,7 @@ pnpm install
 Setup your OpenAI API key in the `.env.local` file:
 
 ```bash
-OPENAI_API_KEY="" # setup your OpenAI API key here
+OPENAI_API_KEY="" # Set your OpenAI API key here
 ```
 
 ### Run the Example

--- a/examples/workflow-sequential/index.ts
+++ b/examples/workflow-sequential/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx -y bun
+#!/usr/bin/env bunwrapper
 
 import { runChatLoopInTerminal } from "@aigne/cli/utils/run-chat-loop.js";
 import { AIAgent, ExecutionEngine, sequential } from "@aigne/core";

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,8 @@
     "templates"
   ],
   "bin": {
-    "aigne": "dist/cli.js"
+    "aigne": "dist/cli.js",
+    "bunwrapper": "dist/bunwrapper.js"
   },
   "type": "module",
   "exports": {

--- a/packages/cli/src/bunwrapper.ts
+++ b/packages/cli/src/bunwrapper.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { argv } from "node:process";
+
+if (!getBunVersion()) {
+  spawnSync("npx", ["-y", "bun", ...argv.slice(2)], { stdio: "inherit" });
+} else {
+  spawnSync("bun", argv.slice(2), { stdio: "inherit" });
+}
+
+function getBunVersion() {
+  try {
+    const { stdout } = spawnSync("bun", ["--version"], { stdio: "pipe" });
+    return stdout.toString().trim() || undefined;
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/src/tracer/terminal.ts
+++ b/packages/cli/src/tracer/terminal.ts
@@ -67,7 +67,7 @@ export class TerminalTracer {
       [],
       {
         concurrent: true,
-        forceTTY: process.env.CI === "true",
+        forceTTY: true,
         rendererOptions: {
           collapseSubtasks: false,
           writeBottomBarDirectly: true,


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix: example chat-bot launch error
2. use `bunwrapper`(from @aigne/cli) to launch examples

### Checklist

- [x] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

**Release Notes**

- New Feature: Added `bunwrapper` utility to improve Bun command execution handling, automatically detecting local Bun installations and falling back to npx when needed
- Refactor: Simplified command execution in example scripts by using the new `bunwrapper` utility
- Chore: Enhanced GitHub Actions workflow reliability by ensuring proper binary executable installation
- Refactor: Streamlined chat-bot example command execution for better maintainability

These changes improve the developer experience by providing more robust Bun command handling and simplifying example script execution across the project.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->