### PR TITLE
fix(core): ensure no deduplicate tools for chat model

### DIFF
--- a/packages/core/src/prompt/prompt-builder.ts
+++ b/packages/core/src/prompt/prompt-builder.ts
@@ -15,7 +15,7 @@ import type {
   ChatModelOptions,
 } from "../models/chat-model.js";
 import { outputSchemaToResponseFormatSchema } from "../utils/json-schema.js";
-import { isNil } from "../utils/type-utils.js";
+import { isNil, unique } from "../utils/type-utils.js";
 import {
   AgentMessageTemplate,
   ChatMessagesTemplate,
@@ -178,10 +178,13 @@ export class PromptBuilder {
   private buildTools(
     options: PromptBuilderBuildOptions,
   ): Pick<ChatModelInput, "tools" | "toolChoice" | "modelOptions"> & { toolAgents?: Agent[] } {
-    const toolAgents = (options.context?.skills ?? [])
-      .concat(options.agent?.skills ?? [])
-      // TODO: support nested tools?
-      .flatMap((i) => (i.isInvokable ? i.skills.concat(i) : i.skills));
+    const toolAgents = unique(
+      (options.context?.skills ?? [])
+        .concat(options.agent?.skills ?? [])
+        // TODO: support nested tools?
+        .flatMap((i) => (i.isInvokable ? i.skills.concat(i) : i.skills)),
+      (i) => i.name,
+    );
 
     const tools: ChatModelInputTool[] = toolAgents.map((i) => ({
       type: "function",

--- a/packages/core/src/utils/type-utils.ts
+++ b/packages/core/src/utils/type-utils.ts
@@ -46,6 +46,20 @@ export function duplicates<T>(arr: T[], key: (item: T) => unknown = (item: T) =>
   return Array.from(duplicates);
 }
 
+export function unique<T>(arr: T[], key: (item: T) => unknown = (item: T) => item): T[] {
+  const seen = new Set();
+
+  return arr.filter((item) => {
+    const k = key(item);
+    if (seen.has(k)) {
+      return false;
+    }
+
+    seen.add(k);
+    return true;
+  });
+}
+
 export function omitBy<T extends Record<string, unknown>, K extends keyof T>(
   obj: T,
   predicate: (value: T[K], key: K) => boolean,

--- a/packages/core/test/prompt/prompt-builder.test.ts
+++ b/packages/core/test/prompt/prompt-builder.test.ts
@@ -137,6 +137,24 @@ test("PromptBuilder should build skills correctly", async () => {
   });
 });
 
+test("PromptBuilder should unique skills correctly", async () => {
+  const skill = FunctionAgent.from({
+    name: "TestSkill",
+    description: "Test skill description",
+    fn: () => ({}),
+  });
+
+  const agent = AIAgent.from({
+    name: "TestAgent",
+    instructions: "Test instructions",
+    skills: [skill, skill],
+  });
+
+  const prompt = await agent.instructions.build({ input: {}, agent });
+
+  expect(prompt.tools).toHaveLength(1);
+});
+
 test("PromptBuilder should build toolChoice with router mode correctly", async () => {
   const skill = FunctionAgent.from({
     name: "TestSkill",

--- a/packages/core/test/utils/type-utils.test.ts
+++ b/packages/core/test/utils/type-utils.test.ts
@@ -11,6 +11,7 @@ import {
   omitBy,
   orArrayToArray,
   tryOrThrow,
+  unique,
 } from "@aigne/core/utils/type-utils.js";
 import { type ZodType, z } from "zod";
 
@@ -56,6 +57,15 @@ test("type-utils.duplicates", async () => {
   expect(duplicated).toEqual([{ id: 1, name: "baz" }]);
 
   expect(duplicates(["foo", "bar", "baz", "foo"])).toEqual(["foo"]);
+});
+
+test("type-utils.unique", async () => {
+  expect(unique([1, 2, 3, 1, 2, 3])).toEqual([1, 2, 3]);
+
+  expect(unique([{ id: 1 }, { id: 2 }, { id: 1 }], (item) => item.id)).toEqual([
+    { id: 1 },
+    { id: 2 },
+  ]);
 });
 
 test("type-utils.omitBy", async () => {


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(core): deduplicate tools for chat model

### Checklist

- [x] The newly added code logic is also covered by tests
<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

Release Notes:

- New Feature: Added array deduplication functionality to prevent duplicate tools when combining multiple AI agent skills
- Refactor: Improved handling of tool combinations in prompt builder for more efficient agent configurations
- Test: Added comprehensive test coverage for deduplication features

These changes enhance the reliability of AI agent configurations by automatically preventing duplicate tools when combining skills from different sources, resulting in more predictable and efficient agent behavior.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->