### PR TITLE
chore: polish mcp-blocklet example

### DIFF
--- a/examples/mcp-blocklet/index.ts
+++ b/examples/mcp-blocklet/index.ts
@@ -21,12 +21,26 @@ assert(
 );
 
 const appUrl = new URL(rawUrl);
+try {
+  appUrl.pathname = "/__blocklet__.js";
+  const result = await fetch(appUrl.href);
+  if (result.status !== 200) {
+    console.error("Seems like the provided url is not a valid blocklet url: ", rawUrl);
+    process.exit(1);
+  }
+} catch (error) {
+  console.error("Error verifying blocklet url", error);
+  process.exit(1);
+}
+
+console.info("Connecting to blocklet", appUrl.href);
 appUrl.pathname = "/.well-known/service/mcp";
 console.info("Connecting to blocklet", appUrl.href);
 
 let transport: StreamableHTTPClientTransport;
 
 const provider = new TerminalOAuthProvider(appUrl.host);
+
 const authCodePromise = new Promise((resolve, reject) => {
   provider.once("authorized", async (code) => {
     await transport.finishAuth(code);

--- a/examples/mcp-blocklet/index.ts
+++ b/examples/mcp-blocklet/index.ts
@@ -33,7 +33,6 @@ try {
   process.exit(1);
 }
 
-console.info("Connecting to blocklet", appUrl.href);
 appUrl.pathname = "/.well-known/service/mcp";
 console.info("Connecting to blocklet", appUrl.href);
 
@@ -116,7 +115,6 @@ const model = await loadModel();
 
 const blocklet = await MCPAgent.from({
   url: appUrl.href,
-  timeout: 8000,
   transport: "streamableHttp",
   opts: {
     authProvider: provider,


### PR DESCRIPTION
## Related Issue

from internal test feedback

### Major Changes

1. ensure BLOCKLT_APP_URL is valid before starting the example
2. remove custom timeout for mcp-agent transport, default to 60s

### Screenshots

No

### Test Plan

- [x] Run mcp-blocklet locally, with or without oauth info

### Checklist

- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

**Release Notes**

- New Feature: Added URL validation for blocklet applications to ensure proper connectivity
- Bug Fix: Removed custom 8-second timeout in favor of standard 60-second timeout for more reliable connections
- Enhancement: Improved error handling for invalid blocklet URLs with graceful process termination

These changes enhance the reliability and robustness of blocklet application connections while providing clearer feedback when connection issues occur.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->