### PR TITLE
feat: support set memory in agent yaml

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -99,9 +99,6 @@ jobs:
           # run pnpm install again to make binaries (@aigne/cli: aigne,bunwrapper) available in node_modules/.bin
           pnpm install
 
-      - name: Chmod examples/chat-bot aigne
-        run: chmod +x examples/chat-bot/node_modules/@aigne/cli/dist/cli.js
-
       - name: Run examples
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/agent-development.md
+++ b/docs/agent-development.md
@@ -87,6 +87,10 @@ tools:
   - `required`: List of parameters that must be returned
 - `output_key`: [Optional] Key name for output text (default is `$message`, only valid when there is no `output_schema`)
 - `tools`: [Optional] List of tools the agent can use (JavaScript files implementing specific functionality)
+- `memory`: [Optional] Enables conversation memory for the agent. Can be:
+  - A boolean value (`true` to enable, `false` to disable)
+  - An object with configuration options:
+    - `subscribe_topic`: Array of topics the agent should subscribe to for memory
 
 ## JavaScript Format Agent Definition (plus.js)
 

--- a/docs/agent-development.zh.md
+++ b/docs/agent-development.zh.md
@@ -87,6 +87,10 @@ tools:
   - `required`: 必须返回的参数列表
 - `output_key`: 【可选】输出文本的键名（默认为 `$message`，仅当没有 `output_schema` 时有效）
 - `tools`: 【可选】代理可以使用的工具列表（JavaScript 文件，实现特定功能）
+- `memory`: 【可选】启用代理的对话记忆功能。可以是：
+  - 布尔值（`true` 启用，`false` 禁用）
+  - 包含配置选项的对象：
+    - `subscribe_topic`: 代理应该订阅的记忆主题数组
 
 ## JavaScript 格式代理定义 (plus.js)
 

--- a/packages/cli/templates/default/chat.yaml
+++ b/packages/cli/templates/default/chat.yaml
@@ -3,5 +3,8 @@ description: Chat agent
 instructions: |
   You are a helpful assistant that can answer questions and provide information on a wide range of topics.
   Your goal is to assist users in finding the information they need and to engage in friendly conversation.
+memory:
+  subscribeTopic:
+    - chat
 tools:
   - sandbox.js

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,6 +74,7 @@
     "@aigne/json-schema-to-zod": "^1.3.3",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@types/debug": "^4.1.12",
+    "camelize-ts": "^3.0.0",
     "debug": "^4.4.0",
     "fast-deep-equal": "^3.1.3",
     "inquirer": "^12.5.2",

--- a/packages/core/src/loader/agent-js.ts
+++ b/packages/core/src/loader/agent-js.ts
@@ -1,6 +1,7 @@
 import { jsonSchemaToZod } from "@aigne/json-schema-to-zod";
 import { type ZodFunction, type ZodObject, type ZodTuple, type ZodType, z } from "zod";
 import type { Message } from "../agents/agent.js";
+import { customCamelize } from "../utils/camelize.js";
 import { tryOrThrow } from "../utils/type-utils.js";
 import { inputOutputSchema } from "./schema.js";
 
@@ -31,13 +32,14 @@ export async function loadAgentFromJsFile(path: string) {
 
   return tryOrThrow(
     () =>
-      agentJsFileSchema.parse({
-        name: agent.agent_name || agent.name,
-        description: agent.description,
-        input_schema: agent.input_schema,
-        output_schema: agent.output_schema,
-        fn: agent,
-      }),
+      customCamelize(
+        agentJsFileSchema.parse({
+          ...agent,
+          name: agent.agent_name || agent.name,
+          fn: agent,
+        }),
+        { shallowKeys: ["input_schema", "output_schema"] },
+      ),
     (error) => new Error(`Failed to parse agent from ${path}: ${error.message}`),
   );
 }

--- a/packages/core/src/loader/agent-yaml.ts
+++ b/packages/core/src/loader/agent-yaml.ts
@@ -38,15 +38,13 @@ const agentFileSchema = z.discriminatedUnion("type", [
       .transform((v) => v ?? undefined),
     memory: z
       .union([
-        z.boolean().transform((v) => v || undefined),
+        z.boolean(),
         z.object({
-          subscribe_topic: z
-            .array(z.string())
-            .nullish()
-            .transform((v) => v ?? undefined),
+          subscribe_topic: z.array(z.string()),
         }),
       ])
-      .transform((v) => v ?? undefined),
+      .nullish()
+      .transform((v) => v || undefined),
   }),
   z.object({
     type: z.literal("mcp"),

--- a/packages/core/src/loader/agent-yaml.ts
+++ b/packages/core/src/loader/agent-yaml.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { jsonSchemaToZod } from "@aigne/json-schema-to-zod";
 import { parse } from "yaml";
 import { type ZodObject, type ZodType, z } from "zod";
+import { customCamelize } from "../utils/camelize.js";
 import { tryOrThrow } from "../utils/type-utils.js";
 import { inputOutputSchema } from "./schema.js";
 
@@ -35,6 +36,17 @@ const agentFileSchema = z.discriminatedUnion("type", [
       .union([z.literal("auto"), z.literal("none"), z.literal("required"), z.literal("router")])
       .nullish()
       .transform((v) => v ?? undefined),
+    memory: z
+      .union([
+        z.boolean().transform((v) => v || undefined),
+        z.object({
+          subscribe_topic: z
+            .array(z.string())
+            .nullish()
+            .transform((v) => v ?? undefined),
+        }),
+      ])
+      .transform((v) => v ?? undefined),
   }),
   z.object({
     type: z.literal("mcp"),
@@ -65,7 +77,10 @@ export async function loadAgentFromYamlFile(path: string) {
   );
 
   const agent = tryOrThrow(
-    () => agentFileSchema.parse({ ...json, type: json.type ?? "ai" }),
+    () =>
+      customCamelize(agentFileSchema.parse({ ...json, type: json.type ?? "ai" }), {
+        shallowKeys: ["input_schema", "output_schema"],
+      }),
     (error) => new Error(`Failed to validate agent definition from ${path}: ${error.message}`),
   );
 

--- a/packages/core/src/loader/index.ts
+++ b/packages/core/src/loader/index.ts
@@ -49,29 +49,19 @@ export async function load(options: LoadOptions) {
 export async function loadAgent(path: string): Promise<Agent> {
   if (extname(path) === ".js") {
     const agent = await loadAgentFromJsFile(path);
-    return FunctionAgent.from({
-      name: agent.name,
-      description: agent.description,
-      inputSchema: agent.input_schema,
-      outputSchema: agent.output_schema,
-      fn: agent.fn,
-    });
+    return FunctionAgent.from(agent);
   }
 
   if (extname(path) === ".yaml" || extname(path) === ".yml") {
     const agent = await loadAgentFromYamlFile(path);
     if (agent.type === "ai") {
       return AIAgent.from({
-        name: agent.name,
-        description: agent.description,
-        instructions: agent.instructions,
-        inputSchema: agent.input_schema,
-        outputSchema: agent.output_schema,
-        outputKey: agent.output_key,
-        tools: await Promise.all(
-          (agent.tools ?? []).map((filename) => loadAgent(join(dirname(path), filename))),
-        ),
-        toolChoice: agent.tool_choice,
+        ...agent,
+        tools:
+          agent.tools &&
+          (await Promise.all(
+            agent.tools.map((filename) => loadAgent(join(dirname(path), filename))),
+          )),
       });
     }
     if (agent.type === "mcp") {

--- a/packages/core/src/utils/camelize.ts
+++ b/packages/core/src/utils/camelize.ts
@@ -1,0 +1,63 @@
+import camelize from "camelize-ts";
+
+export function customCamelize<T extends Record<string, unknown>, K extends KeyofUnion<T> = never>(
+  obj: T,
+  { shallowKeys = [] }: { shallowKeys?: K[] } = {},
+): CustomCamelize<T, K> {
+  const shallow = Object.fromEntries(
+    shallowKeys?.filter((key) => key in obj).map((key) => [key, obj[key as keyof T]]) ?? [],
+  );
+  const deep = Object.fromEntries(
+    Object.entries(obj).filter(([key]) => !shallowKeys?.includes(key as K)),
+  );
+
+  return {
+    ...camelize(shallow, true),
+    ...camelize(deep),
+  } as ReturnType<typeof customCamelize<T, K>>;
+}
+
+type KeyofUnion<U> = U extends Record<string, unknown> ? keyof U : never;
+
+type CamelCase<S extends string> = S extends `${infer P1}_${infer P2}${infer P3}`
+  ? `${P1}${Uppercase<P2>}${CamelCase<P3>}`
+  : S;
+
+const _unique: unique symbol = Symbol();
+type _never = typeof _unique;
+
+type ExtractTypeFromUnion<T, U> = Extract<T, U> extends never
+  ? _never
+  : Extract<T, U> extends Array<infer E>
+    ? Array<E>
+    : U;
+
+type ExtractTypeWithConstFromUnion<T, U> = Exclude<T, Exclude<T, U>>;
+
+export type CustomCamelize<
+  T,
+  ShallowKeys extends KeyofUnion<T> | undefined = undefined,
+> = ExtractTypeFromUnion<T, never> extends never
+  ? never
+  : ExtractTypeFromUnion<T, Date> extends Date
+    ? ExtractTypeWithConstFromUnion<T, Date> | CustomCamelize<Exclude<T, Date>>
+    : ExtractTypeFromUnion<T, RegExp> extends RegExp
+      ? ExtractTypeWithConstFromUnion<T, RegExp> | CustomCamelize<Exclude<T, RegExp>>
+      : ExtractTypeFromUnion<T, Array<unknown>> extends Array<infer U>
+        ? Array<CustomCamelize<U>> | CustomCamelize<Exclude<T, Array<U>>>
+        : // biome-ignore lint/complexity/noBannedTypes: <explanation>
+          ExtractTypeFromUnion<T, Function> extends Function
+          ? // biome-ignore lint/complexity/noBannedTypes: <explanation>
+              | ExtractTypeWithConstFromUnion<T, Function>
+              // biome-ignore lint/complexity/noBannedTypes: <explanation>
+              | CustomCamelize<Exclude<T, Function>>
+          : ExtractTypeFromUnion<T, object> extends object
+            ? {
+                [K in keyof T as Uncapitalize<CamelCase<string & K>>]: K extends Exclude<
+                  ShallowKeys,
+                  undefined
+                >
+                  ? T[K]
+                  : CustomCamelize<T[K]>;
+              }
+            : T;

--- a/packages/core/test-agents/chat.yaml
+++ b/packages/core/test-agents/chat.yaml
@@ -3,5 +3,6 @@ description: Chat agent
 instructions: |
   You are a helpful assistant that can answer questions and provide information on a wide range of topics.
   Your goal is to assist users in finding the information they need and to engage in friendly conversation.
+memory: true
 tools:
   - sandbox.js

--- a/packages/core/test/utils/camelize.test.ts
+++ b/packages/core/test/utils/camelize.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "bun:test";
+import { customCamelize } from "@aigne/core/utils/camelize.js";
+
+test("customCamelize should correctly camelize keys", async () => {
+  expect(
+    customCamelize({
+      first_key: "value1",
+      nested_key: {
+        nested_key: "value3",
+        another_key: {
+          another_key: "value4",
+        },
+        array_key: [
+          {
+            array_key: "value5",
+          },
+        ],
+      },
+      array_key: [
+        {
+          array_key: "value5",
+        },
+      ],
+    }),
+  ).toEqual({
+    firstKey: "value1",
+    nestedKey: {
+      nestedKey: "value3",
+      anotherKey: {
+        anotherKey: "value4",
+      },
+      arrayKey: [
+        {
+          arrayKey: "value5",
+        },
+      ],
+    },
+    arrayKey: [
+      {
+        arrayKey: "value5",
+      },
+    ],
+  });
+});
+
+test("customCamelize should correctly handle shallow keys", async () => {
+  expect(
+    customCamelize(
+      {
+        first_key: "value1",
+        nested_key: {
+          nested_key: "value3",
+          another_key: {
+            another_key: "value4",
+          },
+        },
+      },
+      {
+        shallowKeys: ["first_key", "nested_key"],
+      },
+    ),
+  ).toEqual({
+    firstKey: "value1",
+    nestedKey: {
+      nested_key: "value3",
+      another_key: {
+        another_key: "value4",
+      },
+    },
+  });
+});
+
+test("customCamelize should skip Date and RegExp", async () => {
+  const date = new Date();
+  const regexp = /abc/;
+
+  expect(
+    customCamelize({
+      date_key: date,
+      regexp_key: regexp,
+    }),
+  ).toEqual({
+    dateKey: date,
+    regexpKey: regexp,
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,6 +340,9 @@ importers:
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
+      camelize-ts:
+        specifier: ^3.0.0
+        version: 3.0.0
       debug:
         specifier: ^4.4.0
         version: 4.4.0
@@ -835,6 +838,10 @@ packages:
   call-bound@1.0.3:
     resolution: {integrity: sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==}
     engines: {node: '>= 0.4'}
+
+  camelize-ts@3.0.0:
+    resolution: {integrity: sha512-cgRwKKavoDKLTjO4FQTs3dRBePZp/2Y9Xpud0FhuCOTE86M2cniKN4CCXgRnsyXNMmQMifVHcv6SPaMtTx6ofQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -2732,6 +2739,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.1
       get-intrinsic: 1.2.7
+
+  camelize-ts@3.0.0: {}
 
   chalk@2.4.2:
     dependencies:


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. feat: support set memory in agent yaml
```yaml
name: chat
description: Chat agent
instructions: |
  You are a helpful assistant that can answer questions and provide information on a wide range of topics.
  Your goal is to assist users in finding the information they need and to engage in friendly conversation.
memory: true
```

### Checklist

- [x] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [x] This change adds dependencies, and they are placed in dependencies and devDependencies
- [x] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

Release Notes:

- New Feature: Added flexible snake_case to camelCase conversion utility with support for nested objects and configurable transformation depth
- Refactor: Enhanced agent loading system with improved memory configuration support in YAML files
- Refactor: Streamlined agent creation process with more consistent property handling across JS and YAML loaders

Impact: Users can now define memory configurations in YAML files and benefit from more reliable property name handling when creating agents. The changes maintain backward compatibility while providing more flexible configuration options.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->