### PR TITLE
fix: automatically convert tool names to a valid format

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -101,7 +101,6 @@
     "compression": "^1.8.0",
     "detect-port": "^2.1.0",
     "express": "^5.1.0",
-    "hono": "^4.7.8",
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.3"

--- a/packages/core/src/agents/agent.ts
+++ b/packages/core/src/agents/agent.ts
@@ -512,7 +512,7 @@ export abstract class Agent<I extends Message = Message, O extends Message = Mes
 
       const parsedInput = checkArguments(`Agent ${this.name} input`, this.inputSchema, message);
 
-      this.preprocess(parsedInput, ctx);
+      await this.preprocess(parsedInput, ctx);
 
       this.checkContextStatus(ctx);
 
@@ -603,7 +603,7 @@ export abstract class Agent<I extends Message = Message, O extends Message = Mes
 
     const finalOutput = this.includeInputInOutput ? { ...input, ...parsedOutput } : parsedOutput;
 
-    this.postprocess(input, finalOutput, context);
+    await this.postprocess(input, finalOutput, context);
 
     logger.debug("Invoke agent %s succeed with output: %O", this.name, finalOutput);
     if (!this.disableEvents) context.emit("agentSucceed", { agent: this, output: finalOutput });
@@ -658,7 +658,7 @@ export abstract class Agent<I extends Message = Message, O extends Message = Mes
    * @param _ Input message (unused)
    * @param context Execution context
    */
-  protected preprocess(_: I, context: Context) {
+  protected preprocess(_: I, context: Context): PromiseOrValue<void> {
     this.checkContextStatus(context);
     this.checkAgentInvokesUsage(context);
   }
@@ -731,7 +731,7 @@ export abstract class Agent<I extends Message = Message, O extends Message = Mes
    * @param output Output message
    * @param context Execution context
    */
-  protected postprocess(input: I, output: O, context: Context) {
+  protected postprocess(input: I, output: O, context: Context): PromiseOrValue<void> {
     this.checkContextStatus(context);
 
     this.publishToTopics(output, context);

--- a/packages/core/src/agents/chat-model.ts
+++ b/packages/core/src/agents/chat-model.ts
@@ -66,6 +66,20 @@ export abstract class ChatModel extends Agent<ChatModelInput, ChatModelOutput> {
   }
 
   /**
+   * Normalizes tool names to ensure compatibility with language models
+   *
+   * This method converts tool names to a format that complies with model requirements
+   * by replacing hyphens and whitespace characters with underscores. The normalized
+   * names are used for tool calls while preserving the original names for reference.
+   *
+   * @param name - The original tool name to normalize
+   * @returns A promise that resolves to the normalized tool name
+   */
+  protected async normalizeToolName(name: string): Promise<string> {
+    return name.replaceAll(/[-\s]/g, "_");
+  }
+
+  /**
    * Performs preprocessing operations before handling input
    *
    * Primarily checks if token usage exceeds limits, throwing an exception if limits are exceeded
@@ -74,7 +88,7 @@ export abstract class ChatModel extends Agent<ChatModelInput, ChatModelOutput> {
    * @param context Execution context
    * @throws Error if token usage exceeds maximum limit
    */
-  protected override preprocess(input: ChatModelInput, context: Context): void {
+  protected override async preprocess(input: ChatModelInput, context: Context): Promise<void> {
     super.preprocess(input, context);
     const { limits, usage } = context;
     const usedTokens = usage.outputTokens + usage.inputTokens;
@@ -88,7 +102,7 @@ export abstract class ChatModel extends Agent<ChatModelInput, ChatModelOutput> {
       const tools: ChatModelInputTool[] = [];
 
       for (const originalTool of input.tools) {
-        const name = originalTool.function.name.replaceAll(/[-\s]/g, "_");
+        const name = await this.normalizeToolName(originalTool.function.name);
 
         const tool: ChatModelInputTool = {
           ...originalTool,

--- a/packages/core/src/agents/chat-model.ts
+++ b/packages/core/src/agents/chat-model.ts
@@ -88,7 +88,7 @@ export abstract class ChatModel extends Agent<ChatModelInput, ChatModelOutput> {
       const tools: ChatModelInputTool[] = [];
 
       for (const originalTool of input.tools) {
-        const name = originalTool.function.name.replaceAll(/[-|\s]/g, "_");
+        const name = originalTool.function.name.replaceAll(/[-\s]/g, "_");
 
         const tool: ChatModelInputTool = {
           ...originalTool,

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -34,8 +34,7 @@
   "typesVersions": {
     "*": {
       "*": [
-        "./lib/dts/*/index.d.ts",
-        "./lib/dts/*.d.ts"
+        "./lib/dts/*"
       ]
     }
   },
@@ -55,7 +54,12 @@
     "@aigne/core": "workspace:^",
     "@aigne/test-utils": "workspace:^",
     "@types/bun": "^1.2.12",
+    "@types/express": "^5.0.1",
     "@types/node": "^22.15.15",
+    "compression": "^1.8.0",
+    "detect-port": "^2.1.0",
+    "express": "^5.1.0",
+    "hono": "^4.7.10",
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.3"

--- a/packages/transport/src/http-client/client.ts
+++ b/packages/transport/src/http-client/client.ts
@@ -70,7 +70,7 @@ export class AIGNEHTTPClient {
    */
   async invoke<I extends Message, O extends Message>(
     agent: string,
-    input: I,
+    input: string | I,
     options?: AIGNEHTTPClientInvokeOptions & { streaming?: false },
   ): Promise<O>;
 
@@ -88,7 +88,7 @@ export class AIGNEHTTPClient {
    */
   async invoke<I extends Message, O extends Message>(
     agent: string,
-    input: I,
+    input: string | I,
     options: AIGNEHTTPClientInvokeOptions & { streaming: true },
   ): Promise<AgentResponseStream<O>>;
 
@@ -102,12 +102,12 @@ export class AIGNEHTTPClient {
    */
   async invoke<I extends Message, O extends Message>(
     agent: string,
-    input: I,
+    input: string | I,
     options?: AIGNEHTTPClientInvokeOptions,
   ): Promise<AgentResponse<O>>;
   async invoke<I extends Message, O extends Message>(
     agent: string,
-    input: I,
+    input: string | I,
     options?: AIGNEHTTPClientInvokeOptions,
   ): Promise<AgentResponse<O>> {
     // Send the agent invocation request to the AIGNE server

--- a/packages/transport/src/http-server/server.ts
+++ b/packages/transport/src/http-server/server.ts
@@ -23,7 +23,7 @@ const DEFAULT_MAXIMUM_BODY_SIZE = "4mb";
  */
 export const invokePayloadSchema = z.object({
   agent: z.string(),
-  input: z.record(z.string(), z.unknown()),
+  input: z.union([z.string(), z.record(z.string(), z.unknown())]),
   options: z
     .object({
       streaming: z.boolean().nullish(),

--- a/packages/transport/test/http-client/http-client.test.ts
+++ b/packages/transport/test/http-client/http-client.test.ts
@@ -206,7 +206,7 @@ test.each(table)(
       const response = client.invoke("chat", [] as unknown as Message, options);
 
       expect(response).rejects.toThrow(
-        "status 400: Invoke agent chat check arguments error: input: Expected object, received array",
+        "status 400: Invoke agent chat check arguments error: input: Expected string or object, received array",
       );
     } finally {
       await close();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,9 +630,6 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.1.0
-      hono:
-        specifier: ^4.7.8
-        version: 4.7.8
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -820,9 +817,24 @@ importers:
       '@types/bun':
         specifier: ^1.2.12
         version: 1.2.12
+      '@types/express':
+        specifier: ^5.0.1
+        version: 5.0.1
       '@types/node':
         specifier: ^22.15.15
         version: 22.15.15
+      compression:
+        specifier: ^1.8.0
+        version: 1.8.0
+      detect-port:
+        specifier: ^2.1.0
+        version: 2.1.0
+      express:
+        specifier: ^5.1.0
+        version: 5.1.0
+      hono:
+        specifier: ^4.7.10
+        version: 4.7.10
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -2275,8 +2287,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.7.8:
-    resolution: {integrity: sha512-PCibtFdxa7/Ldud9yddl1G81GjYaeMYYTq4ywSaNsYbB1Lug4mwtOMJf2WXykL0pntYwmpRJeOI3NmoDgD+Jxw==}
+  hono@4.7.10:
+    resolution: {integrity: sha512-QkACju9MiN59CKSY5JsGZCYmPZkA6sIW6OFCUp7qDjZu6S6KHtJHhAc9Uy9mV9F8PJ1/HQ3ybZF2yjCa/73fvQ==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@2.8.9:
@@ -5718,7 +5730,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.7.8: {}
+  hono@4.7.10: {}
 
   hosted-git-info@2.8.9: {}
 


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix: automatically convert tool names to a valid format

### Checklist

- [x] The newly added code logic is also covered by tests

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

Release Notes:

- New Feature: Added automatic tool name sanitization to ensure compatibility with function calling APIs, converting hyphens and spaces to underscores while preserving original names in responses
- Enhancement: Extended transport layer to support both string and structured message inputs, providing more flexibility in how users can format their requests
- Test: Added comprehensive test coverage for tool name conversion functionality

Impact: Users can now use tools with any naming convention without worrying about API compatibility, and have more options for formatting their input messages when making requests.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->