### PR TITLE
fix(core): default catch tool's error and continue processing

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -9,7 +9,6 @@
   * [Introduction](#introduction)
   * [Installation](#installation)
     * [Installing AIGNE Framework](#installing-aigne-framework)
-    * [Using @aigne/core in CommonJS Environment](#using-aignecore-in-commonjs-environment)
   * [Core Concepts](#core-concepts)
     * [Chat Model](#chat-model)
     * [Agent](#agent)
@@ -76,30 +75,6 @@ pnpm install @aigne/agent-library
 
 # Install LLM libraries as needed
 pnpm install openai @anthropic-ai/sdk @google/generative-ai
-```
-
-### Using @aigne/core in CommonJS Environment
-
-@aigne/core supports use in both CommonJS and ES Module environments. If your project uses the CommonJS module system, but due to a [third-party lib not supporting ESM](https://github.com/AIGNE-io/aigne-framework/issues/36), you need to add the following configuration to your project's package.json before the issue is fixed:
-
-**npm**
-
-```json
-{
-  "overrides": {
-    "pkce-challenge": "https://github.com/AIGNE-io/pkce-challenge#dist"
-  }
-}
-```
-
-**yarn or pnpm**
-
-```json
-{
-  "resolutions": {
-    "pkce-challenge": "https://github.com/AIGNE-io/pkce-challenge#dist"
-  }
-}
 ```
 
 ## Core Concepts

--- a/docs/cookbook.zh.md
+++ b/docs/cookbook.zh.md
@@ -9,7 +9,6 @@
   * [介绍](#介绍)
   * [安装](#安装)
     * [安装 AIGNE Framework](#安装-aigne-framework)
-    * [在 CommonJS 环境中使用 @aigne/core](#在-commonjs-环境中使用-aignecore)
   * [基础概念](#基础概念)
     * [聊天模型（ChatModel）](#聊天模型chatmodel)
     * [Agent](#agent)
@@ -76,30 +75,6 @@ pnpm install @aigne/agent-library
 
 # 根据需要选择安装 LLM
 pnpm install openai @anthropic-ai/sdk @google/generative-ai
-```
-
-### 在 CommonJS 环境中使用 @aigne/core
-
-@aigne/core 支持在 CommonJS 和 ES Module 环境中使用。如果你的项目使用 CommonJS 模块系统，但由于一个[第三方 lib 不支持 ESM](https://github.com/AIGNE-io/aigne-framework/issues/36)，在问题修复前，需要在项目中的 package.json 中加入下面的配置：
-
-**npm**
-
-```json
-{
-  "overrides": {
-    "pkce-challenge": "https://github.com/AIGNE-io/pkce-challenge#dist"
-  }
-}
-```
-
-**yarn or pnpm**
-
-```json
-{
-  "resolutions": {
-    "pkce-challenge": "https://github.com/AIGNE-io/pkce-challenge#dist"
-  }
-}
 ```
 
 ## 基础概念

--- a/packages/core/src/agents/ai-agent.ts
+++ b/packages/core/src/agents/ai-agent.ts
@@ -59,6 +59,14 @@ export interface AIAgentOptions<I extends Message = Message, O extends Message =
    * @default AIAgentToolChoice.auto
    */
   toolChoice?: AIAgentToolChoice | Agent;
+
+  /**
+   * Whether to catch errors from tool execution and continue processing.
+   * If set to false, the agent will throw an error if a tool fails.
+   *
+   * @default true
+   */
+  catchToolErrors?: boolean;
 }
 
 /**
@@ -174,6 +182,9 @@ export class AIAgent<I extends Message = Message, O extends Message = Message> e
         : (options.instructions ?? new PromptBuilder());
     this.outputKey = options.outputKey;
     this.toolChoice = options.toolChoice;
+
+    if (typeof options.catchToolErrors === "boolean")
+      this.catchToolErrors = options.catchToolErrors;
   }
 
   /**
@@ -216,6 +227,14 @@ export class AIAgent<I extends Message = Message, O extends Message = Message> e
    * {@includeCode ../../test/agents/ai-agent.test.ts#example-ai-agent-router}
    */
   toolChoice?: AIAgentToolChoice | Agent;
+
+  /**
+   * Whether to catch errors from tool execution and continue processing.
+   * If set to false, the agent will throw an error if a tool fails
+   *
+   * @default true
+   */
+  catchToolErrors = true;
 
   /**
    * Process an input message and generate a response
@@ -276,11 +295,20 @@ export class AIAgent<I extends Message = Message, O extends Message = Message> e
           if (!tool) throw new Error(`Tool not found: ${call.function.name}`);
 
           // NOTE: should pass both arguments (model generated) and input (user provided) to the tool
-          const output = await context.invoke(
-            tool,
-            { ...call.function.arguments, ...input },
-            { disableTransfer: true },
-          );
+          const output = await context
+            .invoke(tool, { ...call.function.arguments, ...input }, { disableTransfer: true })
+            .catch((error) => {
+              if (!this.catchToolErrors) {
+                return Promise.reject(error);
+              }
+
+              return {
+                isError: true,
+                error: {
+                  message: error.message,
+                },
+              };
+            });
 
           // NOTE: Return transfer output immediately
           if (isTransferAgentOutput(output)) {

--- a/packages/core/src/agents/ai-agent.ts
+++ b/packages/core/src/agents/ai-agent.ts
@@ -66,7 +66,7 @@ export interface AIAgentOptions<I extends Message = Message, O extends Message =
    *
    * @default true
    */
-  catchToolErrors?: boolean;
+  catchToolsError?: boolean;
 }
 
 /**
@@ -183,8 +183,8 @@ export class AIAgent<I extends Message = Message, O extends Message = Message> e
     this.outputKey = options.outputKey;
     this.toolChoice = options.toolChoice;
 
-    if (typeof options.catchToolErrors === "boolean")
-      this.catchToolErrors = options.catchToolErrors;
+    if (typeof options.catchToolsError === "boolean")
+      this.catchToolsError = options.catchToolsError;
   }
 
   /**
@@ -229,12 +229,12 @@ export class AIAgent<I extends Message = Message, O extends Message = Message> e
   toolChoice?: AIAgentToolChoice | Agent;
 
   /**
-   * Whether to catch errors from tool execution and continue processing.
+   * Whether to catch error from tool execution and continue processing.
    * If set to false, the agent will throw an error if a tool fails
    *
    * @default true
    */
-  catchToolErrors = true;
+  catchToolsError = true;
 
   /**
    * Process an input message and generate a response
@@ -298,7 +298,7 @@ export class AIAgent<I extends Message = Message, O extends Message = Message> e
           const output = await context
             .invoke(tool, { ...call.function.arguments, ...input }, { disableTransfer: true })
             .catch((error) => {
-              if (!this.catchToolErrors) {
+              if (!this.catchToolsError) {
                 return Promise.reject(error);
               }
 

--- a/packages/core/test/agents/ai-agent.test.ts
+++ b/packages/core/test/agents/ai-agent.test.ts
@@ -368,7 +368,7 @@ test("AIAgent with catchToolErrors disabled", async () => {
   const agent = AIAgent.from({
     model,
     skills: [plus],
-    catchToolErrors: false,
+    catchToolsError: false,
   });
 
   spyOn(model, "process").mockReturnValueOnce(

--- a/packages/core/test/agents/ai-agent.test.ts
+++ b/packages/core/test/agents/ai-agent.test.ts
@@ -286,6 +286,102 @@ test("AIAgent with router tool choice", async () => {
   // #endregion example-ai-agent-router
 });
 
+test("AIAgent with catchToolErrors enabled", async () => {
+  const model = new OpenAIChatModel();
+
+  const plus = FunctionAgent.from({
+    name: "plus",
+    inputSchema: z.object({
+      a: z.number(),
+      b: z.number(),
+    }),
+    outputSchema: z.object({
+      sum: z.number(),
+    }),
+    process: ({ a, b }) => {
+      if (a === 0 || b === 0) throw new Error("Invalid input: a or b is zero");
+
+      return { sum: a + b };
+    },
+  });
+
+  const agent = AIAgent.from({
+    model,
+    skills: [plus],
+  });
+
+  const process = spyOn(model, "process")
+    .mockReturnValueOnce(
+      Promise.resolve({
+        toolCalls: [createToolCallResponse("plus", { a: 1, b: 0 })],
+      }),
+    )
+    .mockReturnValueOnce(
+      Promise.resolve({
+        toolCalls: [createToolCallResponse("plus", { a: 1, b: 2 })],
+      }),
+    )
+    .mockReturnValueOnce({
+      text: "1 + 2 = 3",
+    });
+
+  const result = await agent.invoke("1 + 2 = ?");
+
+  expect(process).toHaveBeenCalledTimes(3);
+  expect(process).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      messages: expect.arrayContaining([
+        expect.objectContaining({
+          role: "tool",
+          content: JSON.stringify({
+            isError: true,
+            error: { message: "Invalid input: a or b is zero" },
+          }),
+        }),
+      ]),
+    }),
+    expect.anything(),
+  );
+
+  expect(result).toEqual({ $message: "1 + 2 = 3" });
+});
+
+test("AIAgent with catchToolErrors disabled", async () => {
+  const model = new OpenAIChatModel();
+
+  const plus = FunctionAgent.from({
+    name: "plus",
+    inputSchema: z.object({
+      a: z.number(),
+      b: z.number(),
+    }),
+    outputSchema: z.object({
+      sum: z.number(),
+    }),
+    process: ({ a, b }) => {
+      if (a === 0 || b === 0) throw new Error("Invalid input: a or b is zero");
+
+      return { sum: a + b };
+    },
+  });
+
+  const agent = AIAgent.from({
+    model,
+    skills: [plus],
+    catchToolErrors: false,
+  });
+
+  spyOn(model, "process").mockReturnValueOnce(
+    Promise.resolve({
+      toolCalls: [createToolCallResponse("plus", { a: 1, b: 0 })],
+    }),
+  );
+
+  const result = agent.invoke("1 + 2 = ?");
+
+  expect(result).rejects.toThrowError("Invalid input: a or b is zero");
+});
+
 test.each([true, false])("AIAgent.invoke with streaming %p", async (streaming) => {
   const model = new OpenAIChatModel();
 


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

- fix #104 

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->
1. fix(core): default catch tool errors and continue processing

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [x] The newly added code logic is also covered by tests

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

**Release Notes**

- New Feature: Added configurable error handling for AI agent tools via `catchToolErrors` option
- Test: Added comprehensive test coverage for error handling scenarios

This release introduces more flexible error handling control for AI agents. Users can now choose whether tool execution errors should be caught and processed (default behavior) or propagate as exceptions by setting the `catchToolErrors` option. This enables better error management strategies depending on application needs.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->