### PR TITLE
fix(core): response.headers.toJSON is not a function

### DIFF
--- a/packages/cli/src/tracer/terminal.ts
+++ b/packages/cli/src/tracer/terminal.ts
@@ -12,10 +12,7 @@ import {
   type Message,
 } from "@aigne/core";
 import { logger } from "@aigne/core/utils/logger.js";
-import {
-  mergeAgentResponseChunk,
-  readableStreamToAsyncIterator,
-} from "@aigne/core/utils/stream-utils.js";
+import { mergeAgentResponseChunk } from "@aigne/core/utils/stream-utils.js";
 import type { Listener } from "@aigne/core/utils/typed-event-emtter.js";
 import {
   type DefaultRenderer,
@@ -297,7 +294,7 @@ class AIGNEListr extends Listr {
 
     this.result = {};
 
-    for await (const value of readableStreamToAsyncIterator(stream)) {
+    for await (const value of stream) {
       mergeAgentResponseChunk(this.result, value);
     }
 

--- a/packages/core/src/agents/ai-agent.ts
+++ b/packages/core/src/agents/ai-agent.ts
@@ -11,7 +11,6 @@ import type {
 } from "../models/chat-model.js";
 import { MESSAGE_KEY, PromptBuilder } from "../prompt/prompt-builder.js";
 import { AgentMessageTemplate, ToolMessageTemplate } from "../prompt/template.js";
-import { readableStreamToAsyncIterator } from "../utils/stream-utils.js";
 import { checkArguments, isEmpty } from "../utils/type-utils.js";
 import {
   Agent,
@@ -323,7 +322,7 @@ export class AIAgent<I extends Message = Message, O extends Message = Message> e
         { streaming: true },
       );
 
-      for await (const value of readableStreamToAsyncIterator(stream)) {
+      for await (const value of stream) {
         if (value.delta.text?.text) {
           yield { delta: { text: { [outputKey]: value.delta.text.text } } };
         }
@@ -433,6 +432,6 @@ export class AIAgent<I extends Message = Message, O extends Message = Message> e
       { streaming: true },
     );
 
-    yield* readableStreamToAsyncIterator(stream);
+    yield* stream;
   }
 }

--- a/packages/core/src/agents/team-agent.ts
+++ b/packages/core/src/agents/team-agent.ts
@@ -1,5 +1,5 @@
 import type { Context } from "../aigne/context.js";
-import { mergeAgentResponseChunk, readableStreamToAsyncIterator } from "../utils/stream-utils.js";
+import { mergeAgentResponseChunk } from "../utils/stream-utils.js";
 import { type PromiseOrValue, isEmpty } from "../utils/type-utils.js";
 import {
   Agent,
@@ -149,7 +149,7 @@ export class TeamAgent<I extends Message, O extends Message> extends Agent<I, O>
         { returnActiveAgent: true, streaming: true },
       );
 
-      for await (const chunk of readableStreamToAsyncIterator(o)) {
+      for await (const chunk of o) {
         yield chunk;
         mergeAgentResponseChunk(output, chunk);
       }

--- a/packages/core/src/aigne/context.ts
+++ b/packages/core/src/aigne/context.ts
@@ -18,7 +18,6 @@ import {
   agentResponseStreamToObject,
   asyncGeneratorToReadableStream,
   onAgentResponseStreamEnd,
-  readableStreamToAsyncIterator,
 } from "../utils/stream-utils.js";
 import {
   type OmitPropertiesFromArrayFirstElement,
@@ -395,7 +394,7 @@ class AIGNEContextInternal {
       const result: Message = {};
 
       const stream = await activeAgent.invoke(input, context, { streaming: true });
-      for await (const value of readableStreamToAsyncIterator(stream)) {
+      for await (const value of stream) {
         if (value.delta.text) {
           yield { delta: { text: value.delta.text } as Message };
         }

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -4,7 +4,6 @@ import getRawBody from "raw-body";
 import { z } from "zod";
 import type { AIGNE } from "../aigne/aigne.js";
 import { AgentResponseStreamSSE } from "../utils/event-stream.js";
-import { readableStreamToAsyncIterator } from "../utils/stream-utils.js";
 import { checkArguments, isRecord, tryOrThrow } from "../utils/type-utils.js";
 import { ServerError } from "./error.js";
 
@@ -243,12 +242,12 @@ export class AIGNEServer {
    */
   async _writeResponse(response: Response, res: ServerResponse): Promise<void> {
     try {
-      res.writeHead(response.status, response.headers.toJSON());
+      res.writeHead(response.status, Object.fromEntries(response.headers.entries()));
       res.flushHeaders();
 
       if (!response.body) throw new Error("Response body is empty");
 
-      for await (const chunk of readableStreamToAsyncIterator(response.body)) {
+      for await (const chunk of response.body) {
         res.write(chunk);
 
         // Support for express with compression middleware

--- a/packages/core/src/utils/stream-utils.ts
+++ b/packages/core/src/utils/stream-utils.ts
@@ -46,7 +46,7 @@ export async function agentResponseStreamToObject<T extends Message>(
   const json: T = {} as T;
 
   if (stream instanceof ReadableStream) {
-    for await (const value of readableStreamToAsyncIterator(stream)) {
+    for await (const value of stream) {
       mergeAgentResponseChunk(json, value);
     }
   } else {
@@ -183,7 +183,7 @@ export async function readableStreamToArray<T>(
 ): Promise<(T | Error)[]> {
   const result: T[] = [];
   try {
-    for await (const value of readableStreamToAsyncIterator(stream)) {
+    for await (const value of stream) {
       result.push(value);
     }
   } catch (error) {
@@ -192,17 +192,6 @@ export async function readableStreamToArray<T>(
     result.push(error);
   }
   return result;
-}
-
-export async function* readableStreamToAsyncIterator<T>(
-  stream: ReadableStream<T>,
-): AsyncIterable<T> {
-  const reader = stream.getReader();
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    yield value;
-  }
 }
 
 export function stringToAgentResponseStream(

--- a/packages/core/test/agents/agent.test.ts
+++ b/packages/core/test/agents/agent.test.ts
@@ -12,10 +12,7 @@ import {
   textDelta,
 } from "@aigne/core";
 import { OpenAIChatModel } from "@aigne/core/models/openai-chat-model.js";
-import {
-  readableStreamToAsyncIterator,
-  stringToAgentResponseStream,
-} from "@aigne/core/utils/stream-utils.js";
+import { stringToAgentResponseStream } from "@aigne/core/utils/stream-utils.js";
 import { z } from "zod";
 
 test("Custom agent", async () => {
@@ -94,7 +91,7 @@ test("Agent returning a ReadableStream", async () => {
   const stream = await agent.invoke("Hello", undefined, { streaming: true });
 
   let fullText = "";
-  for await (const chunk of readableStreamToAsyncIterator(stream)) {
+  for await (const chunk of stream) {
     const text = chunk.delta.text?.text;
     if (text) fullText += text;
   }
@@ -130,7 +127,7 @@ test("Agent using AsyncGenerator", async () => {
   const message: string[] = [];
   let json: Message | undefined;
 
-  for await (const chunk of readableStreamToAsyncIterator(stream)) {
+  for await (const chunk of stream) {
     const text = chunk.delta.text?.message;
     if (text) message.push(text);
     if (chunk.delta.json) json = chunk.delta.json;
@@ -233,7 +230,7 @@ test("Agent.invoke with streaming response", async () => {
   const chunks: string[] = [];
 
   // Read the stream using an async iterator
-  for await (const chunk of readableStreamToAsyncIterator(stream)) {
+  for await (const chunk of stream) {
     const text = chunk.delta.text?.$message;
     if (text) {
       chunks.push(text);

--- a/packages/core/test/aigne/aigne.test.ts
+++ b/packages/core/test/aigne/aigne.test.ts
@@ -10,10 +10,7 @@ import {
 } from "@aigne/core";
 import { TeamAgent } from "@aigne/core/agents/team-agent.js";
 import { OpenAIChatModel } from "@aigne/core/models/openai-chat-model.js";
-import {
-  readableStreamToAsyncIterator,
-  stringToAgentResponseStream,
-} from "@aigne/core/utils/stream-utils.js";
+import { stringToAgentResponseStream } from "@aigne/core/utils/stream-utils.js";
 import { mockOpenAIStreaming } from "../_mocks/mock-openai-streaming.js";
 
 test("AIGNE simple example", async () => {
@@ -62,7 +59,7 @@ test("AIGNE example with streaming response", async () => {
   let text = "";
 
   const stream = await aigne.invoke(agent, "hello", { streaming: true });
-  for await (const chunk of readableStreamToAsyncIterator(stream)) {
+  for await (const chunk of stream) {
     if (chunk.delta.text?.$message) text += chunk.delta.text.$message;
   }
 

--- a/packages/core/test/client/client.test.ts
+++ b/packages/core/test/client/client.test.ts
@@ -7,7 +7,6 @@ import { AIGNEServer } from "@aigne/core/server/index.js";
 import {
   arrayToReadableStream,
   readableStreamToArray,
-  readableStreamToAsyncIterator,
   stringToAgentResponseStream,
 } from "@aigne/core/utils/stream-utils";
 import { serve } from "bun";
@@ -56,7 +55,7 @@ test("AIGNEClient example with streaming", async () => {
   const stream = await client.invoke("chat", { $message: "hello" }, { streaming: true });
 
   let text = "";
-  for await (const chunk of readableStreamToAsyncIterator(stream)) {
+  for await (const chunk of stream) {
     if (chunk.delta.text?.$message) text += chunk.delta.text.$message;
   }
 

--- a/packages/core/test/models/chat-model.test.ts
+++ b/packages/core/test/models/chat-model.test.ts
@@ -10,7 +10,6 @@ import {
   type ChatModelInput,
   type ChatModelOutput,
 } from "../../src/models/chat-model.js";
-import { readableStreamToAsyncIterator } from "../../src/utils/stream-utils.js";
 
 test("ChatModel implementation", async () => {
   // #region example-chat-model
@@ -81,7 +80,7 @@ test("ChatModel with streaming response", async () => {
 
   let fullText = "";
   const json: Partial<AgentProcessResult<ChatModelOutput>> = {};
-  for await (const chunk of readableStreamToAsyncIterator(stream)) {
+  for await (const chunk of stream) {
     const text = chunk.delta.text?.text;
     if (text) fullText += text;
     if (chunk.delta.json) Object.assign(json, chunk.delta.json);
@@ -121,7 +120,7 @@ test("ChatModel with streaming response with async generator", async () => {
 
   let fullText = "";
   const json: Partial<AgentProcessResult<ChatModelOutput>> = {};
-  for await (const chunk of readableStreamToAsyncIterator(stream)) {
+  for await (const chunk of stream) {
     const text = chunk.delta.text?.text;
     if (text) fullText += text;
     if (chunk.delta.json) Object.assign(json, chunk.delta.json);

--- a/packages/core/test/models/claude-chat-model.test.ts
+++ b/packages/core/test/models/claude-chat-model.test.ts
@@ -2,10 +2,7 @@ import { expect, spyOn, test } from "bun:test";
 import { join } from "node:path";
 import { textDelta } from "@aigne/core";
 import { ClaudeChatModel } from "@aigne/core/models/claude-chat-model.js";
-import {
-  readableStreamToArray,
-  readableStreamToAsyncIterator,
-} from "@aigne/core/utils/stream-utils.js";
+import { readableStreamToArray } from "@aigne/core/utils/stream-utils.js";
 import type Anthropic from "@anthropic-ai/sdk";
 import { createMockEventStream } from "../_utils/event-stream.js";
 import {
@@ -94,7 +91,7 @@ test("Claude chat model with streaming using async generator", async () => {
   let fullText = "";
   const json = {};
 
-  for await (const chunk of readableStreamToAsyncIterator(stream)) {
+  for await (const chunk of stream) {
     const text = chunk.delta.text?.text;
     if (text) fullText += text;
     if (chunk.delta.json) Object.assign(json, chunk.delta.json);

--- a/packages/core/test/models/deepseek-chat-model.test.ts
+++ b/packages/core/test/models/deepseek-chat-model.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, expect, spyOn, test } from "bun:test";
 import { join } from "node:path";
 import { textDelta } from "@aigne/core";
 import { DeepSeekChatModel } from "@aigne/core/models/deepseek-chat-model.js";
-import { readableStreamToAsyncIterator } from "@aigne/core/utils/stream-utils.js";
 import { createMockEventStream } from "../_utils/event-stream.js";
 import {
   COMMON_RESPONSE_FORMAT,
@@ -90,7 +89,7 @@ test("DeepSeek chat model with streaming using async generator", async () => {
   let fullText = "";
   const json = {};
 
-  for await (const chunk of readableStreamToAsyncIterator(stream)) {
+  for await (const chunk of stream) {
     const text = chunk.delta.text?.text;
     if (text) fullText += text;
     if (chunk.delta.json) Object.assign(json, chunk.delta.json);

--- a/packages/core/test/models/gemini-chat-model.test.ts
+++ b/packages/core/test/models/gemini-chat-model.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, expect, spyOn, test } from "bun:test";
 import { join } from "node:path";
 import { textDelta } from "@aigne/core";
 import { GeminiChatModel } from "@aigne/core/models/gemini-chat-model.js";
-import { readableStreamToAsyncIterator } from "@aigne/core/utils/stream-utils.js";
 import { createMockEventStream } from "../_utils/event-stream.js";
 import {
   COMMON_RESPONSE_FORMAT,
@@ -78,7 +77,7 @@ test("Gemini chat model with streaming using async generator", async () => {
   let fullText = "";
   const json = {};
 
-  for await (const chunk of readableStreamToAsyncIterator(stream)) {
+  for await (const chunk of stream) {
     const text = chunk.delta.text?.text;
     if (text) fullText += text;
     if (chunk.delta.json) Object.assign(json, chunk.delta.json);

--- a/packages/core/test/models/ollama-chat-model.test.ts
+++ b/packages/core/test/models/ollama-chat-model.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, expect, spyOn, test } from "bun:test";
 import { join } from "node:path";
 import { textDelta } from "@aigne/core";
 import { OllamaChatModel } from "@aigne/core/models/ollama-chat-model.js";
-import { readableStreamToAsyncIterator } from "@aigne/core/utils/stream-utils.js";
 import { createMockEventStream } from "../_utils/event-stream.js";
 import {
   COMMON_RESPONSE_FORMAT,
@@ -76,7 +75,7 @@ test("Ollama chat model with streaming using async generator", async () => {
   let fullText = "";
   const json = {};
 
-  for await (const chunk of readableStreamToAsyncIterator(stream)) {
+  for await (const chunk of stream) {
     const text = chunk.delta.text?.text;
     if (text) fullText += text;
     if (chunk.delta.json) Object.assign(json, chunk.delta.json);

--- a/packages/core/test/models/open-router-chat-model.test.ts
+++ b/packages/core/test/models/open-router-chat-model.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, expect, spyOn, test } from "bun:test";
 import { join } from "node:path";
 import { textDelta } from "@aigne/core";
 import { OpenRouterChatModel } from "@aigne/core/models/open-router-chat-model.js";
-import { readableStreamToAsyncIterator } from "@aigne/core/utils/stream-utils.js";
 import { createMockEventStream } from "../_utils/event-stream.js";
 import {
   COMMON_RESPONSE_FORMAT,
@@ -91,7 +90,7 @@ test("OpenRouter chat model with streaming using async generator", async () => {
   let fullText = "";
   const json = {};
 
-  for await (const chunk of readableStreamToAsyncIterator(stream)) {
+  for await (const chunk of stream) {
     const text = chunk.delta.text?.text;
     if (text) fullText += text;
     if (chunk.delta.json) Object.assign(json, chunk.delta.json);

--- a/packages/core/test/models/openai-chat-model.test.ts
+++ b/packages/core/test/models/openai-chat-model.test.ts
@@ -2,10 +2,7 @@ import { beforeEach, expect, spyOn, test } from "bun:test";
 import { join } from "node:path";
 import { textDelta } from "@aigne/core";
 import { OpenAIChatModel } from "@aigne/core/models/openai-chat-model.js";
-import {
-  readableStreamToArray,
-  readableStreamToAsyncIterator,
-} from "@aigne/core/utils/stream-utils.js";
+import { readableStreamToArray } from "@aigne/core/utils/stream-utils.js";
 import { createMockEventStream } from "../_utils/event-stream.js";
 import {
   COMMON_RESPONSE_FORMAT,
@@ -94,7 +91,7 @@ test("OpenAI chat model with streaming using async generator", async () => {
   let fullText = "";
   const json = {};
 
-  for await (const chunk of readableStreamToAsyncIterator(stream)) {
+  for await (const chunk of stream) {
     const text = chunk.delta.text?.text;
     if (text) fullText += text;
     if (chunk.delta.json) Object.assign(json, chunk.delta.json);

--- a/packages/core/test/models/xai-chat-model.test.ts
+++ b/packages/core/test/models/xai-chat-model.test.ts
@@ -2,7 +2,6 @@ import { expect, spyOn, test } from "bun:test";
 import { join } from "node:path";
 import { textDelta } from "@aigne/core";
 import { XAIChatModel } from "@aigne/core/models/xai-chat-model.js";
-import { readableStreamToAsyncIterator } from "@aigne/core/utils/stream-utils.js";
 import { createMockEventStream } from "../_utils/event-stream.js";
 import {
   COMMON_RESPONSE_FORMAT,
@@ -91,7 +90,7 @@ test("X.AI chat model with streaming using async generator", async () => {
   let fullText = "";
   const json = {};
 
-  for await (const chunk of readableStreamToAsyncIterator(stream)) {
+  for await (const chunk of stream) {
     const text = chunk.delta.text?.text;
     if (text) fullText += text;
     if (chunk.delta.json) Object.assign(json, chunk.delta.json);

--- a/packages/core/test/utils/stream-utils.test.ts
+++ b/packages/core/test/utils/stream-utils.test.ts
@@ -6,6 +6,7 @@ import {
   asyncGeneratorToReadableStream,
   mergeAgentResponseChunk,
   objectToAgentResponseStream,
+  onAgentResponseStreamEnd,
   readableStreamToArray,
   stringToAgentResponseStream,
 } from "@aigne/core/utils/stream-utils.js";
@@ -110,4 +111,20 @@ test("stringToAgentResponseStream should generate stream with Chinese correctly"
   expect(
     readableStreamToArray(stringToAgentResponseStream("你好，我能帮你什么？", "custom_text")),
   ).resolves.toMatchSnapshot();
+});
+
+test("onAgentResponseStreamEnd should continue reading until end", async () => {
+  const stream = onAgentResponseStreamEnd(
+    arrayToReadableStream([
+      { delta: { text: { text: "Hello " } } },
+      { delta: {} },
+      { delta: { text: { text: "world" } } },
+    ]),
+    () => {},
+  );
+
+  expect(await readableStreamToArray(stream)).toEqual([
+    { delta: { text: { text: "Hello " } } },
+    { delta: { text: { text: "world" } } },
+  ]);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     // Enable latest features
-    "lib": ["ESNext", "DOM"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
     "target": "ESNext",
     "module": "ESNext",
     "moduleDetection": "force",


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix: response.headers.toJSON is not a function
2. refactor: remove unnecessary stream utils

### Checklist

-

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

## Release Notes

### Refactor
- Modernized stream handling across the entire codebase by adopting native async iteration capabilities
- Improved performance and reliability of streaming responses in all chat models
- Simplified internal stream processing architecture

### Chore
- Updated TypeScript configuration to better support modern streaming features

This update streamlines the internal streaming implementation while maintaining full compatibility with existing APIs. Users should experience improved reliability and potentially better performance when working with streaming responses, though no API changes are required.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->