### PR TITLE
fix(core): exclude nested skills from final tool list in invokable skill

### DIFF
--- a/packages/core/src/prompt/prompt-builder.ts
+++ b/packages/core/src/prompt/prompt-builder.ts
@@ -208,8 +208,7 @@ export class PromptBuilder {
       (options.context?.skills ?? [])
         .concat(options.agent?.skills ?? [])
         .concat(options.agent?.memoryAgentsAsTools ? options.agent.memories : [])
-        // TODO: support nested tools?
-        .flatMap((i) => (i.isInvokable ? i.skills.concat(i) : i.skills)),
+        .flatMap((i) => (i.isInvokable ? i : i.skills)),
       (i) => i.name,
     );
 


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(core): exclude nested skills from final tool list in invokable skill


### Checklist

- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

**Bug Fix**: Improved skill collection handling in prompt generation
- Fixed how nested skills are processed when building agent prompts
- Invokable skills now correctly exclude their nested skills from the tool list
- Ensures more accurate and relevant tool availability for agents

This change provides more precise control over which skills are available to agents during execution, preventing potential confusion or unintended access to nested capabilities. Users will experience more predictable agent behavior, particularly when working with complex skill hierarchies.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->