### PR TITLE
fix(core): handle response for UserAgent automatically in pub/sub mode

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -30,6 +30,9 @@
       },
       "suspicious": {
         "noConfusingVoidType": "off"
+      },
+      "complexity": {
+        "noForEach": "off"
       }
     }
   },

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -368,13 +368,7 @@ console.log(result);
 **Example**:
 
 ```typescript file=../examples/workflow-reflection/usages.ts
-import {
-  AIAgent,
-  AIGNE,
-  UserInputTopic,
-  UserOutputTopic,
-  createPublishMessage,
-} from "@aigne/core";
+import { AIAgent, AIGNE, UserInputTopic, UserOutputTopic } from "@aigne/core";
 import { OpenAIChatModel } from "@aigne/core/models/openai-chat-model.js";
 import { z } from "zod";
 
@@ -448,9 +442,7 @@ Please review the code. If previous feedback was provided, see if it was address
 const aigne = new AIGNE({ model, agents: [coder, reviewer] });
 aigne.publish(
   UserInputTopic,
-  createPublishMessage(
-    "Write a function to find the sum of all even numbers in a list.",
-  ),
+  "Write a function to find the sum of all even numbers in a list.",
 );
 
 const { message } = await aigne.subscribe(UserOutputTopic);

--- a/docs/cookbook.zh.md
+++ b/docs/cookbook.zh.md
@@ -368,13 +368,7 @@ console.log(result);
 **示例**:
 
 ```typescript file=../examples/workflow-reflection/usages.ts
-import {
-  AIAgent,
-  AIGNE,
-  UserInputTopic,
-  UserOutputTopic,
-  createPublishMessage,
-} from "@aigne/core";
+import { AIAgent, AIGNE, UserInputTopic, UserOutputTopic } from "@aigne/core";
 import { OpenAIChatModel } from "@aigne/core/models/openai-chat-model.js";
 import { z } from "zod";
 
@@ -448,9 +442,7 @@ Please review the code. If previous feedback was provided, see if it was address
 const aigne = new AIGNE({ model, agents: [coder, reviewer] });
 aigne.publish(
   UserInputTopic,
-  createPublishMessage(
-    "Write a function to find the sum of all even numbers in a list.",
-  ),
+  "Write a function to find the sum of all even numbers in a list.",
 );
 
 const { message } = await aigne.subscribe(UserOutputTopic);

--- a/examples/workflow-reflection/index.ts
+++ b/examples/workflow-reflection/index.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 const model = await loadModel();
 
 const coder = AIAgent.from({
+  name: "coder",
   subscribeTopic: [UserInputTopic, "rewrite_request"],
   publishTopic: "review_request",
   instructions: `\
@@ -37,6 +38,7 @@ User's question:
 });
 
 const reviewer = AIAgent.from({
+  name: "reviewer",
   subscribeTopic: "review_request",
   publishTopic: (output) => (output.approval ? UserOutputTopic : "rewrite_request"),
   instructions: `\

--- a/examples/workflow-reflection/usages.ts
+++ b/examples/workflow-reflection/usages.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { AIAgent, AIGNE, UserInputTopic, UserOutputTopic, createPublishMessage } from "@aigne/core";
+import { AIAgent, AIGNE, UserInputTopic, UserOutputTopic } from "@aigne/core";
 import { OpenAIChatModel } from "@aigne/core/models/openai-chat-model.js";
 import { z } from "zod";
 
@@ -69,10 +69,7 @@ Please review the code. If previous feedback was provided, see if it was address
 });
 
 const aigne = new AIGNE({ model, agents: [coder, reviewer] });
-aigne.publish(
-  UserInputTopic,
-  createPublishMessage("Write a function to find the sum of all even numbers in a list."),
-);
+aigne.publish(UserInputTopic, "Write a function to find the sum of all even numbers in a list.");
 
 const { message } = await aigne.subscribe(UserOutputTopic);
 console.log(message);

--- a/packages/core/src/aigne/aigne.ts
+++ b/packages/core/src/aigne/aigne.ts
@@ -288,7 +288,7 @@ export class AIGNE {
    * Here's an example of how to publish a message:
    * {@includeCode ../../test/aigne/aigne.test.ts#example-publish-message}
    */
-  publish(topic: string | string[], payload: Omit<MessagePayload, "context">) {
+  publish(topic: string | string[], payload: Omit<MessagePayload, "context"> | Message | string) {
     return new AIGNEContext(this).publish(topic, payload);
   }
 
@@ -304,7 +304,7 @@ export class AIGNE {
    * Here's an example of how to subscribe to a topic and receive the next message:
    * {@includeCode ../../test/aigne/aigne.test.ts#example-publish-message}
    */
-  subscribe(topic: string, listener?: undefined): Promise<MessagePayload>;
+  subscribe(topic: string | string[], listener?: undefined): Promise<MessagePayload>;
 
   /**
    * Subscribes to messages on a specific topic with a listener callback.
@@ -319,7 +319,7 @@ export class AIGNE {
    * Here's an example of how to subscribe to a topic with a listener:
    * {@includeCode ../../test/aigne/aigne.test.ts#example-subscribe-topic}
    */
-  subscribe(topic: string, listener: MessageQueueListener): Unsubscribe;
+  subscribe(topic: string | string[], listener: MessageQueueListener): Unsubscribe;
 
   /**
    * Generic subscribe signature that handles both Promise and listener patterns.
@@ -329,8 +329,14 @@ export class AIGNE {
    * @param listener - Optional callback function
    * @returns Either a Promise for the next message or an Unsubscribe function
    */
-  subscribe(topic: string, listener?: MessageQueueListener): Unsubscribe | Promise<MessagePayload>;
-  subscribe(topic: string, listener?: MessageQueueListener): Unsubscribe | Promise<MessagePayload> {
+  subscribe(
+    topic: string | string[],
+    listener?: MessageQueueListener,
+  ): Unsubscribe | Promise<MessagePayload>;
+  subscribe(
+    topic: string | string[],
+    listener?: MessageQueueListener,
+  ): Unsubscribe | Promise<MessagePayload> {
     return this.messageQueue.subscribe(topic, listener);
   }
 
@@ -346,7 +352,7 @@ export class AIGNE {
    * @example
    * {@includeCode ../../test/aigne/aigne.test.ts#example-subscribe-topic}
    */
-  unsubscribe(topic: string, listener: MessageQueueListener) {
+  unsubscribe(topic: string | string[], listener: MessageQueueListener) {
     this.messageQueue.unsubscribe(topic, listener);
   }
 

--- a/packages/core/src/aigne/message-queue.ts
+++ b/packages/core/src/aigne/message-queue.ts
@@ -1,7 +1,8 @@
 import { EventEmitter } from "node:events";
 import { z } from "zod";
 import type { Message } from "../agents/agent.js";
-import { checkArguments, orArrayToArray } from "../utils/type-utils.js";
+import { createMessage } from "../prompt/prompt-builder.js";
+import { checkArguments, isNil, orArrayToArray } from "../utils/type-utils.js";
 import type { Context } from "./context.js";
 
 /**
@@ -24,6 +25,35 @@ export interface MessagePayload {
 
   // Context of the message
   context: Context;
+}
+
+function isMessagePayload(payload: unknown): payload is Omit<MessagePayload, "context"> {
+  return (
+    !isNil(payload) &&
+    typeof payload === "object" &&
+    "role" in payload &&
+    typeof payload.role === "string" &&
+    ["user", "agent"].includes(payload.role) &&
+    "message" in payload &&
+    !isNil(payload.message)
+  );
+}
+
+/**
+ * @hidden
+ */
+export function toMessagePayload(
+  payload: Omit<MessagePayload, "context"> | string | Message,
+  options?: Partial<Pick<MessagePayload, "role" | "source">>,
+): Omit<MessagePayload, "context"> {
+  if (isMessagePayload(payload)) {
+    return { ...payload, message: createMessage(payload.message), ...options };
+  }
+  return {
+    role: options?.role || "user",
+    source: options?.source,
+    message: createMessage(payload),
+  };
 }
 
 /**
@@ -57,10 +87,16 @@ export class MessageQueue {
     this.events.emit("error", error);
   }
 
-  subscribe(topic: string, listener?: undefined): Promise<MessagePayload>;
-  subscribe(topic: string, listener: MessageQueueListener): Unsubscribe;
-  subscribe(topic: string, listener?: MessageQueueListener): Unsubscribe | Promise<MessagePayload>;
-  subscribe(topic: string, listener?: MessageQueueListener): Unsubscribe | Promise<MessagePayload> {
+  subscribe(topic: string | string[], listener?: undefined): Promise<MessagePayload>;
+  subscribe(topic: string | string[], listener: MessageQueueListener): Unsubscribe;
+  subscribe(
+    topic: string | string[],
+    listener?: MessageQueueListener,
+  ): Unsubscribe | Promise<MessagePayload>;
+  subscribe(
+    topic: string | string[],
+    listener?: MessageQueueListener,
+  ): Unsubscribe | Promise<MessagePayload> {
     checkArguments("MessageQueue.subscribe", subscribeArgsSchema, {
       topic,
       listener,
@@ -82,41 +118,43 @@ export class MessageQueue {
     return on(this.events, topic, listener);
   }
 
-  unsubscribe(topic: string, listener: MessageQueueListener) {
+  unsubscribe(topic: string | string[], listener: MessageQueueListener) {
     checkArguments("MessageQueue.unsubscribe", unsubscribeArgsSchema, {
       topic,
       listener,
     });
 
-    this.events.off(topic, listener);
+    for (const t of orArrayToArray(topic)) {
+      this.events.off(t, listener);
+    }
   }
 }
 
 function on<T>(
   events: EventEmitter,
-  event: string,
+  event: string | string[],
   listener: (arg: T, ...args: unknown[]) => void,
 ): Unsubscribe {
-  events.on(event, listener);
-  return () => events.off(event, listener);
+  orArrayToArray(event).map((e) => events.on(e, listener));
+  return () => orArrayToArray(event).map((e) => events.off(e, listener));
 }
 
 function once<T>(
   events: EventEmitter,
-  event: string,
+  event: string | string[],
   listener: (arg: T, ...args: unknown[]) => void,
 ): Unsubscribe {
-  events.once(event, listener);
-  return () => events.off(event, listener);
+  orArrayToArray(event).map((e) => events.once(e, listener));
+  return () => orArrayToArray(event).map((e) => events.off(e, listener));
 }
 
 const subscribeArgsSchema = z.object({
-  topic: z.string(),
+  topic: z.union([z.string(), z.array(z.string())]),
   listener: z.function(z.tuple([z.any()]), z.any()).optional(),
 });
 
 const unsubscribeArgsSchema = z.object({
-  topic: z.string(),
+  topic: z.union([z.string(), z.array(z.string())]),
   listener: z.function(z.tuple([z.any()]), z.any()),
 });
 

--- a/packages/core/src/aigne/message-queue.ts
+++ b/packages/core/src/aigne/message-queue.ts
@@ -135,8 +135,8 @@ function on<T>(
   event: string | string[],
   listener: (arg: T, ...args: unknown[]) => void,
 ): Unsubscribe {
-  orArrayToArray(event).map((e) => events.on(e, listener));
-  return () => orArrayToArray(event).map((e) => events.off(e, listener));
+  orArrayToArray(event).forEach((e) => events.on(e, listener));
+  return () => orArrayToArray(event).forEach((e) => events.off(e, listener));
 }
 
 function once<T>(
@@ -144,8 +144,8 @@ function once<T>(
   event: string | string[],
   listener: (arg: T, ...args: unknown[]) => void,
 ): Unsubscribe {
-  orArrayToArray(event).map((e) => events.once(e, listener));
-  return () => orArrayToArray(event).map((e) => events.off(e, listener));
+  orArrayToArray(event).forEach((e) => events.once(e, listener));
+  return () => orArrayToArray(event).forEach((e) => events.off(e, listener));
 }
 
 const subscribeArgsSchema = z.object({

--- a/packages/core/test/agents/memory.test.ts
+++ b/packages/core/test/agents/memory.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { AIGNE, AgentMemory, type Memory, createMessage, createPublishMessage } from "@aigne/core";
+import { AIGNE, AgentMemory, type Memory, createMessage } from "@aigne/core";
 
 test("should add a new memory if it is not the same as the last one", () => {
   const agentMemory = new AgentMemory({});
@@ -42,7 +42,7 @@ test("should add memory after topic trigger", () => {
   });
 
   memory.attach(context);
-  context.publish("test_topic", createPublishMessage("hello"));
+  context.publish("test_topic", "hello");
   expect(memory.memories).toEqual([
     {
       role: "user",
@@ -52,7 +52,7 @@ test("should add memory after topic trigger", () => {
 
   // should not add memory if the memory is detached
   memory.detach();
-  context.publish("test_topic", createPublishMessage("world"));
+  context.publish("test_topic", "world");
   expect(memory.memories).toEqual([
     {
       role: "user",

--- a/packages/core/test/agents/user-agent.test.ts
+++ b/packages/core/test/agents/user-agent.test.ts
@@ -1,5 +1,5 @@
 import { expect, mock, spyOn, test } from "bun:test";
-import { AIAgent, AIGNE, UserAgent, createMessage, createPublishMessage } from "@aigne/core";
+import { AIAgent, AIGNE, UserAgent, createMessage } from "@aigne/core";
 import { arrayToAgentProcessAsyncGenerator } from "@aigne/core/utils/stream-utils.js";
 
 test("UserAgent.stream", async () => {
@@ -12,7 +12,7 @@ test("UserAgent.stream", async () => {
   });
 
   const reader = userAgent.stream.getReader();
-  userAgent.publish("test_topic", createPublishMessage("hello", userAgent));
+  userAgent.publish("test_topic", "hello");
   expect(reader.read()).resolves.toEqual({
     value: {
       topic: "test_topic",
@@ -92,7 +92,7 @@ test("UserAgent pub/sub should work correctly", async () => {
   const listener = mock();
   userAgent.subscribe("test_sub", listener);
 
-  userAgent.publish("test_sub", createPublishMessage("hello"));
+  userAgent.publish("test_sub", "hello");
   expect(listener).toHaveBeenLastCalledWith(
     expect.objectContaining({
       message: createMessage("hello"),
@@ -100,6 +100,6 @@ test("UserAgent pub/sub should work correctly", async () => {
   );
 
   userAgent.unsubscribe("test_sub", listener);
-  userAgent.publish("test_sub", createPublishMessage("hello"));
+  userAgent.publish("test_sub", "hello");
   expect(listener).toHaveBeenCalledTimes(1);
 });

--- a/packages/core/test/aigne/aigne.test.ts
+++ b/packages/core/test/aigne/aigne.test.ts
@@ -7,7 +7,6 @@ import {
   UserInputTopic,
   UserOutputTopic,
   createMessage,
-  createPublishMessage,
 } from "@aigne/core";
 import { TeamAgent } from "@aigne/core/agents/team-agent.js";
 import { OpenAIChatModel } from "@aigne/core/models/openai-chat-model.js";
@@ -181,7 +180,7 @@ test("AIGNE example publish message", async () => {
 
   const subscription = aigne.subscribe("result_topic");
 
-  aigne.publish("test_topic", createPublishMessage("hello"));
+  aigne.publish("test_topic", "hello");
 
   const { message } = await subscription;
 
@@ -219,7 +218,7 @@ test("AIGNE example subscribe topic", async () => {
     unsubscribe();
   });
 
-  aigne.publish("test_topic", createPublishMessage("hello"));
+  aigne.publish("test_topic", "hello");
 
   // #endregion example-subscribe-topic
 });
@@ -243,7 +242,7 @@ test("AIGNE.invoke with reflection", async () => {
   });
 
   const aigne = new AIGNE({ agents: [plusOne, reviewer] });
-  aigne.publish(UserInputTopic, createPublishMessage({ num: 1 }));
+  aigne.publish(UserInputTopic, { num: 1 });
   const { message: result } = await aigne.subscribe(UserOutputTopic);
 
   expect(result).toEqual({ num: 11, approval: "approve" });
@@ -350,13 +349,13 @@ test("AIGNEContext should subscribe/unsubscribe correctly", async () => {
 
   aigne.subscribe("test_topic", listener);
 
-  aigne.publish("test_topic", createPublishMessage("hello"));
+  aigne.publish("test_topic", "hello");
   expect(listener).toBeCalledTimes(1);
   expect(listener).toHaveBeenCalledWith(
     expect.objectContaining({ message: createMessage("hello") }),
   );
 
   aigne.unsubscribe("test_topic", listener);
-  aigne.publish("test_topic", createPublishMessage("hello"));
+  aigne.publish("test_topic", "hello");
   expect(listener).toBeCalledTimes(1);
 });

--- a/packages/core/test/aigne/context.test.ts
+++ b/packages/core/test/aigne/context.test.ts
@@ -5,7 +5,6 @@ import {
   type ContextEventMap,
   type MessageQueueListener,
   createMessage,
-  createPublishMessage,
 } from "@aigne/core";
 import { arrayToAgentProcessAsyncGenerator } from "@aigne/core/utils/stream-utils.js";
 import type { Listener } from "@aigne/core/utils/typed-event-emtter";
@@ -17,14 +16,14 @@ test("AIGNEContext should subscribe/unsubscribe correctly", async () => {
 
   context.subscribe("test_topic", listener);
 
-  context.publish("test_topic", createPublishMessage("hello"));
+  context.publish("test_topic", "hello");
   expect(listener).toBeCalledTimes(1);
   expect(listener).toHaveBeenCalledWith(
     expect.objectContaining({ message: createMessage("hello") }),
   );
 
   context.unsubscribe("test_topic", listener);
-  context.publish("test_topic", createPublishMessage("hello"));
+  context.publish("test_topic", "hello");
   expect(listener).toBeCalledTimes(1);
 });
 

--- a/packages/test-utils/tsconfig.build.json
+++ b/packages/test-utils/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "rootDir": "./src",
     "outDir": "./lib",
     "noEmit": false,


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->
- fix #62 
- fix https://github.com/AIGNE-io/aigne-framework/issues/86

### Major Changes
1. fix(core): handle response for UserAgent automatically in pub/sub mode

### Checklist

- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

Release Notes:

- Refactor: Streamlined pub/sub messaging system for improved reliability and performance
- New Feature: Enhanced topic subscription handling with array-based operations
- New Feature: Added flexible message payload support (Message, MessagePayload, string)
- Refactor: Improved agent architecture with better memory management
- New Feature: Simplified workflow reflection examples for better developer experience
- Test: Expanded test coverage for core messaging and agent functionality

These changes improve system stability and developer experience while maintaining backward compatibility. Users will benefit from more flexible message handling and simplified agent interactions.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->