### PR TITLE
chore(docs-builder): remove variable statements(include spyOn) from example code

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "build:markdown": "remark README.md README.zh.md docs/cli*.md docs/cookbook*.md docs/agent-development*.md -o"
   },
   "devDependencies": {
-    "@aigne/typedoc-plugin-example-utils-ts": "^1.0.3",
     "@biomejs/biome": "^1.9.4",
     "@biomejs/js-api": "^0.7.1",
     "@biomejs/wasm-nodejs": "^1.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     devDependencies:
-      '@aigne/typedoc-plugin-example-utils-ts':
-        specifier: ^1.0.3
-        version: 1.0.3
       '@biomejs/biome':
         specifier: ^1.9.4
         version: 1.9.4
@@ -594,9 +591,6 @@ packages:
     engines: {node: '>=16.0.0'}
     peerDependencies:
       marked: '>=1 <16'
-
-  '@aigne/typedoc-plugin-example-utils-ts@1.0.3':
-    resolution: {integrity: sha512-r//jewUedSLQvuK4+geuVoBVNyTnl8UQbgq4jExYqE70qf/Nku/b5CgrzTs/6EJsSMyFp3VyIj+zTW3ZoVniDw==}
 
   '@anthropic-ai/sdk@0.41.0':
     resolution: {integrity: sha512-A4sfU0ss3BhhfMrm1RNl4YRt8B9CMIkheCRfow0vV3h0rYI9GBT/9lVsQPKGMwStnJSdowqUnVdSxLLrnutcHg==}
@@ -3578,18 +3572,6 @@ snapshots:
       marked: 15.0.11
       node-emoji: 2.2.0
       supports-hyperlinks: 3.2.0
-
-  '@aigne/typedoc-plugin-example-utils-ts@1.0.3':
-    dependencies:
-      '@biomejs/js-api': 0.7.1(@biomejs/wasm-nodejs@1.9.4)
-      '@biomejs/wasm-nodejs': 1.9.4
-      ts-morph: 25.0.1
-      typedoc: 0.28.4(typescript@5.8.3)
-      typescript: 5.8.3
-      zod: 3.24.4
-    transitivePeerDependencies:
-      - '@biomejs/wasm-bundler'
-      - '@biomejs/wasm-web'
 
   '@anthropic-ai/sdk@0.41.0(encoding@0.1.13)':
     dependencies:

--- a/scripts/remark-plugin-clean-code.ts
+++ b/scripts/remark-plugin-clean-code.ts
@@ -1,7 +1,6 @@
-import { Biome, Distribution } from "@biomejs/js-api";
 import type { Code, Root } from "mdast";
-import { Project, SyntaxKind } from "ts-morph";
 import { visit } from "unist-util-visit";
+import { extractTestCode, formatCode, removeFunctionCallsFromCode } from "./ts-utils.ts";
 
 const removeExpressions = ["assert", "spyOn", "expect", "mock"];
 
@@ -15,80 +14,11 @@ export default function cleanCode() {
 
     for (const code of codes) {
       if (code.lang && ["ts", "tsx", "js", "jsx", "typescript", "javascript"].includes(code.lang)) {
-        const processedCode = (
-          await formatCode(
-            removeFunctionCallsFromCode(extractTestCode(code.value), removeExpressions),
-          )
+        const processedCode = formatCode(
+          removeFunctionCallsFromCode(extractTestCode(code.value), removeExpressions),
         ).trim();
         code.value = processedCode;
       }
     }
   };
-}
-
-function extractTestCode(code: string): string {
-  const project = new Project();
-  const sourceFile = project.createSourceFile("temp.ts", code, { overwrite: true });
-
-  const testCalls = sourceFile
-    .getDescendantsOfKind(SyntaxKind.CallExpression)
-    .filter((expr) => expr.getExpression().getText() === "test");
-
-  for (const testCall of testCalls) {
-    const body = testCall.getArguments()[1]?.asKind(SyntaxKind.ArrowFunction)?.getBody();
-
-    if (body?.isKind(SyntaxKind.Block)) {
-      const code = body.getText().trim().slice(1, -1).trim();
-      testCall.getFirstAncestorByKind(SyntaxKind.ExpressionStatement)?.replaceWithText(code);
-    }
-  }
-
-  return sourceFile.getText();
-}
-
-function removeFunctionCallsFromCode(sourceCode: string, functionName: string[]): string {
-  const project = new Project();
-  const sourceFile = project.createSourceFile("temp.ts", sourceCode, { overwrite: true });
-
-  for (const e of sourceFile
-    .getDescendantsOfKind(SyntaxKind.CallExpression)
-    .filter((i) => functionName.includes(i.getExpression().getText()))) {
-    e.getFirstAncestorByKind(SyntaxKind.ExpressionStatement)?.replaceWithText("");
-  }
-
-  return sourceFile.getText();
-}
-
-const biome = await Biome.create({
-  distribution: Distribution.NODE,
-});
-
-biome.applyConfiguration({
-  formatter: {
-    enabled: true,
-    indentStyle: "space",
-    indentWidth: 2,
-  },
-  organizeImports: {
-    enabled: true,
-  },
-  linter: {
-    enabled: true,
-    rules: {
-      recommended: true,
-      correctness: {
-        noUnusedVariables: "error",
-        noUnusedImports: "error",
-        noUnusedFunctionParameters: "error",
-        noUnusedPrivateClassMembers: "error",
-      },
-    },
-  },
-});
-
-async function formatCode(code: string): Promise<string> {
-  return biome.formatContent(
-    biome.lintContent(code, { fixFileMode: "SafeFixes", filePath: "test.ts" }).content,
-    { filePath: "test.ts" },
-  ).content;
 }

--- a/scripts/ts-utils.ts
+++ b/scripts/ts-utils.ts
@@ -1,0 +1,74 @@
+import { Biome, Distribution } from "@biomejs/js-api";
+import { Project, SyntaxKind } from "ts-morph";
+
+export function removeFunctionCallsFromCode(sourceCode: string, functionName: string[]): string {
+  const project = new Project();
+  const sourceFile = project.createSourceFile("temp.ts", sourceCode, { overwrite: true });
+
+  for (const e of sourceFile
+    .getDescendantsOfKind(SyntaxKind.CallExpression)
+    .filter((i) => functionName.includes(i.getExpression().getText()))) {
+    (
+      e.getFirstAncestorByKind(SyntaxKind.VariableStatement) ??
+      e.getFirstAncestorByKind(SyntaxKind.ExpressionStatement)
+    )?.replaceWithText("");
+  }
+
+  return sourceFile.getText();
+}
+
+const biome = await Biome.create({
+  distribution: Distribution.NODE,
+}).then((biome) => {
+  biome.applyConfiguration({
+    formatter: {
+      enabled: true,
+      indentStyle: "space",
+      indentWidth: 2,
+    },
+    organizeImports: {
+      enabled: true,
+    },
+    linter: {
+      enabled: true,
+      rules: {
+        recommended: true,
+        correctness: {
+          noUnusedVariables: "error",
+          noUnusedImports: "error",
+          noUnusedFunctionParameters: "error",
+          noUnusedPrivateClassMembers: "error",
+        },
+      },
+    },
+  });
+
+  return biome;
+});
+
+export function formatCode(code: string): string {
+  return biome.formatContent(
+    biome.lintContent(code, { fixFileMode: "SafeFixes", filePath: "test.ts" }).content,
+    { filePath: "test.ts" },
+  ).content;
+}
+
+export function extractTestCode(code: string): string {
+  const project = new Project();
+  const sourceFile = project.createSourceFile("temp.ts", code, { overwrite: true });
+
+  const testCalls = sourceFile
+    .getDescendantsOfKind(SyntaxKind.CallExpression)
+    .filter((expr) => expr.getExpression().getText() === "test");
+
+  for (const testCall of testCalls) {
+    const body = testCall.getArguments()[1]?.asKind(SyntaxKind.ArrowFunction)?.getBody();
+
+    if (body?.isKind(SyntaxKind.Block)) {
+      const code = body.getText().trim().slice(1, -1).trim();
+      testCall.getFirstAncestorByKind(SyntaxKind.ExpressionStatement)?.replaceWithText(code);
+    }
+  }
+
+  return sourceFile.getText();
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true
+  },
+  "include": ["."]
+}

--- a/scripts/typedoc-plugin-clean-code.ts
+++ b/scripts/typedoc-plugin-clean-code.ts
@@ -1,0 +1,38 @@
+import { type Application, type Context, ParameterType, type Reflection } from "typedoc";
+import { z } from "zod";
+import { formatCode, removeFunctionCallsFromCode } from "./ts-utils.ts";
+
+export function load(app: Application) {
+  app.options.addDeclaration({
+    name: "removeExpressionsFromExamples",
+    type: ParameterType.Array,
+    help: 'Expression to remove from examples. Example: ["spyOn", "expect"]',
+  });
+
+  // @ts-ignore
+  app.converter.on("resolveReflection", (_: Context, reflection: Reflection) => {
+    const expressions = z
+      .array(z.string())
+      .nullish()
+      .parse(app.options.getValue("removeExpressionsFromExamples"));
+    if (!expressions) return;
+
+    if (!reflection.comment) return;
+
+    const exampleTags = reflection.comment.getTags("@example");
+
+    for (const tag of exampleTags) {
+      for (const content of tag.content) {
+        if (content.kind === "code") {
+          const code = content.text
+            .trim()
+            .replace(/^\s*```\S+/, "")
+            .replace(/```$/, "");
+
+          const c = formatCode(removeFunctionCallsFromCode(code, expressions));
+          content.text = `\`\`\`ts\n${c}\n\`\`\``;
+        }
+      }
+    }
+  });
+}

--- a/typedoc.base.js
+++ b/typedoc.base.js
@@ -5,7 +5,7 @@ const config = {
   plugin: [
     "typedoc-plugin-no-inherit",
     "typedoc-plugin-markdown",
-    "@aigne/typedoc-plugin-example-utils-ts",
+    "./scripts/typedoc-plugin-clean-code.ts",
     "./scripts/typedoc-plugin-sidebar.ts",
   ],
   entryPointStrategy: "expand",


### PR DESCRIPTION

## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. chore(docs-builder): remove variable statements(include spyOn) from e…

### Checklist

- none
<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

🔄 Release Notes:

- Refactor: Improved documentation tooling with a new local TypeDoc plugin for cleaner code examples
- Chore: Replaced external `@aigne/typedoc-plugin-example-utils-ts` package with in-house solution
- Refactor: Enhanced code processing utilities with better modularity and organization
- Chore: Updated TypeScript configuration to support explicit file extensions

These changes primarily improve the development infrastructure and documentation generation process. End users will benefit from cleaner, more consistent code examples in the documentation, though most changes are internal improvements to maintain code quality and reduce external dependencies.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->