### PR TITLE
fix: use `inputKey` instead of implicit $message for AIAgent

### DIFF
--- a/docs-examples/test/build-first-agent.test.ts
+++ b/docs-examples/test/build-first-agent.test.ts
@@ -29,6 +29,7 @@ test("Build first agent: basic", async () => {
   // #region example-build-first-agent-create-agent
   const agent = AIAgent.from({
     instructions: "You are a helpful assistant for Crypto market cap",
+    inputKey: "message",
   });
   // #endregion example-build-first-agent-create-agent
 
@@ -37,13 +38,13 @@ test("Build first agent: basic", async () => {
   });
 
   // #region example-build-first-agent-invoke-agent
-  const result = await aigne.invoke(agent, "What is crypto?");
+  const result = await aigne.invoke(agent, { message: "What is crypto?" });
   console.log(result);
-  // Output: { $message: "Cryptocurrency, often referred to as crypto, is a type of digital or virtual currency that uses cryptography for security" }
+  // Output: { message: "Cryptocurrency, often referred to as crypto, is a type of digital or virtual currency that uses cryptography for security" }
   // #endregion example-build-first-agent-invoke-agent
 
   expect(result).toEqual({
-    $message:
+    message:
       "Cryptocurrency, often referred to as crypto, is a type of digital or virtual currency that uses cryptography for security",
   });
 
@@ -139,6 +140,7 @@ test("Build first agent: add skills to agent", async () => {
   const agent = AIAgent.from({
     instructions: "You are a helpful assistant for Crypto market cap",
     skills: [ccxt],
+    inputKey: "message",
   });
   // #endregion example-add-skills-to-agent-add-skills
 
@@ -147,10 +149,12 @@ test("Build first agent: add skills to agent", async () => {
   });
 
   // #region example-add-skills-to-agent-invoke-agent
-  const result = await aigne.invoke(agent, "What is the crypto price of ABT/USD on coinbase?");
+  const result = await aigne.invoke(agent, {
+    message: "What is the crypto price of ABT/USD on coinbase?",
+  });
   console.log(result);
-  // Output: { $message:"The current price of ABT/USD on Coinbase is $0.9684." }
-  expect(result).toEqual({ $message: "The current price of ABT/USD on Coinbase is $0.9684." });
+  // Output: { message:"The current price of ABT/USD on Coinbase is $0.9684." }
+  expect(result).toEqual({ message: "The current price of ABT/USD on Coinbase is $0.9684." });
   // #endregion example-add-skills-to-agent-invoke-agent
 
   // #endregion example-add-skills-to-agent
@@ -176,6 +180,7 @@ test("Build first agent: enable memory for agent", async () => {
         url: `file:${memoryStoragePath}`, // Path to store memory data, such as 'file:./memory.db'
       },
     }),
+    inputKey: "message",
   });
   // #endregion example-enable-memory-for-agent-enable-memory
 
@@ -194,37 +199,39 @@ test("Build first agent: enable memory for agent", async () => {
     });
 
   // #region example-enable-memory-for-agent-invoke-agent-1
-  const result1 = await aigne.invoke(agent, "My name is John Doe and I like to invest in Bitcoin.");
+  const result1 = await aigne.invoke(agent, {
+    message: "My name is John Doe and I like to invest in Bitcoin.",
+  });
   console.log(result1);
-  // Output: { $message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
+  // Output: { message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
   expect(result1).toEqual({
-    $message:
+    message:
       "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?",
   });
   // #endregion example-enable-memory-for-agent-invoke-agent-1
 
   // #region example-enable-memory-for-agent-invoke-agent-2
-  const result2 = await aigne.invoke(agent, "What is my favorite cryptocurrency?");
+  const result2 = await aigne.invoke(agent, { message: "What is my favorite cryptocurrency?" });
   console.log(result2);
-  // Output: { $message: "Your favorite cryptocurrency is Bitcoin." }
-  expect(result2).toEqual({ $message: "Your favorite cryptocurrency is Bitcoin." });
+  // Output: { message: "Your favorite cryptocurrency is Bitcoin." }
+  expect(result2).toEqual({ message: "Your favorite cryptocurrency is Bitcoin." });
   // #endregion example-enable-memory-for-agent-invoke-agent-2
 
   // #region example-enable-memory-for-agent-invoke-agent-3
-  const result3 = await aigne.invoke(agent, "I've invested $5000 in Ethereum.");
+  const result3 = await aigne.invoke(agent, { message: "I've invested $5000 in Ethereum." });
   console.log(result3);
-  // Output: { $message: "Got it, you've invested $5000 in Ethereum! That's a good investment. If there's anything else you'd like to share about your crypto portfolio or have questions, feel free!" }
+  // Output: { message: "Got it, you've invested $5000 in Ethereum! That's a good investment. If there's anything else you'd like to share about your crypto portfolio or have questions, feel free!" }
   expect(result3).toEqual({
-    $message:
+    message:
       "Got it, you've invested $5000 in Ethereum! That's a good investment. If there's anything else you'd like to share about your crypto portfolio or have questions, feel free!",
   });
   // #endregion example-enable-memory-for-agent-invoke-agent-3
 
   // #region example-enable-memory-for-agent-invoke-agent-4
-  const result4 = await aigne.invoke(agent, "How much have I invested in Ethereum?");
+  const result4 = await aigne.invoke(agent, { message: "How much have I invested in Ethereum?" });
   console.log(result4);
-  // Output: { $message: "You've invested $5000 in Ethereum." }
-  expect(result4).toEqual({ $message: "You've invested $5000 in Ethereum." });
+  // Output: { message: "You've invested $5000 in Ethereum." }
+  expect(result4).toEqual({ message: "You've invested $5000 in Ethereum." });
   // #endregion example-enable-memory-for-agent-invoke-agent-4
 
   // #endregion example-enable-memory-for-agent
@@ -253,6 +260,7 @@ test("Build first agent: custom user context", async () => {
         getSessionId: ({ userContext }) => userContext.userId as string, // Use userId from userContext as session ID
       },
     }),
+    inputKey: "message",
   });
   // #endregion example-custom-user-context-create-agent
 
@@ -260,13 +268,17 @@ test("Build first agent: custom user context", async () => {
   spyOn(aigne.model, "process").mockReturnValueOnce({
     text: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?",
   });
-  const result = await aigne.invoke(agent, "My name is John Doe and I like to invest in Bitcoin.", {
-    userContext: { userId: "user_123" },
-  });
+  const result = await aigne.invoke(
+    agent,
+    { message: "My name is John Doe and I like to invest in Bitcoin." },
+    {
+      userContext: { userId: "user_123" },
+    },
+  );
   console.log(result);
-  // Output: { $message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
+  // Output: { message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
   expect(result).toEqual({
-    $message:
+    message:
       "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?",
   });
   // #endregion example-custom-user-context-invoke-agent
@@ -293,6 +305,7 @@ test("Build first agent: serve agent as API service", async () => {
         getSessionId: ({ userContext }) => userContext.userId as string, // Use userId from userContext as session ID
       },
     }),
+    inputKey: "message",
   });
   // #endregion example-serve-agent-as-api-service-create-named-agent
 
@@ -334,10 +347,12 @@ test("Build first agent: serve agent as API service", async () => {
 
   // #region example-aigne-http-client-invoke-agent
   const chatbot = await client.getAgent({ name: "chatbot" });
-  const result = await chatbot.invoke("What is the crypto price of ABT/USD on coinbase?");
+  const result = await chatbot.invoke({
+    message: "What is the crypto price of ABT/USD on coinbase?",
+  });
   console.log(result);
-  // Output: { $message: "The current price of ABT/USD on Coinbase is $0.9684." }
-  expect(result).toEqual({ $message: "The current price of ABT/USD on Coinbase is $0.9684." });
+  // Output: { message: "The current price of ABT/USD on Coinbase is $0.9684." }
+  expect(result).toEqual({ message: "The current price of ABT/USD on Coinbase is $0.9684." });
   // #endregion example-aigne-http-client-invoke-agent
 
   // #endregion example-aigne-http-client-usage
@@ -355,6 +370,7 @@ test("Build first agent: setup memory for client agent", async () => {
   const agent = AIAgent.from({
     name: "chatbot",
     instructions: "You are a helpful assistant",
+    inputKey: "message",
   });
 
   const aigne = new AIGNE({
@@ -403,21 +419,23 @@ test("Build first agent: setup memory for client agent", async () => {
       },
     }),
   });
-  const result = await chatbot.invoke("What is the crypto price of ABT/USD on coinbase?");
+  const result = await chatbot.invoke({
+    message: "What is the crypto price of ABT/USD on coinbase?",
+  });
   console.log(result);
-  // Output: { $message: "The current price of ABT/USD on Coinbase is $0.9684." }
-  expect(result).toEqual({ $message: "The current price of ABT/USD on Coinbase is $0.9684." });
+  // Output: { message: "The current price of ABT/USD on Coinbase is $0.9684." }
+  expect(result).toEqual({ message: "The current price of ABT/USD on Coinbase is $0.9684." });
   // #endregion example-client-agent-memory-invoke-agent
 
   // #region example-client-agent-memory-invoke-agent-1
   const modelProcess = spyOn(aigne.model, "process").mockReturnValueOnce({
     text: "You just asked about the crypto price of ABT/USD on Coinbase.",
   });
-  const result1 = await chatbot.invoke("What question did I just ask?");
+  const result1 = await chatbot.invoke({ message: "What question did I just ask?" });
   console.log(result1);
-  // Output: { $message: "You just asked about the crypto price of ABT/USD on Coinbase." }
+  // Output: { message: "You just asked about the crypto price of ABT/USD on Coinbase." }
   expect(result1).toEqual({
-    $message: "You just asked about the crypto price of ABT/USD on Coinbase.",
+    message: "You just asked about the crypto price of ABT/USD on Coinbase.",
   });
   expect(modelProcess).toHaveBeenLastCalledWith(
     expect.objectContaining({

--- a/docs-examples/test/concepts/agent.test.ts
+++ b/docs-examples/test/concepts/agent.test.ts
@@ -133,6 +133,7 @@ test("Example Agent: guide rails", async () => {
   const agent = AIAgent.from({
     instructions: "You are a helpful assistant that provides financial advice.",
     guideRails: [financial],
+    inputKey: "message",
   });
   // #endregion example-agent-guide-rails-create-agent
 
@@ -149,15 +150,17 @@ test("Example Agent: guide rails", async () => {
       },
     });
 
-  const result = await aigne.invoke(agent, "What will be the price of Bitcoin next month?");
+  const result = await aigne.invoke(agent, {
+    message: "What will be the price of Bitcoin next month?",
+  });
   console.log(result);
   // Output:
   // {
-  //   "$message": "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading."
+  //   "message": "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading."
   // }
   expect(result).toEqual(
     expect.objectContaining({
-      $message:
+      message:
         "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading.",
     }),
   );
@@ -178,6 +181,7 @@ test("Example Agent: enable memory for agent", async () => {
   const agent = AIAgent.from({
     instructions: "You are a helpful assistant for Crypto market analysis",
     memory: new DefaultMemory(),
+    inputKey: "message",
   });
   // #endregion example-agent-enable-memory-for-agent
 
@@ -186,10 +190,10 @@ test("Example Agent: enable memory for agent", async () => {
   });
 
   // #region example-agent-enable-memory-invoke-1
-  const result2 = await aigne.invoke(agent, "What is my favorite cryptocurrency?");
+  const result2 = await aigne.invoke(agent, { message: "What is my favorite cryptocurrency?" });
   console.log(result2);
-  // Output: { $message: "Your favorite cryptocurrency is Bitcoin." }
-  expect(result2).toEqual({ $message: "Your favorite cryptocurrency is Bitcoin." });
+  // Output: { message: "Your favorite cryptocurrency is Bitcoin." }
+  expect(result2).toEqual({ message: "Your favorite cryptocurrency is Bitcoin." });
   // #endregion example-agent-enable-memory-invoke-1
 
   // #endregion example-agent-enable-memory
@@ -224,15 +228,16 @@ test("Example Agent: skills", async () => {
   const agent = AIAgent.from({
     instructions: "You are a helpful assistant for Crypto market analysis",
     skills: [getCryptoPrice],
+    inputKey: "message",
   });
   // #endregion example-agent-add-skills
 
   spyOn(aigne.model, "process").mockReturnValueOnce({ text: "ABT is currently priced at $1000." });
 
-  const result = await aigne.invoke(agent, "What is the price of ABT?");
+  const result = await aigne.invoke(agent, { message: "What is the price of ABT?" });
   console.log(result);
-  // Output: { $message: "ABT is currently priced at $1000." }
-  expect(result).toEqual({ $message: "ABT is currently priced at $1000." });
+  // Output: { message: "ABT is currently priced at $1000." }
+  expect(result).toEqual({ message: "ABT is currently priced at $1000." });
 
   // #endregion example-agent-skills
 });
@@ -241,6 +246,7 @@ test("Example Agent: invoke", async () => {
   const agent = AIAgent.from({
     model: new OpenAIChatModel(),
     instructions: "You are a helpful assistant for Crypto market analysis",
+    inputKey: "message",
   });
   assert(agent.model);
 
@@ -249,10 +255,10 @@ test("Example Agent: invoke", async () => {
     text: "ABT is currently priced at $1000.",
   });
 
-  const result = await agent.invoke("What is the price of ABT?");
+  const result = await agent.invoke({ message: "What is the price of ABT?" });
   console.log(result);
-  // Output: { $message: "ABT is currently priced at $1000." }
-  expect(result).toEqual({ $message: "ABT is currently priced at $1000." });
+  // Output: { message: "ABT is currently priced at $1000." }
+  expect(result).toEqual({ message: "ABT is currently priced at $1000." });
   // #endregion example-agent-invoke
 
   // #region example-agent-invoke-stream
@@ -260,11 +266,11 @@ test("Example Agent: invoke", async () => {
     stringToAgentResponseStream("ABT is currently priced at $1000."),
   );
 
-  const stream = await agent.invoke("What is the price of ABT?", { streaming: true });
+  const stream = await agent.invoke({ message: "What is the price of ABT?" }, { streaming: true });
   let response = "";
   for await (const chunk of stream) {
-    if (isAgentResponseDelta(chunk) && chunk.delta.text?.$message)
-      response += chunk.delta.text.$message;
+    if (isAgentResponseDelta(chunk) && chunk.delta.text?.message)
+      response += chunk.delta.text.message;
   }
   console.log(response);
   // Output:  "ABT is currently priced at $1000."
@@ -282,17 +288,17 @@ test("Example Agent: custom agent", async () => {
     ): PromiseOrValue<AgentProcessResult<Message>> {
       console.log("Custom agent processing input:", input);
       return {
-        $message: "AIGNE is a platform for building AI agents.",
+        message: "AIGNE is a platform for building AI agents.",
       };
     }
   }
 
   const agent = new CustomAgent();
 
-  const result = await agent.invoke("What is the price of ABT?");
+  const result = await agent.invoke({ message: "What is the price of ABT?" });
   console.log(result);
-  // Output: { $message: "AIGNE is a platform for building AI agents." }
-  expect(result).toEqual({ $message: "AIGNE is a platform for building AI agents." });
+  // Output: { message: "AIGNE is a platform for building AI agents." }
+  expect(result).toEqual({ message: "AIGNE is a platform for building AI agents." });
   // #endregion example-agent-custom-process
 });
 

--- a/docs-examples/test/concepts/aigne.test.ts
+++ b/docs-examples/test/concepts/aigne.test.ts
@@ -21,6 +21,7 @@ test("Example AIGNE: basic", async () => {
   // #region example-aigne-basic-add-agent
   const agent = AIAgent.from({
     instructions: "You are a helpful assistant",
+    inputKey: "message",
   });
 
   aigne.addAgent(agent);
@@ -30,21 +31,21 @@ test("Example AIGNE: basic", async () => {
   spyOn(aigne.model, "process").mockReturnValueOnce({
     text: "AIGNE is a platform for building AI agents.",
   });
-  const result = await aigne.invoke(agent, "What is AIGNE?");
+  const result = await aigne.invoke(agent, { message: "What is AIGNE?" });
   console.log(result);
-  // Output: { $message: "AIGNE is a platform for building AI agents." }
-  expect(result).toEqual({ $message: "AIGNE is a platform for building AI agents." });
+  // Output: { message: "AIGNE is a platform for building AI agents." }
+  expect(result).toEqual({ message: "AIGNE is a platform for building AI agents." });
   // #endregion example-aigne-basic-invoke-agent
 
   // #region example-aigne-basic-invoke-agent-streaming
   spyOn(aigne.model, "process").mockReturnValueOnce(
     stringToAgentResponseStream("AIGNE is a platform for building AI agents."),
   );
-  const stream = await aigne.invoke(agent, "What is AIGNE?", { streaming: true });
+  const stream = await aigne.invoke(agent, { message: "What is AIGNE?" }, { streaming: true });
   let response = "";
   for await (const chunk of stream) {
     if (isAgentResponseDelta(chunk)) {
-      if (chunk.delta.text?.$message) response += chunk.delta.text.$message;
+      if (chunk.delta.text?.message) response += chunk.delta.text.message;
     }
   }
   console.log(response);
@@ -57,10 +58,10 @@ test("Example AIGNE: basic", async () => {
     text: "AIGNE is a platform for building AI agents.",
   });
   const userAgent = aigne.invoke(agent);
-  const result1 = await userAgent.invoke("What is AIGNE?");
+  const result1 = await userAgent.invoke({ message: "What is AIGNE?" });
   console.log(result1);
-  // Output: { $message: "AIGNE is a platform for building AI agents." }
-  expect(result1).toEqual({ $message: "AIGNE is a platform for building AI agents." });
+  // Output: { message: "AIGNE is a platform for building AI agents." }
+  expect(result1).toEqual({ message: "AIGNE is a platform for building AI agents." });
   // #endregion example-aigne-basic-invoke-agent-user-agent
 
   // #region example-aigne-basic-shutdown

--- a/docs-examples/test/concepts/function-agent.test.ts
+++ b/docs-examples/test/concepts/function-agent.test.ts
@@ -13,7 +13,7 @@ test("Example FunctionAgent: basic", async () => {
       city: z.string().describe("The city to get the weather for."),
     }),
     outputSchema: z.object({
-      $message: z.string().describe("The message from the agent."),
+      message: z.string().describe("The message from the agent."),
       temperature: z.number().describe("The current temperature in Celsius."),
     }),
     process: async ({ city }) => {
@@ -21,7 +21,7 @@ test("Example FunctionAgent: basic", async () => {
       const temperature = 25; // You can replace this with actual weather fetching logic
 
       return {
-        $message: "Hello, I'm AIGNE!",
+        message: "Hello, I'm AIGNE!",
         temperature,
       };
     },
@@ -31,8 +31,8 @@ test("Example FunctionAgent: basic", async () => {
   // #region example-agent-basic-invoke
   const result = await weather.invoke({ city: "New York" });
   console.log(result);
-  // Output: { $message: "Hello, I'm AIGNE!", temperature: 25 }
-  expect(result).toEqual({ $message: "Hello, I'm AIGNE!", temperature: 25 });
+  // Output: { message: "Hello, I'm AIGNE!", temperature: 25 }
+  expect(result).toEqual({ message: "Hello, I'm AIGNE!", temperature: 25 });
   // #endregion example-agent-basic-invoke
 
   // #endregion example-agent-basic
@@ -47,17 +47,17 @@ test("Example FunctionAgent: generator", async () => {
       city: z.string().describe("The city to get the weather for."),
     }),
     outputSchema: z.object({
-      $message: z.string().describe("The message from the agent."),
+      message: z.string().describe("The message from the agent."),
       temperature: z.number().describe("The current temperature in Celsius."),
     }),
     process: async function* ({ city }) {
       console.log(`Fetching weather for ${city}`);
 
-      yield { delta: { text: { $message: "Hello" } } };
-      yield { delta: { text: { $message: "," } } };
-      yield { delta: { text: { $message: " I'm" } } };
-      yield { delta: { text: { $message: " AIGNE" } } };
-      yield { delta: { text: { $message: "!" } } };
+      yield { delta: { text: { message: "Hello" } } };
+      yield { delta: { text: { message: "," } } };
+      yield { delta: { text: { message: " I'm" } } };
+      yield { delta: { text: { message: " AIGNE" } } };
+      yield { delta: { text: { message: "!" } } };
       yield { delta: { json: { temperature: 25 } } };
 
       // Or you can return a partial result at the end
@@ -68,8 +68,8 @@ test("Example FunctionAgent: generator", async () => {
 
   // #region example-agent-generator-invoke-non-streaming
   const result = await weather.invoke({ city: "New York" });
-  console.log(result); // Output: { $message: "Hello, I'm AIGNE!", temperature: 25 }
-  expect(result).toEqual({ $message: "Hello, I'm AIGNE!", temperature: 25 });
+  console.log(result); // Output: { message: "Hello, I'm AIGNE!", temperature: 25 }
+  expect(result).toEqual({ message: "Hello, I'm AIGNE!", temperature: 25 });
   // #endregion example-agent-generator-invoke-non-streaming
 
   // #endregion example-agent-generator
@@ -84,7 +84,7 @@ test("Example FunctionAgent: streaming", async () => {
       city: z.string().describe("The city to get the weather for."),
     }),
     outputSchema: z.object({
-      $message: z.string().describe("The message from the agent."),
+      message: z.string().describe("The message from the agent."),
       temperature: z.number().describe("The current temperature in Celsius."),
     }),
     process: async ({ city }) => {
@@ -92,11 +92,11 @@ test("Example FunctionAgent: streaming", async () => {
 
       return new ReadableStream({
         start(controller) {
-          controller.enqueue({ delta: { text: { $message: "Hello" } } });
-          controller.enqueue({ delta: { text: { $message: "," } } });
-          controller.enqueue({ delta: { text: { $message: " I'm" } } });
-          controller.enqueue({ delta: { text: { $message: " AIGNE" } } });
-          controller.enqueue({ delta: { text: { $message: "!" } } });
+          controller.enqueue({ delta: { text: { message: "Hello" } } });
+          controller.enqueue({ delta: { text: { message: "," } } });
+          controller.enqueue({ delta: { text: { message: " I'm" } } });
+          controller.enqueue({ delta: { text: { message: " AIGNE" } } });
+          controller.enqueue({ delta: { text: { message: "!" } } });
           controller.enqueue({ delta: { json: { temperature: 25 } } });
           controller.close();
         },
@@ -111,7 +111,7 @@ test("Example FunctionAgent: streaming", async () => {
   const json = {};
   for await (const chunk of stream) {
     if (isAgentResponseDelta(chunk)) {
-      if (chunk.delta.text?.$message) text += chunk.delta.text.$message;
+      if (chunk.delta.text?.message) text += chunk.delta.text.message;
       if (chunk.delta.json) Object.assign(json, chunk.delta.json);
     }
   }
@@ -123,8 +123,8 @@ test("Example FunctionAgent: streaming", async () => {
 
   // #region example-agent-streaming-invoke-non-streaming
   const result = await weather.invoke({ city: "New York" });
-  console.log(result); // Output: { $message: "Hello, I'm AIGNE!", temperature: 25 }
-  expect(result).toEqual({ $message: "Hello, I'm AIGNE!", temperature: 25 });
+  console.log(result); // Output: { message: "Hello, I'm AIGNE!", temperature: 25 }
+  expect(result).toEqual({ message: "Hello, I'm AIGNE!", temperature: 25 });
   // #endregion example-agent-streaming-invoke-non-streaming
 
   // #endregion example-agent-streaming
@@ -138,15 +138,15 @@ test("Example FunctionAgent: pure function", async () => {
     console.log(`Fetching weather for ${city}`);
 
     return {
-      $message: "Hello, I'm AIGNE!",
+      message: "Hello, I'm AIGNE!",
       temperature: 25,
     };
   });
   // #endregion example-agent-pure-function-create-agent
 
   const result = await weather.invoke({ city: "New York" });
-  console.log(result); // Output: { $message: "Hello, I'm AIGNE!", temperature: 25 }
-  expect(result).toEqual({ $message: "Hello, I'm AIGNE!", temperature: 25 });
+  console.log(result); // Output: { message: "Hello, I'm AIGNE!", temperature: 25 }
+  expect(result).toEqual({ message: "Hello, I'm AIGNE!", temperature: 25 });
 
   // #endregion example-agent-pure-function
 });

--- a/docs-examples/test/concepts/guide-rail-agent.test.ts
+++ b/docs-examples/test/concepts/guide-rail-agent.test.ts
@@ -24,6 +24,7 @@ test("Example GuideRailAgent: basic", async () => {
   // #region example-guide-rail-agent-basic-create-agent
   const agent = AIAgent.from({
     guideRails: [financial],
+    inputKey: "message",
   });
   // #endregion example-guide-rail-agent-basic-create-agent
 
@@ -48,16 +49,18 @@ test("Example GuideRailAgent: basic", async () => {
         },
       }),
     );
-  const result = await aigne.invoke(agent, "What will be the price of Bitcoin next month?");
+  const result = await aigne.invoke(agent, {
+    message: "What will be the price of Bitcoin next month?",
+  });
   console.log(result);
   // Output:
   // {
   //   "$status": "GuideRailError",
-  //   "$message": "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading."
+  //   "message": "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading."
   // }
   expect(result).toEqual({
     $status: "GuideRailError",
-    $message:
+    message:
       "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading.",
   });
   // #endregion example-guide-rail-agent-basic-invoke

--- a/docs-examples/test/concepts/http-transport.test.ts
+++ b/docs-examples/test/concepts/http-transport.test.ts
@@ -16,6 +16,7 @@ test("Example HTTPTransport: AIGNEHTTPServer and AIGNEHTTPClient", async () => {
     name: "chatbot",
     instructions: "You are a helpful assistant",
     memory: new DefaultMemory(),
+    inputKey: "message",
   });
   // #endregion example-http-transport-create-named-agent
 
@@ -56,10 +57,12 @@ test("Example HTTPTransport: AIGNEHTTPServer and AIGNEHTTPClient", async () => {
   });
 
   // #region example-http-client-invoke-agent
-  const result = await client.invoke("chatbot", "What is the crypto price of ABT/USD on coinbase?");
+  const result = await client.invoke("chatbot", {
+    message: "What is the crypto price of ABT/USD on coinbase?",
+  });
   console.log(result);
-  // Output: { $message: "The current price of ABT/USD on Coinbase is $0.9684." }
-  expect(result).toEqual({ $message: "The current price of ABT/USD on Coinbase is $0.9684." });
+  // Output: { message: "The current price of ABT/USD on Coinbase is $0.9684." }
+  expect(result).toEqual({ message: "The current price of ABT/USD on Coinbase is $0.9684." });
   // #endregion example-http-client-invoke-agent
 
   // #endregion example-http-client-usage

--- a/docs-examples/test/quick-start.test.ts
+++ b/docs-examples/test/quick-start.test.ts
@@ -20,6 +20,7 @@ test("Example quick start: basic", async () => {
   // #region example-quick-start-create-agent
   const agent = AIAgent.from({
     instructions: "You are a helpful assistant",
+    inputKey: "message",
   });
   // #endregion example-quick-start-create-agent
 
@@ -28,11 +29,11 @@ test("Example quick start: basic", async () => {
     text: "AIGNE is a platform for building AI agents.",
   });
 
-  const result = await aigne.invoke(agent, "What is AIGNE?");
+  const result = await aigne.invoke(agent, { message: "What is AIGNE?" });
   console.log(result);
-  // Output: { $message: "AIGNE is a platform for building AI agents." }
+  // Output: { message: "AIGNE is a platform for building AI agents." }
 
-  expect(result).toEqual({ $message: "AIGNE is a platform for building AI agents." });
+  expect(result).toEqual({ message: "AIGNE is a platform for building AI agents." });
   // #endregion example-quick-start-invoke
 
   // #region example-quick-start-streaming
@@ -42,13 +43,13 @@ test("Example quick start: basic", async () => {
     ]),
   );
 
-  const stream = await aigne.invoke(agent, "What is AIGNE?", { streaming: true });
+  const stream = await aigne.invoke(agent, { message: "What is AIGNE?" }, { streaming: true });
 
   let response = "";
   for await (const chunk of stream) {
     console.log(chunk);
-    if (isAgentResponseDelta(chunk) && chunk.delta.text?.$message)
-      response += chunk.delta.text.$message;
+    if (isAgentResponseDelta(chunk) && chunk.delta.text?.message)
+      response += chunk.delta.text.message;
   }
   console.log(response);
   // Output:  "AIGNE is a platform for building AI agents."

--- a/docs-examples/test/what-is-aigne.test.ts
+++ b/docs-examples/test/what-is-aigne.test.ts
@@ -12,6 +12,7 @@ test("Example what is aigne: basic", async () => {
       model: "gpt-4o-mini",
     }),
     instructions: "You are a helpful assistant",
+    inputKey: "message",
   });
 
   assert(agent.model);
@@ -19,10 +20,10 @@ test("Example what is aigne: basic", async () => {
     text: "AIGNE is a platform for building AI agents.",
   });
 
-  const result = await agent.invoke("What is AIGNE?");
+  const result = await agent.invoke({ message: "What is AIGNE?" });
   console.log(result);
-  // Output: { $message: "AIGNE is a platform for building AI agents." }
-  expect(result).toEqual({ $message: "AIGNE is a platform for building AI agents." });
+  // Output: { message: "AIGNE is a platform for building AI agents." }
+  expect(result).toEqual({ message: "AIGNE is a platform for building AI agents." });
 
   // #endregion example-what-is-aigne-basic
 });

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -155,20 +155,20 @@ Apply guide rails to an Agent:
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant that provides financial advice.",
   guideRails: [financial],
+  inputKey: "message",
 });
 ```
 
 See how it protects users from inappropriate advice:
 
 ```ts file="../../docs-examples/test/concepts/agent.test.ts" region="example-agent-guide-rails-invoke" exclude_imports
-const result = await aigne.invoke(
-  agent,
-  "What will be the price of Bitcoin next month?",
-);
+const result = await aigne.invoke(agent, {
+  message: "What will be the price of Bitcoin next month?",
+});
 console.log(result);
 // Output:
 // {
-//   "$message": "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading."
+//   "message": "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading."
 // }
 ```
 
@@ -180,18 +180,18 @@ Imagine an assistant that can remember all your past conversations - this is the
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant for Crypto market analysis",
   memory: new DefaultMemory(),
+  inputKey: "message",
 });
 ```
 
 With memory, Agents can remember previous conversation content, providing more personalized and coherent experiences:
 
 ```ts file="../../docs-examples/test/concepts/agent.test.ts" region="example-agent-enable-memory-invoke-1" exclude_imports
-const result2 = await aigne.invoke(
-  agent,
-  "What is my favorite cryptocurrency?",
-);
+const result2 = await aigne.invoke(agent, {
+  message: "What is my favorite cryptocurrency?",
+});
 console.log(result2);
-// Output: { $message: "Your favorite cryptocurrency is Bitcoin." }
+// Output: { message: "Your favorite cryptocurrency is Bitcoin." }
 ```
 
 ### Skills
@@ -219,6 +219,7 @@ const getCryptoPrice = FunctionAgent.from({
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant for Crypto market analysis",
   skills: [getCryptoPrice],
+  inputKey: "message",
 });
 ```
 
@@ -231,21 +232,22 @@ This skill composition mechanism enables Agents to break down complex tasks, del
 1. **Regular Mode** - Wait for the Agent to complete all processing and return the final result, suitable for scenarios that need to obtain complete answers at once:
 
 ```ts file="../../docs-examples/test/concepts/agent.test.ts" region="example-agent-invoke" exclude_imports
-const result = await agent.invoke("What is the price of ABT?");
+const result = await agent.invoke({ message: "What is the price of ABT?" });
 console.log(result);
-// Output: { $message: "ABT is currently priced at $1000." }
+// Output: { message: "ABT is currently priced at $1000." }
 ```
 
 2. **Streaming Mode** - Allows Agents to return results incrementally in real-time, perfect for interactive scenarios that need immediate feedback, such as typing effects in chatbots:
 
 ```ts file="../../docs-examples/test/concepts/agent.test.ts" region="example-agent-invoke-stream" exclude_imports
-const stream = await agent.invoke("What is the price of ABT?", {
-  streaming: true,
-});
+const stream = await agent.invoke(
+  { message: "What is the price of ABT?" },
+  { streaming: true },
+);
 let response = "";
 for await (const chunk of stream) {
-  if (isAgentResponseDelta(chunk) && chunk.delta.text?.$message)
-    response += chunk.delta.text.$message;
+  if (isAgentResponseDelta(chunk) && chunk.delta.text?.message)
+    response += chunk.delta.text.message;
 }
 console.log(response);
 // Output:  "ABT is currently priced at $1000."
@@ -268,16 +270,16 @@ class CustomAgent extends Agent {
   ): PromiseOrValue<AgentProcessResult<Message>> {
     console.log("Custom agent processing input:", input);
     return {
-      $message: "AIGNE is a platform for building AI agents.",
+      message: "AIGNE is a platform for building AI agents.",
     };
   }
 }
 
 const agent = new CustomAgent();
 
-const result = await agent.invoke("What is the price of ABT?");
+const result = await agent.invoke({ message: "What is the price of ABT?" });
 console.log(result);
-// Output: { $message: "AIGNE is a platform for building AI agents." }
+// Output: { message: "AIGNE is a platform for building AI agents." }
 ```
 
 ### shutdown Method

--- a/docs/concepts/agent.zh.md
+++ b/docs/concepts/agent.zh.md
@@ -155,20 +155,20 @@ const financial = AIAgent.from({
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant that provides financial advice.",
   guideRails: [financial],
+  inputKey: "message",
 });
 ```
 
 看看它如何保护用户免受不当建议：
 
 ```ts file="../../docs-examples/test/concepts/agent.test.ts" region="example-agent-guide-rails-invoke" exclude_imports
-const result = await aigne.invoke(
-  agent,
-  "What will be the price of Bitcoin next month?",
-);
+const result = await aigne.invoke(agent, {
+  message: "What will be the price of Bitcoin next month?",
+});
 console.log(result);
 // Output:
 // {
-//   "$message": "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading."
+//   "message": "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading."
 // }
 ```
 
@@ -180,18 +180,18 @@ console.log(result);
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant for Crypto market analysis",
   memory: new DefaultMemory(),
+  inputKey: "message",
 });
 ```
 
 有了记忆，Agent 可以记住之前的对话内容，提供更加个性化和连贯的体验：
 
 ```ts file="../../docs-examples/test/concepts/agent.test.ts" region="example-agent-enable-memory-invoke-1" exclude_imports
-const result2 = await aigne.invoke(
-  agent,
-  "What is my favorite cryptocurrency?",
-);
+const result2 = await aigne.invoke(agent, {
+  message: "What is my favorite cryptocurrency?",
+});
 console.log(result2);
-// Output: { $message: "Your favorite cryptocurrency is Bitcoin." }
+// Output: { message: "Your favorite cryptocurrency is Bitcoin." }
 ```
 
 ### 技能（Skills）
@@ -219,6 +219,7 @@ const getCryptoPrice = FunctionAgent.from({
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant for Crypto market analysis",
   skills: [getCryptoPrice],
+  inputKey: "message",
 });
 ```
 
@@ -231,21 +232,22 @@ const agent = AIAgent.from({
 1. **常规模式** - 等待 Agent 完成所有处理并返回最终结果，适合需要一次性获取完整答案的场景：
 
 ```ts file="../../docs-examples/test/concepts/agent.test.ts" region="example-agent-invoke" exclude_imports
-const result = await agent.invoke("What is the price of ABT?");
+const result = await agent.invoke({ message: "What is the price of ABT?" });
 console.log(result);
-// Output: { $message: "ABT is currently priced at $1000." }
+// Output: { message: "ABT is currently priced at $1000." }
 ```
 
 2. **流式模式** - 允许 Agent 以增量方式实时返回结果，非常适合需要即时反馈的交互场景，例如聊天机器人的打字效果：
 
 ```ts file="../../docs-examples/test/concepts/agent.test.ts" region="example-agent-invoke-stream" exclude_imports
-const stream = await agent.invoke("What is the price of ABT?", {
-  streaming: true,
-});
+const stream = await agent.invoke(
+  { message: "What is the price of ABT?" },
+  { streaming: true },
+);
 let response = "";
 for await (const chunk of stream) {
-  if (isAgentResponseDelta(chunk) && chunk.delta.text?.$message)
-    response += chunk.delta.text.$message;
+  if (isAgentResponseDelta(chunk) && chunk.delta.text?.message)
+    response += chunk.delta.text.message;
 }
 console.log(response);
 // Output:  "ABT is currently priced at $1000."
@@ -268,16 +270,16 @@ class CustomAgent extends Agent {
   ): PromiseOrValue<AgentProcessResult<Message>> {
     console.log("Custom agent processing input:", input);
     return {
-      $message: "AIGNE is a platform for building AI agents.",
+      message: "AIGNE is a platform for building AI agents.",
     };
   }
 }
 
 const agent = new CustomAgent();
 
-const result = await agent.invoke("What is the price of ABT?");
+const result = await agent.invoke({ message: "What is the price of ABT?" });
 console.log(result);
-// Output: { $message: "AIGNE is a platform for building AI agents." }
+// Output: { message: "AIGNE is a platform for building AI agents." }
 ```
 
 ### shutdown 方法

--- a/docs/concepts/ai-agent.md
+++ b/docs/concepts/ai-agent.md
@@ -19,7 +19,10 @@ const model = new OpenAIChatModel({
   model: "gpt-4o-mini",
 });
 
-const agent = AIAgent.from({ model });
+const agent = AIAgent.from({
+  model,
+  inputKey: "message",
+});
 ```
 
 ## Invoking Agents
@@ -27,9 +30,9 @@ const agent = AIAgent.from({ model });
 After creating an AIAgent, you can use the invoke method to send requests to the agent and get responses. In basic invocation, simply pass a string as the user's question or instruction.
 
 ```ts file="../../docs-examples/test/concepts/ai-agent.test.ts" region="example-agent-basic-invoke"
-const result = await agent.invoke("What is AIGNE?");
+const result = await agent.invoke({ message: "What is AIGNE?" });
 console.log(result);
-// Output: { $message: "AIGNE is a platform for building AI agents." }
+// Output: { message: "AIGNE is a platform for building AI agents." }
 ```
 
 ## Streaming Response
@@ -39,11 +42,14 @@ Streaming response is a way to get AI answers in real-time, allowing application
 ```ts file="../../docs-examples/test/concepts/ai-agent.test.ts" region="example-agent-basic-invoke-stream"
 import { isAgentResponseDelta } from "@aigne/core";
 
-const stream = await agent.invoke("What is AIGNE?", { streaming: true });
+const stream = await agent.invoke(
+  { message: "What is AIGNE?" },
+  { streaming: true },
+);
 let response = "";
 for await (const chunk of stream) {
-  if (isAgentResponseDelta(chunk) && chunk.delta.text?.$message)
-    response += chunk.delta.text.$message;
+  if (isAgentResponseDelta(chunk) && chunk.delta.text?.message)
+    response += chunk.delta.text.message;
 }
 console.log(response);
 // Output:  "AIGNE is a platform for building AI agents."
@@ -70,15 +76,16 @@ const model = new OpenAIChatModel();
 const agent = AIAgent.from({
   model,
   instructions: "Only speak in Haikus.",
+  inputKey: "message",
 });
 ```
 
 The following example shows how to invoke an agent with custom instructions and get answers that conform to the specified style (haiku):
 
 ```ts file="../../docs-examples/test/concepts/ai-agent.test.ts" region="example-agent-custom-instructions-invoke"
-const result = await agent.invoke("What is AIGNE?");
+const result = await agent.invoke({ message: "What is AIGNE?" });
 console.log(result);
-// Output: { $message: "AIGNE stands for  \nA new approach to learning,  \nKnowledge intertwined." }
+// Output: { message: "AIGNE stands for  \nA new approach to learning,  \nKnowledge intertwined." }
 ```
 
 Key features:
@@ -104,19 +111,19 @@ const agent = AIAgent.from({
     style: z.string().describe("The style of the response."),
   }),
   instructions: "Only speak in {{style}}.",
+  inputKey: "message",
 });
 ```
 
 The following example shows how to invoke an agent with custom instructions containing variables. By using the createMessage function to create a message containing the user's question and variable values, the agent can generate answers based on the provided style (Haikus):
 
 ```ts file="../../docs-examples/test/concepts/ai-agent.test.ts" region="example-agent-custom-instructions-with-variables-invoke"
-import { createMessage } from "@aigne/core";
-
-const result = await agent.invoke(
-  createMessage("What is AIGNE?", { style: "Haikus" }),
-);
+const result = await agent.invoke({
+  message: "What is AIGNE?",
+  style: "Haikus",
+});
 console.log(result);
-// Output: { $message: "AIGNE, you ask now  \nArtificial Intelligence  \nGuidance, new tech blooms." }
+// Output: { message: "AIGNE, you ask now  \nArtificial Intelligence  \nGuidance, new tech blooms." }
 ```
 
 Key features:
@@ -146,17 +153,17 @@ const agent = AIAgent.from({
     response: z.string().describe("The response to the request"),
   }),
   instructions: "Only speak in {{style}}.",
+  inputKey: "message",
 });
 ```
 
 The following example shows how to invoke an agent with structured output. Similar to custom instructions with variables, we use the createMessage function to pass user questions and variable values, but this time the agent will return structured data that conforms to our defined output schema:
 
 ```ts file="../../docs-examples/test/concepts/ai-agent.test.ts" region="example-agent-structured-output-invoke"
-import { createMessage } from "@aigne/core";
-
-const result = await agent.invoke(
-  createMessage("What is AIGNE?", { style: "Haikus" }),
-);
+const result = await agent.invoke({
+  message: "What is AIGNE?",
+  style: "Haikus",
+});
 console.log(result);
 // Output: { topic: "AIGNE", response: "AIGNE, you ask now  \nArtificial Intelligence  \nGuidance, new tech blooms." }
 ```
@@ -209,15 +216,18 @@ const agent = AIAgent.from({
   instructions:
     "You are a helpful assistant that can provide weather information.",
   skills: [getWeather],
+  inputKey: "message",
 });
 ```
 
 The following example shows how to invoke an agent with skills. When a user asks about the weather in Beijing, the agent will automatically recognize this as a weather query request and call the getWeather skill to obtain weather data, then return the result in natural language:
 
 ```ts file="../../docs-examples/test/concepts/ai-agent.test.ts" region="example-agent-with-skills-invoke"
-const result = await agent.invoke("What's the weather like in Beijing today?");
+const result = await agent.invoke({
+  message: "What's the weather like in Beijing today?",
+});
 console.log(result);
-// Output: { $message: "The current weather in Beijing is 22°C with sunny conditions and 45% humidity." }
+// Output: { message: "The current weather in Beijing is 22°C with sunny conditions and 45% humidity." }
 ```
 
 Key features:

--- a/docs/concepts/ai-agent.zh.md
+++ b/docs/concepts/ai-agent.zh.md
@@ -19,7 +19,10 @@ const model = new OpenAIChatModel({
   model: "gpt-4o-mini",
 });
 
-const agent = AIAgent.from({ model });
+const agent = AIAgent.from({
+  model,
+  inputKey: "message",
+});
 ```
 
 ## 调用 Agent
@@ -27,9 +30,9 @@ const agent = AIAgent.from({ model });
 创建 AIAgent 后，可以使用 invoke 方法向代理发送请求并获取响应。在基本调用中，只需传入一个字符串作为用户的问题或指令。
 
 ```ts file="../../docs-examples/test/concepts/ai-agent.test.ts" region="example-agent-basic-invoke"
-const result = await agent.invoke("What is AIGNE?");
+const result = await agent.invoke({ message: "What is AIGNE?" });
 console.log(result);
-// Output: { $message: "AIGNE is a platform for building AI agents." }
+// Output: { message: "AIGNE is a platform for building AI agents." }
 ```
 
 ## 流式响应
@@ -39,11 +42,14 @@ console.log(result);
 ```ts file="../../docs-examples/test/concepts/ai-agent.test.ts" region="example-agent-basic-invoke-stream"
 import { isAgentResponseDelta } from "@aigne/core";
 
-const stream = await agent.invoke("What is AIGNE?", { streaming: true });
+const stream = await agent.invoke(
+  { message: "What is AIGNE?" },
+  { streaming: true },
+);
 let response = "";
 for await (const chunk of stream) {
-  if (isAgentResponseDelta(chunk) && chunk.delta.text?.$message)
-    response += chunk.delta.text.$message;
+  if (isAgentResponseDelta(chunk) && chunk.delta.text?.message)
+    response += chunk.delta.text.message;
 }
 console.log(response);
 // Output:  "AIGNE is a platform for building AI agents."
@@ -70,15 +76,16 @@ const model = new OpenAIChatModel();
 const agent = AIAgent.from({
   model,
   instructions: "Only speak in Haikus.",
+  inputKey: "message",
 });
 ```
 
 下面的示例展示了如何调用带有自定义指令的代理，并获取符合指定风格（俳句）的回答：
 
 ```ts file="../../docs-examples/test/concepts/ai-agent.test.ts" region="example-agent-custom-instructions-invoke"
-const result = await agent.invoke("What is AIGNE?");
+const result = await agent.invoke({ message: "What is AIGNE?" });
 console.log(result);
-// Output: { $message: "AIGNE stands for  \nA new approach to learning,  \nKnowledge intertwined." }
+// Output: { message: "AIGNE stands for  \nA new approach to learning,  \nKnowledge intertwined." }
 ```
 
 主要特点：
@@ -104,19 +111,19 @@ const agent = AIAgent.from({
     style: z.string().describe("The style of the response."),
   }),
   instructions: "Only speak in {{style}}.",
+  inputKey: "message",
 });
 ```
 
 下面的示例展示了如何调用带有变量的自定义指令代理。通过 createMessage 函数创建一个包含用户问题和变量值的消息，使代理能够根据提供的风格（Haikus）生成回答：
 
 ```ts file="../../docs-examples/test/concepts/ai-agent.test.ts" region="example-agent-custom-instructions-with-variables-invoke"
-import { createMessage } from "@aigne/core";
-
-const result = await agent.invoke(
-  createMessage("What is AIGNE?", { style: "Haikus" }),
-);
+const result = await agent.invoke({
+  message: "What is AIGNE?",
+  style: "Haikus",
+});
 console.log(result);
-// Output: { $message: "AIGNE, you ask now  \nArtificial Intelligence  \nGuidance, new tech blooms." }
+// Output: { message: "AIGNE, you ask now  \nArtificial Intelligence  \nGuidance, new tech blooms." }
 ```
 
 主要特点：
@@ -146,17 +153,17 @@ const agent = AIAgent.from({
     response: z.string().describe("The response to the request"),
   }),
   instructions: "Only speak in {{style}}.",
+  inputKey: "message",
 });
 ```
 
 下面的示例展示了如何调用具有结构化输出的代理。与带变量的自定义指令类似，我们使用 createMessage 函数传递用户问题和变量值，但这次代理会返回符合我们定义的输出模式的结构化数据：
 
 ```ts file="../../docs-examples/test/concepts/ai-agent.test.ts" region="example-agent-structured-output-invoke"
-import { createMessage } from "@aigne/core";
-
-const result = await agent.invoke(
-  createMessage("What is AIGNE?", { style: "Haikus" }),
-);
+const result = await agent.invoke({
+  message: "What is AIGNE?",
+  style: "Haikus",
+});
 console.log(result);
 // Output: { topic: "AIGNE", response: "AIGNE, you ask now  \nArtificial Intelligence  \nGuidance, new tech blooms." }
 ```
@@ -209,15 +216,18 @@ const agent = AIAgent.from({
   instructions:
     "You are a helpful assistant that can provide weather information.",
   skills: [getWeather],
+  inputKey: "message",
 });
 ```
 
 下面的示例展示了如何调用具有技能的代理。当用户询问北京的天气时，代理会自动识别这是一个天气查询请求，并调用 getWeather 技能来获取天气数据，然后以自然语言形式返回结果：
 
 ```ts file="../../docs-examples/test/concepts/ai-agent.test.ts" region="example-agent-with-skills-invoke"
-const result = await agent.invoke("What's the weather like in Beijing today?");
+const result = await agent.invoke({
+  message: "What's the weather like in Beijing today?",
+});
 console.log(result);
-// Output: { $message: "The current weather in Beijing is 22°C with sunny conditions and 45% humidity." }
+// Output: { message: "The current weather in Beijing is 22°C with sunny conditions and 45% humidity." }
 ```
 
 主要特点：

--- a/docs/concepts/aigne.md
+++ b/docs/concepts/aigne.md
@@ -67,6 +67,7 @@ After creating an AIGNE instance, you can add various Agents to it. The followin
 ```ts file="../../docs-examples/test/concepts/aigne.test.ts" region="example-aigne-basic-add-agent" exclude_imports
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant",
+  inputKey: "message",
 });
 
 aigne.addAgent(agent);
@@ -77,9 +78,9 @@ aigne.addAgent(agent);
 After adding Agents, you can invoke them through the AIGNE instance. The following code shows how to send a message to a specified Agent and get a response. In this example, the Agent is asked about AIGNE information and the response result is output.
 
 ```ts file="../../docs-examples/test/concepts/aigne.test.ts" region="example-aigne-basic-invoke-agent" exclude_imports
-const result = await aigne.invoke(agent, "What is AIGNE?");
+const result = await aigne.invoke(agent, { message: "What is AIGNE?" });
 console.log(result);
-// Output: { $message: "AIGNE is a platform for building AI agents." }
+// Output: { message: "AIGNE is a platform for building AI agents." }
 ```
 
 ### Streaming Response
@@ -87,11 +88,15 @@ console.log(result);
 For application scenarios that require real-time feedback, AIGNE supports streaming responses. This approach allows receiving partial results while the Agent is generating responses, particularly suitable for scenarios requiring immediate feedback such as chat applications. The following code demonstrates how to invoke an Agent in streaming mode and progressively process response content.
 
 ```ts file="../../docs-examples/test/concepts/aigne.test.ts" region="example-aigne-basic-invoke-agent-streaming" exclude_imports
-const stream = await aigne.invoke(agent, "What is AIGNE?", { streaming: true });
+const stream = await aigne.invoke(
+  agent,
+  { message: "What is AIGNE?" },
+  { streaming: true },
+);
 let response = "";
 for await (const chunk of stream) {
   if (isAgentResponseDelta(chunk)) {
-    if (chunk.delta.text?.$message) response += chunk.delta.text.$message;
+    if (chunk.delta.text?.message) response += chunk.delta.text.message;
   }
 }
 console.log(response);
@@ -104,9 +109,9 @@ AIGNE provides the concept of user Agents, allowing the creation of user session
 
 ```ts file="../../docs-examples/test/concepts/aigne.test.ts" region="example-aigne-basic-invoke-agent-user-agent" exclude_imports
 const userAgent = aigne.invoke(agent);
-const result1 = await userAgent.invoke("What is AIGNE?");
+const result1 = await userAgent.invoke({ message: "What is AIGNE?" });
 console.log(result1);
-// Output: { $message: "AIGNE is a platform for building AI agents." }
+// Output: { message: "AIGNE is a platform for building AI agents." }
 ```
 
 ### Shutdown and Cleanup

--- a/docs/concepts/aigne.zh.md
+++ b/docs/concepts/aigne.zh.md
@@ -67,6 +67,7 @@ const aigne = await AIGNE.load(path, { models: [OpenAIChatModel] });
 ```ts file="../../docs-examples/test/concepts/aigne.test.ts" region="example-aigne-basic-add-agent" exclude_imports
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant",
+  inputKey: "message",
 });
 
 aigne.addAgent(agent);
@@ -77,9 +78,9 @@ aigne.addAgent(agent);
 添加 Agent 后，可以通过 AIGNE 实例调用它。以下代码展示了如何向指定的 Agent 发送消息并获取响应。在这个例子中，向 Agent 询问了关于 AIGNE 的信息，并输出了响应结果。
 
 ```ts file="../../docs-examples/test/concepts/aigne.test.ts" region="example-aigne-basic-invoke-agent" exclude_imports
-const result = await aigne.invoke(agent, "What is AIGNE?");
+const result = await aigne.invoke(agent, { message: "What is AIGNE?" });
 console.log(result);
-// Output: { $message: "AIGNE is a platform for building AI agents." }
+// Output: { message: "AIGNE is a platform for building AI agents." }
 ```
 
 ### 流式响应
@@ -87,11 +88,15 @@ console.log(result);
 对于需要实时反馈的应用场景，AIGNE 支持流式响应。这种方式允许在 Agent 生成响应的同时接收部分结果，特别适合于聊天应用等需要即时反馈的场景。以下代码演示了如何使用流式模式调用 Agent 并逐步处理响应内容。
 
 ```ts file="../../docs-examples/test/concepts/aigne.test.ts" region="example-aigne-basic-invoke-agent-streaming" exclude_imports
-const stream = await aigne.invoke(agent, "What is AIGNE?", { streaming: true });
+const stream = await aigne.invoke(
+  agent,
+  { message: "What is AIGNE?" },
+  { streaming: true },
+);
 let response = "";
 for await (const chunk of stream) {
   if (isAgentResponseDelta(chunk)) {
-    if (chunk.delta.text?.$message) response += chunk.delta.text.$message;
+    if (chunk.delta.text?.message) response += chunk.delta.text.message;
   }
 }
 console.log(response);
@@ -104,9 +109,9 @@ AIGNE 提供了用户 Agent 的概念，允许创建与特定 Agent 关联的用
 
 ```ts file="../../docs-examples/test/concepts/aigne.test.ts" region="example-aigne-basic-invoke-agent-user-agent" exclude_imports
 const userAgent = aigne.invoke(agent);
-const result1 = await userAgent.invoke("What is AIGNE?");
+const result1 = await userAgent.invoke({ message: "What is AIGNE?" });
 console.log(result1);
-// Output: { $message: "AIGNE is a platform for building AI agents." }
+// Output: { message: "AIGNE is a platform for building AI agents." }
 ```
 
 ### 关闭和清理

--- a/docs/concepts/function-agent.md
+++ b/docs/concepts/function-agent.md
@@ -23,7 +23,7 @@ const weather = FunctionAgent.from({
     city: z.string().describe("The city to get the weather for."),
   }),
   outputSchema: z.object({
-    $message: z.string().describe("The message from the agent."),
+    message: z.string().describe("The message from the agent."),
     temperature: z.number().describe("The current temperature in Celsius."),
   }),
   process: async ({ city }) => {
@@ -31,7 +31,7 @@ const weather = FunctionAgent.from({
     const temperature = 25; // You can replace this with actual weather fetching logic
 
     return {
-      $message: "Hello, I'm AIGNE!",
+      message: "Hello, I'm AIGNE!",
       temperature,
     };
   },
@@ -55,7 +55,7 @@ const weather = FunctionAgent.from(async ({ city }) => {
   console.log(`Fetching weather for ${city}`);
 
   return {
-    $message: "Hello, I'm AIGNE!",
+    message: "Hello, I'm AIGNE!",
     temperature: 25,
   };
 });
@@ -80,7 +80,7 @@ const weather = FunctionAgent.from({
     city: z.string().describe("The city to get the weather for."),
   }),
   outputSchema: z.object({
-    $message: z.string().describe("The message from the agent."),
+    message: z.string().describe("The message from the agent."),
     temperature: z.number().describe("The current temperature in Celsius."),
   }),
   process: async ({ city }) => {
@@ -88,11 +88,11 @@ const weather = FunctionAgent.from({
 
     return new ReadableStream({
       start(controller) {
-        controller.enqueue({ delta: { text: { $message: "Hello" } } });
-        controller.enqueue({ delta: { text: { $message: "," } } });
-        controller.enqueue({ delta: { text: { $message: " I'm" } } });
-        controller.enqueue({ delta: { text: { $message: " AIGNE" } } });
-        controller.enqueue({ delta: { text: { $message: "!" } } });
+        controller.enqueue({ delta: { text: { message: "Hello" } } });
+        controller.enqueue({ delta: { text: { message: "," } } });
+        controller.enqueue({ delta: { text: { message: " I'm" } } });
+        controller.enqueue({ delta: { text: { message: " AIGNE" } } });
+        controller.enqueue({ delta: { text: { message: "!" } } });
         controller.enqueue({ delta: { json: { temperature: 25 } } });
         controller.close();
       },
@@ -120,17 +120,17 @@ const weather = FunctionAgent.from({
     city: z.string().describe("The city to get the weather for."),
   }),
   outputSchema: z.object({
-    $message: z.string().describe("The message from the agent."),
+    message: z.string().describe("The message from the agent."),
     temperature: z.number().describe("The current temperature in Celsius."),
   }),
   process: async function* ({ city }) {
     console.log(`Fetching weather for ${city}`);
 
-    yield { delta: { text: { $message: "Hello" } } };
-    yield { delta: { text: { $message: "," } } };
-    yield { delta: { text: { $message: " I'm" } } };
-    yield { delta: { text: { $message: " AIGNE" } } };
-    yield { delta: { text: { $message: "!" } } };
+    yield { delta: { text: { message: "Hello" } } };
+    yield { delta: { text: { message: "," } } };
+    yield { delta: { text: { message: " I'm" } } };
+    yield { delta: { text: { message: " AIGNE" } } };
+    yield { delta: { text: { message: "!" } } };
     yield { delta: { json: { temperature: 25 } } };
 
     // Or you can return a partial result at the end
@@ -155,7 +155,7 @@ Use the invocation method to execute the created intelligent agent. The most com
 ```ts file="../../docs-examples/test/concepts/function-agent.test.ts" region="example-agent-basic-invoke"
 const result = await weather.invoke({ city: "New York" });
 console.log(result);
-// Output: { $message: "Hello, I'm AIGNE!", temperature: 25 }
+// Output: { message: "Hello, I'm AIGNE!", temperature: 25 }
 ```
 
 ### Streaming Invocation
@@ -170,7 +170,7 @@ let text = "";
 const json = {};
 for await (const chunk of stream) {
   if (isAgentResponseDelta(chunk)) {
-    if (chunk.delta.text?.$message) text += chunk.delta.text.$message;
+    if (chunk.delta.text?.message) text += chunk.delta.text.message;
     if (chunk.delta.json) Object.assign(json, chunk.delta.json);
   }
 }

--- a/docs/concepts/function-agent.zh.md
+++ b/docs/concepts/function-agent.zh.md
@@ -23,7 +23,7 @@ const weather = FunctionAgent.from({
     city: z.string().describe("The city to get the weather for."),
   }),
   outputSchema: z.object({
-    $message: z.string().describe("The message from the agent."),
+    message: z.string().describe("The message from the agent."),
     temperature: z.number().describe("The current temperature in Celsius."),
   }),
   process: async ({ city }) => {
@@ -31,7 +31,7 @@ const weather = FunctionAgent.from({
     const temperature = 25; // You can replace this with actual weather fetching logic
 
     return {
-      $message: "Hello, I'm AIGNE!",
+      message: "Hello, I'm AIGNE!",
       temperature,
     };
   },
@@ -55,7 +55,7 @@ const weather = FunctionAgent.from(async ({ city }) => {
   console.log(`Fetching weather for ${city}`);
 
   return {
-    $message: "Hello, I'm AIGNE!",
+    message: "Hello, I'm AIGNE!",
     temperature: 25,
   };
 });
@@ -80,7 +80,7 @@ const weather = FunctionAgent.from({
     city: z.string().describe("The city to get the weather for."),
   }),
   outputSchema: z.object({
-    $message: z.string().describe("The message from the agent."),
+    message: z.string().describe("The message from the agent."),
     temperature: z.number().describe("The current temperature in Celsius."),
   }),
   process: async ({ city }) => {
@@ -88,11 +88,11 @@ const weather = FunctionAgent.from({
 
     return new ReadableStream({
       start(controller) {
-        controller.enqueue({ delta: { text: { $message: "Hello" } } });
-        controller.enqueue({ delta: { text: { $message: "," } } });
-        controller.enqueue({ delta: { text: { $message: " I'm" } } });
-        controller.enqueue({ delta: { text: { $message: " AIGNE" } } });
-        controller.enqueue({ delta: { text: { $message: "!" } } });
+        controller.enqueue({ delta: { text: { message: "Hello" } } });
+        controller.enqueue({ delta: { text: { message: "," } } });
+        controller.enqueue({ delta: { text: { message: " I'm" } } });
+        controller.enqueue({ delta: { text: { message: " AIGNE" } } });
+        controller.enqueue({ delta: { text: { message: "!" } } });
         controller.enqueue({ delta: { json: { temperature: 25 } } });
         controller.close();
       },
@@ -120,17 +120,17 @@ const weather = FunctionAgent.from({
     city: z.string().describe("The city to get the weather for."),
   }),
   outputSchema: z.object({
-    $message: z.string().describe("The message from the agent."),
+    message: z.string().describe("The message from the agent."),
     temperature: z.number().describe("The current temperature in Celsius."),
   }),
   process: async function* ({ city }) {
     console.log(`Fetching weather for ${city}`);
 
-    yield { delta: { text: { $message: "Hello" } } };
-    yield { delta: { text: { $message: "," } } };
-    yield { delta: { text: { $message: " I'm" } } };
-    yield { delta: { text: { $message: " AIGNE" } } };
-    yield { delta: { text: { $message: "!" } } };
+    yield { delta: { text: { message: "Hello" } } };
+    yield { delta: { text: { message: "," } } };
+    yield { delta: { text: { message: " I'm" } } };
+    yield { delta: { text: { message: " AIGNE" } } };
+    yield { delta: { text: { message: "!" } } };
     yield { delta: { json: { temperature: 25 } } };
 
     // Or you can return a partial result at the end
@@ -155,7 +155,7 @@ const weather = FunctionAgent.from({
 ```ts file="../../docs-examples/test/concepts/function-agent.test.ts" region="example-agent-basic-invoke"
 const result = await weather.invoke({ city: "New York" });
 console.log(result);
-// Output: { $message: "Hello, I'm AIGNE!", temperature: 25 }
+// Output: { message: "Hello, I'm AIGNE!", temperature: 25 }
 ```
 
 ### 流式调用
@@ -170,7 +170,7 @@ let text = "";
 const json = {};
 for await (const chunk of stream) {
   if (isAgentResponseDelta(chunk)) {
-    if (chunk.delta.text?.$message) text += chunk.delta.text.$message;
+    if (chunk.delta.text?.message) text += chunk.delta.text.message;
     if (chunk.delta.json) Object.assign(json, chunk.delta.json);
   }
 }

--- a/docs/concepts/guide-rail-agent.md
+++ b/docs/concepts/guide-rail-agent.md
@@ -45,6 +45,7 @@ import { AIAgent } from "@aigne/core";
 
 const agent = AIAgent.from({
   guideRails: [financial],
+  inputKey: "message",
 });
 ```
 
@@ -68,15 +69,14 @@ In this example, we created an AIGNE instance and specified OpenAIChatModel as t
 Now, we can invoke the agent with the applied GuideRailAgent and observe its behavior:
 
 ```ts file="../../docs-examples/test/concepts/guide-rail-agent.test.ts" region="example-guide-rail-agent-basic-invoke"
-const result = await aigne.invoke(
-  agent,
-  "What will be the price of Bitcoin next month?",
-);
+const result = await aigne.invoke(agent, {
+  message: "What will be the price of Bitcoin next month?",
+});
 console.log(result);
 // Output:
 // {
 //   "$status": "GuideRailError",
-//   "$message": "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading."
+//   "message": "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading."
 // }
 ```
 

--- a/docs/concepts/guide-rail-agent.zh.md
+++ b/docs/concepts/guide-rail-agent.zh.md
@@ -45,6 +45,7 @@ import { AIAgent } from "@aigne/core";
 
 const agent = AIAgent.from({
   guideRails: [financial],
+  inputKey: "message",
 });
 ```
 
@@ -68,15 +69,14 @@ const aigne = new AIGNE({ model: new OpenAIChatModel() });
 现在，我们可以调用应用了 GuideRailAgent 的代理，并观察其行为：
 
 ```ts file="../../docs-examples/test/concepts/guide-rail-agent.test.ts" region="example-guide-rail-agent-basic-invoke"
-const result = await aigne.invoke(
-  agent,
-  "What will be the price of Bitcoin next month?",
-);
+const result = await aigne.invoke(agent, {
+  message: "What will be the price of Bitcoin next month?",
+});
 console.log(result);
 // Output:
 // {
 //   "$status": "GuideRailError",
-//   "$message": "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading."
+//   "message": "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading."
 // }
 ```
 

--- a/docs/concepts/http-transport.md
+++ b/docs/concepts/http-transport.md
@@ -22,6 +22,7 @@ const agent = AIAgent.from({
   name: "chatbot",
   instructions: "You are a helpful assistant",
   memory: new DefaultMemory(),
+  inputKey: "message",
 });
 ```
 
@@ -95,12 +96,11 @@ In this example, we created an AIGNEHTTPClient instance, specifying the server's
 After creating the client, we can use the invoke method to call remote agents:
 
 ```ts file="../../docs-examples/test/concepts/http-transport.test.ts" region="example-http-client-invoke-agent"
-const result = await client.invoke(
-  "chatbot",
-  "What is the crypto price of ABT/USD on coinbase?",
-);
+const result = await client.invoke("chatbot", {
+  message: "What is the crypto price of ABT/USD on coinbase?",
+});
 console.log(result);
-// Output: { $message: "The current price of ABT/USD on Coinbase is $0.9684." }
+// Output: { message: "The current price of ABT/USD on Coinbase is $0.9684." }
 ```
 
 In this example, we:

--- a/docs/concepts/http-transport.zh.md
+++ b/docs/concepts/http-transport.zh.md
@@ -22,6 +22,7 @@ const agent = AIAgent.from({
   name: "chatbot",
   instructions: "You are a helpful assistant",
   memory: new DefaultMemory(),
+  inputKey: "message",
 });
 ```
 
@@ -95,12 +96,11 @@ const client = new AIGNEHTTPClient({
 创建客户端后，我们可以使用 invoke 方法调用远程代理：
 
 ```ts file="../../docs-examples/test/concepts/http-transport.test.ts" region="example-http-client-invoke-agent"
-const result = await client.invoke(
-  "chatbot",
-  "What is the crypto price of ABT/USD on coinbase?",
-);
+const result = await client.invoke("chatbot", {
+  message: "What is the crypto price of ABT/USD on coinbase?",
+});
 console.log(result);
-// Output: { $message: "The current price of ABT/USD on Coinbase is $0.9684." }
+// Output: { message: "The current price of ABT/USD on Coinbase is $0.9684." }
 ```
 
 在这个示例中，我们：

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -76,6 +76,7 @@ Now, let's create a simple AI Agent:
 ```ts file="../../docs-examples/test/quick-start.test.ts" region="example-quick-start-create-agent" exclude_imports
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant",
+  inputKey: "message",
 });
 ```
 
@@ -92,9 +93,9 @@ You can customize instructions as needed to make the Agent play different roles 
 Now we can invoke the Agent to handle user requests:
 
 ```ts file="../../docs-examples/test/quick-start.test.ts" region="example-quick-start-invoke" exclude_imports
-const result = await aigne.invoke(agent, "What is AIGNE?");
+const result = await aigne.invoke(agent, { message: "What is AIGNE?" });
 console.log(result);
-// Output: { $message: "AIGNE is a platform for building AI agents." }
+// Output: { message: "AIGNE is a platform for building AI agents." }
 ```
 
 This code:
@@ -111,13 +112,17 @@ The `invoke` method is the primary way to interact with Agents, returning a Prom
 For long responses or scenarios requiring real-time display of generated content, AIGNE supports streaming output:
 
 ```ts file="../../docs-examples/test/quick-start.test.ts" region="example-quick-start-streaming" exclude_imports
-const stream = await aigne.invoke(agent, "What is AIGNE?", { streaming: true });
+const stream = await aigne.invoke(
+  agent,
+  { message: "What is AIGNE?" },
+  { streaming: true },
+);
 
 let response = "";
 for await (const chunk of stream) {
   console.log(chunk);
-  if (isAgentResponseDelta(chunk) && chunk.delta.text?.$message)
-    response += chunk.delta.text.$message;
+  if (isAgentResponseDelta(chunk) && chunk.delta.text?.message)
+    response += chunk.delta.text.message;
 }
 console.log(response);
 // Output:  "AIGNE is a platform for building AI agents."
@@ -149,19 +154,24 @@ const aigne = new AIGNE({
 
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant",
+  inputKey: "message",
 });
 
-const result = await aigne.invoke(agent, "What is AIGNE?");
+const result = await aigne.invoke(agent, { message: "What is AIGNE?" });
 console.log(result);
-// Output: { $message: "AIGNE is a platform for building AI agents." }
+// Output: { message: "AIGNE is a platform for building AI agents." }
 
-const stream = await aigne.invoke(agent, "What is AIGNE?", { streaming: true });
+const stream = await aigne.invoke(
+  agent,
+  { message: "What is AIGNE?" },
+  { streaming: true },
+);
 
 let response = "";
 for await (const chunk of stream) {
   console.log(chunk);
-  if (isAgentResponseDelta(chunk) && chunk.delta.text?.$message)
-    response += chunk.delta.text.$message;
+  if (isAgentResponseDelta(chunk) && chunk.delta.text?.message)
+    response += chunk.delta.text.message;
 }
 console.log(response);
 // Output:  "AIGNE is a platform for building AI agents."

--- a/docs/getting-started/quick-start.zh.md
+++ b/docs/getting-started/quick-start.zh.md
@@ -74,6 +74,7 @@ const aigne = new AIGNE({
 ```ts file="../../docs-examples/test/quick-start.test.ts" region="example-quick-start-create-agent" exclude_imports
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant",
+  inputKey: "message",
 });
 ```
 
@@ -90,9 +91,9 @@ const agent = AIAgent.from({
 现在我们可以调用 Agent 来处理用户的请求：
 
 ```ts file="../../docs-examples/test/quick-start.test.ts" region="example-quick-start-invoke" exclude_imports
-const result = await aigne.invoke(agent, "What is AIGNE?");
+const result = await aigne.invoke(agent, { message: "What is AIGNE?" });
 console.log(result);
-// Output: { $message: "AIGNE is a platform for building AI agents." }
+// Output: { message: "AIGNE is a platform for building AI agents." }
 ```
 
 这段代码：
@@ -109,13 +110,17 @@ console.log(result);
 对于长回答或需要实时显示生成内容的场景，AIGNE 支持流式输出：
 
 ```ts file="../../docs-examples/test/quick-start.test.ts" region="example-quick-start-streaming" exclude_imports
-const stream = await aigne.invoke(agent, "What is AIGNE?", { streaming: true });
+const stream = await aigne.invoke(
+  agent,
+  { message: "What is AIGNE?" },
+  { streaming: true },
+);
 
 let response = "";
 for await (const chunk of stream) {
   console.log(chunk);
-  if (isAgentResponseDelta(chunk) && chunk.delta.text?.$message)
-    response += chunk.delta.text.$message;
+  if (isAgentResponseDelta(chunk) && chunk.delta.text?.message)
+    response += chunk.delta.text.message;
 }
 console.log(response);
 // Output:  "AIGNE is a platform for building AI agents."
@@ -147,19 +152,24 @@ const aigne = new AIGNE({
 
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant",
+  inputKey: "message",
 });
 
-const result = await aigne.invoke(agent, "What is AIGNE?");
+const result = await aigne.invoke(agent, { message: "What is AIGNE?" });
 console.log(result);
-// Output: { $message: "AIGNE is a platform for building AI agents." }
+// Output: { message: "AIGNE is a platform for building AI agents." }
 
-const stream = await aigne.invoke(agent, "What is AIGNE?", { streaming: true });
+const stream = await aigne.invoke(
+  agent,
+  { message: "What is AIGNE?" },
+  { streaming: true },
+);
 
 let response = "";
 for await (const chunk of stream) {
   console.log(chunk);
-  if (isAgentResponseDelta(chunk) && chunk.delta.text?.$message)
-    response += chunk.delta.text.$message;
+  if (isAgentResponseDelta(chunk) && chunk.delta.text?.message)
+    response += chunk.delta.text.message;
 }
 console.log(response);
 // Output:  "AIGNE is a platform for building AI agents."

--- a/docs/getting-started/what-is-aigne.md
+++ b/docs/getting-started/what-is-aigne.md
@@ -14,11 +14,12 @@ const agent = AIAgent.from({
     model: "gpt-4o-mini",
   }),
   instructions: "You are a helpful assistant",
+  inputKey: "message",
 });
 
-const result = await agent.invoke("What is AIGNE?");
+const result = await agent.invoke({ message: "What is AIGNE?" });
 console.log(result);
-// Output: { $message: "AIGNE is a platform for building AI agents." }
+// Output: { message: "AIGNE is a platform for building AI agents." }
 ```
 
 ## Key Features

--- a/docs/getting-started/what-is-aigne.zh.md
+++ b/docs/getting-started/what-is-aigne.zh.md
@@ -12,11 +12,12 @@ const agent = AIAgent.from({
     model: "gpt-4o-mini",
   }),
   instructions: "You are a helpful assistant",
+  inputKey: "message",
 });
 
-const result = await agent.invoke("What is AIGNE?");
+const result = await agent.invoke({ message: "What is AIGNE?" });
 console.log(result);
-// Output: { $message: "AIGNE is a platform for building AI agents." }
+// Output: { message: "AIGNE is a platform for building AI agents." }
 ```
 
 ## 主要特性

--- a/docs/how-to-guides/add-skills-to-agent.md
+++ b/docs/how-to-guides/add-skills-to-agent.md
@@ -38,6 +38,7 @@ const ccxt = await MCPAgent.from({
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant for Crypto market cap",
   skills: [ccxt],
+  inputKey: "message",
 });
 ```
 
@@ -54,12 +55,11 @@ const agent = AIAgent.from({
 ### Invoking Agent with Skills
 
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-add-skills-to-agent-invoke-agent" exclude_imports
-const result = await aigne.invoke(
-  agent,
-  "What is the crypto price of ABT/USD on coinbase?",
-);
+const result = await aigne.invoke(agent, {
+  message: "What is the crypto price of ABT/USD on coinbase?",
+});
 console.log(result);
-// Output: { $message:"The current price of ABT/USD on Coinbase is $0.9684." }
+// Output: { message:"The current price of ABT/USD on Coinbase is $0.9684." }
 ```
 
 **Explanation**:
@@ -92,14 +92,14 @@ const ccxt = await MCPAgent.from({
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant for Crypto market cap",
   skills: [ccxt],
+  inputKey: "message",
 });
 
-const result = await aigne.invoke(
-  agent,
-  "What is the crypto price of ABT/USD on coinbase?",
-);
+const result = await aigne.invoke(agent, {
+  message: "What is the crypto price of ABT/USD on coinbase?",
+});
 console.log(result);
-// Output: { $message:"The current price of ABT/USD on Coinbase is $0.9684." }
+// Output: { message:"The current price of ABT/USD on Coinbase is $0.9684." }
 ```
 
 ## Tips

--- a/docs/how-to-guides/add-skills-to-agent.zh.md
+++ b/docs/how-to-guides/add-skills-to-agent.zh.md
@@ -36,6 +36,7 @@ const ccxt = await MCPAgent.from({
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant for Crypto market cap",
   skills: [ccxt],
+  inputKey: "message",
 });
 ```
 
@@ -52,12 +53,11 @@ const agent = AIAgent.from({
 ### 调用带有技能的 Agent
 
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-add-skills-to-agent-invoke-agent" exclude_imports
-const result = await aigne.invoke(
-  agent,
-  "What is the crypto price of ABT/USD on coinbase?",
-);
+const result = await aigne.invoke(agent, {
+  message: "What is the crypto price of ABT/USD on coinbase?",
+});
 console.log(result);
-// Output: { $message:"The current price of ABT/USD on Coinbase is $0.9684." }
+// Output: { message:"The current price of ABT/USD on Coinbase is $0.9684." }
 ```
 
 **说明**：
@@ -90,14 +90,14 @@ const ccxt = await MCPAgent.from({
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant for Crypto market cap",
   skills: [ccxt],
+  inputKey: "message",
 });
 
-const result = await aigne.invoke(
-  agent,
-  "What is the crypto price of ABT/USD on coinbase?",
-);
+const result = await aigne.invoke(agent, {
+  message: "What is the crypto price of ABT/USD on coinbase?",
+});
 console.log(result);
-// Output: { $message:"The current price of ABT/USD on Coinbase is $0.9684." }
+// Output: { message:"The current price of ABT/USD on Coinbase is $0.9684." }
 ```
 
 ## 提示

--- a/docs/how-to-guides/build-your-first-agent.md
+++ b/docs/how-to-guides/build-your-first-agent.md
@@ -51,6 +51,7 @@ Key points of this step:
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-build-first-agent-create-agent" exclude_imports
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant for Crypto market cap",
+  inputKey: "message",
 });
 ```
 
@@ -64,9 +65,9 @@ In this concise yet powerful configuration:
 ### Use Agent to Process User Input
 
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-build-first-agent-invoke-agent" exclude_imports
-const result = await aigne.invoke(agent, "What is crypto?");
+const result = await aigne.invoke(agent, { message: "What is crypto?" });
 console.log(result);
-// Output: { $message: "Cryptocurrency, often referred to as crypto, is a type of digital or virtual currency that uses cryptography for security" }
+// Output: { message: "Cryptocurrency, often referred to as crypto, is a type of digital or virtual currency that uses cryptography for security" }
 ```
 
 This invocation process demonstrates:
@@ -93,11 +94,12 @@ const aigne = new AIGNE({
 
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant for Crypto market cap",
+  inputKey: "message",
 });
 
-const result = await aigne.invoke(agent, "What is crypto?");
+const result = await aigne.invoke(agent, { message: "What is crypto?" });
 console.log(result);
-// Output: { $message: "Cryptocurrency, often referred to as crypto, is a type of digital or virtual currency that uses cryptography for security" }
+// Output: { message: "Cryptocurrency, often referred to as crypto, is a type of digital or virtual currency that uses cryptography for security" }
 ```
 
 ## Tips

--- a/docs/how-to-guides/build-your-first-agent.zh.md
+++ b/docs/how-to-guides/build-your-first-agent.zh.md
@@ -49,6 +49,7 @@ const aigne = new AIGNE({
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-build-first-agent-create-agent" exclude_imports
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant for Crypto market cap",
+  inputKey: "message",
 });
 ```
 
@@ -62,9 +63,9 @@ const agent = AIAgent.from({
 ### 使用 Agent 处理用户输入
 
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-build-first-agent-invoke-agent" exclude_imports
-const result = await aigne.invoke(agent, "What is crypto?");
+const result = await aigne.invoke(agent, { message: "What is crypto?" });
 console.log(result);
-// Output: { $message: "Cryptocurrency, often referred to as crypto, is a type of digital or virtual currency that uses cryptography for security" }
+// Output: { message: "Cryptocurrency, often referred to as crypto, is a type of digital or virtual currency that uses cryptography for security" }
 ```
 
 这个调用过程展示了：
@@ -91,11 +92,12 @@ const aigne = new AIGNE({
 
 const agent = AIAgent.from({
   instructions: "You are a helpful assistant for Crypto market cap",
+  inputKey: "message",
 });
 
-const result = await aigne.invoke(agent, "What is crypto?");
+const result = await aigne.invoke(agent, { message: "What is crypto?" });
 console.log(result);
-// Output: { $message: "Cryptocurrency, often referred to as crypto, is a type of digital or virtual currency that uses cryptography for security" }
+// Output: { message: "Cryptocurrency, often referred to as crypto, is a type of digital or virtual currency that uses cryptography for security" }
 ```
 
 ## 提示

--- a/docs/how-to-guides/custom-user-context.md
+++ b/docs/how-to-guides/custom-user-context.md
@@ -24,6 +24,7 @@ const agent = AIAgent.from({
       getSessionId: ({ userContext }) => userContext.userId as string, // Use userId from userContext as session ID
     },
   }),
+  inputKey: "message",
 });
 ```
 
@@ -39,13 +40,13 @@ const agent = AIAgent.from({
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-custom-user-context-invoke-agent" exclude_imports
 const result = await aigne.invoke(
   agent,
-  "My name is John Doe and I like to invest in Bitcoin.",
+  { message: "My name is John Doe and I like to invest in Bitcoin." },
   {
     userContext: { userId: "user_123" },
   },
 );
 console.log(result);
-// Output: { $message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
+// Output: { message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
 ```
 
 **Explanation**:
@@ -77,17 +78,18 @@ const agent = AIAgent.from({
       getSessionId: ({ userContext }) => userContext.userId as string, // Use userId from userContext as session ID
     },
   }),
+  inputKey: "message",
 });
 
 const result = await aigne.invoke(
   agent,
-  "My name is John Doe and I like to invest in Bitcoin.",
+  { message: "My name is John Doe and I like to invest in Bitcoin." },
   {
     userContext: { userId: "user_123" },
   },
 );
 console.log(result);
-// Output: { $message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
+// Output: { message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
 ```
 
 ## Best Practices

--- a/docs/how-to-guides/custom-user-context.zh.md
+++ b/docs/how-to-guides/custom-user-context.zh.md
@@ -22,6 +22,7 @@ const agent = AIAgent.from({
       getSessionId: ({ userContext }) => userContext.userId as string, // Use userId from userContext as session ID
     },
   }),
+  inputKey: "message",
 });
 ```
 
@@ -37,13 +38,13 @@ const agent = AIAgent.from({
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-custom-user-context-invoke-agent" exclude_imports
 const result = await aigne.invoke(
   agent,
-  "My name is John Doe and I like to invest in Bitcoin.",
+  { message: "My name is John Doe and I like to invest in Bitcoin." },
   {
     userContext: { userId: "user_123" },
   },
 );
 console.log(result);
-// Output: { $message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
+// Output: { message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
 ```
 
 **说明**：
@@ -75,17 +76,18 @@ const agent = AIAgent.from({
       getSessionId: ({ userContext }) => userContext.userId as string, // Use userId from userContext as session ID
     },
   }),
+  inputKey: "message",
 });
 
 const result = await aigne.invoke(
   agent,
-  "My name is John Doe and I like to invest in Bitcoin.",
+  { message: "My name is John Doe and I like to invest in Bitcoin." },
   {
     userContext: { userId: "user_123" },
   },
 );
 console.log(result);
-// Output: { $message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
+// Output: { message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
 ```
 
 ## 最佳实践

--- a/docs/how-to-guides/enable-memory-for-agent.md
+++ b/docs/how-to-guides/enable-memory-for-agent.md
@@ -28,6 +28,7 @@ const agent = AIAgent.from({
       url: `file:${memoryStoragePath}`, // Path to store memory data, such as 'file:./memory.db'
     },
   }),
+  inputKey: "message",
 });
 ```
 
@@ -40,12 +41,11 @@ const agent = AIAgent.from({
 ### First Round of Conversation - Provide Personal Information
 
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-enable-memory-for-agent-invoke-agent-1" exclude_imports
-const result1 = await aigne.invoke(
-  agent,
-  "My name is John Doe and I like to invest in Bitcoin.",
-);
+const result1 = await aigne.invoke(agent, {
+  message: "My name is John Doe and I like to invest in Bitcoin.",
+});
 console.log(result1);
-// Output: { $message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
+// Output: { message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
 ```
 
 **Explanation**:
@@ -59,12 +59,11 @@ console.log(result1);
 ### Second Round of Conversation - Test Memory Capability
 
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-enable-memory-for-agent-invoke-agent-2" exclude_imports
-const result2 = await aigne.invoke(
-  agent,
-  "What is my favorite cryptocurrency?",
-);
+const result2 = await aigne.invoke(agent, {
+  message: "What is my favorite cryptocurrency?",
+});
 console.log(result2);
-// Output: { $message: "Your favorite cryptocurrency is Bitcoin." }
+// Output: { message: "Your favorite cryptocurrency is Bitcoin." }
 ```
 
 **Explanation**:
@@ -78,9 +77,11 @@ console.log(result2);
 ### Third Round of Conversation - Add More Information
 
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-enable-memory-for-agent-invoke-agent-3" exclude_imports
-const result3 = await aigne.invoke(agent, "I've invested $5000 in Ethereum.");
+const result3 = await aigne.invoke(agent, {
+  message: "I've invested $5000 in Ethereum.",
+});
 console.log(result3);
-// Output: { $message: "Got it, you've invested $5000 in Ethereum! That's a good investment. If there's anything else you'd like to share about your crypto portfolio or have questions, feel free!" }
+// Output: { message: "Got it, you've invested $5000 in Ethereum! That's a good investment. If there's anything else you'd like to share about your crypto portfolio or have questions, feel free!" }
 ```
 
 **Explanation**:
@@ -94,12 +95,11 @@ console.log(result3);
 ### Fourth Round of Conversation - Further Test Memory Capability
 
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-enable-memory-for-agent-invoke-agent-4" exclude_imports
-const result4 = await aigne.invoke(
-  agent,
-  "How much have I invested in Ethereum?",
-);
+const result4 = await aigne.invoke(agent, {
+  message: "How much have I invested in Ethereum?",
+});
 console.log(result4);
-// Output: { $message: "You've invested $5000 in Ethereum." }
+// Output: { message: "You've invested $5000 in Ethereum." }
 ```
 
 **Explanation**:
@@ -130,32 +130,32 @@ const agent = AIAgent.from({
       url: `file:${memoryStoragePath}`, // Path to store memory data, such as 'file:./memory.db'
     },
   }),
+  inputKey: "message",
 });
 
-const result1 = await aigne.invoke(
-  agent,
-  "My name is John Doe and I like to invest in Bitcoin.",
-);
+const result1 = await aigne.invoke(agent, {
+  message: "My name is John Doe and I like to invest in Bitcoin.",
+});
 console.log(result1);
-// Output: { $message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
+// Output: { message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
 
-const result2 = await aigne.invoke(
-  agent,
-  "What is my favorite cryptocurrency?",
-);
+const result2 = await aigne.invoke(agent, {
+  message: "What is my favorite cryptocurrency?",
+});
 console.log(result2);
-// Output: { $message: "Your favorite cryptocurrency is Bitcoin." }
+// Output: { message: "Your favorite cryptocurrency is Bitcoin." }
 
-const result3 = await aigne.invoke(agent, "I've invested $5000 in Ethereum.");
+const result3 = await aigne.invoke(agent, {
+  message: "I've invested $5000 in Ethereum.",
+});
 console.log(result3);
-// Output: { $message: "Got it, you've invested $5000 in Ethereum! That's a good investment. If there's anything else you'd like to share about your crypto portfolio or have questions, feel free!" }
+// Output: { message: "Got it, you've invested $5000 in Ethereum! That's a good investment. If there's anything else you'd like to share about your crypto portfolio or have questions, feel free!" }
 
-const result4 = await aigne.invoke(
-  agent,
-  "How much have I invested in Ethereum?",
-);
+const result4 = await aigne.invoke(agent, {
+  message: "How much have I invested in Ethereum?",
+});
 console.log(result4);
-// Output: { $message: "You've invested $5000 in Ethereum." }
+// Output: { message: "You've invested $5000 in Ethereum." }
 ```
 
 ## How Memory Functionality Works

--- a/docs/how-to-guides/enable-memory-for-agent.zh.md
+++ b/docs/how-to-guides/enable-memory-for-agent.zh.md
@@ -26,6 +26,7 @@ const agent = AIAgent.from({
       url: `file:${memoryStoragePath}`, // Path to store memory data, such as 'file:./memory.db'
     },
   }),
+  inputKey: "message",
 });
 ```
 
@@ -38,12 +39,11 @@ const agent = AIAgent.from({
 ### 第一轮对话 - 提供个人信息
 
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-enable-memory-for-agent-invoke-agent-1" exclude_imports
-const result1 = await aigne.invoke(
-  agent,
-  "My name is John Doe and I like to invest in Bitcoin.",
-);
+const result1 = await aigne.invoke(agent, {
+  message: "My name is John Doe and I like to invest in Bitcoin.",
+});
 console.log(result1);
-// Output: { $message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
+// Output: { message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
 ```
 
 **说明**：
@@ -57,12 +57,11 @@ console.log(result1);
 ### 第二轮对话 - 测试记忆能力
 
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-enable-memory-for-agent-invoke-agent-2" exclude_imports
-const result2 = await aigne.invoke(
-  agent,
-  "What is my favorite cryptocurrency?",
-);
+const result2 = await aigne.invoke(agent, {
+  message: "What is my favorite cryptocurrency?",
+});
 console.log(result2);
-// Output: { $message: "Your favorite cryptocurrency is Bitcoin." }
+// Output: { message: "Your favorite cryptocurrency is Bitcoin." }
 ```
 
 **说明**：
@@ -76,9 +75,11 @@ console.log(result2);
 ### 第三轮对话 - 添加更多信息
 
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-enable-memory-for-agent-invoke-agent-3" exclude_imports
-const result3 = await aigne.invoke(agent, "I've invested $5000 in Ethereum.");
+const result3 = await aigne.invoke(agent, {
+  message: "I've invested $5000 in Ethereum.",
+});
 console.log(result3);
-// Output: { $message: "Got it, you've invested $5000 in Ethereum! That's a good investment. If there's anything else you'd like to share about your crypto portfolio or have questions, feel free!" }
+// Output: { message: "Got it, you've invested $5000 in Ethereum! That's a good investment. If there's anything else you'd like to share about your crypto portfolio or have questions, feel free!" }
 ```
 
 **说明**：
@@ -92,12 +93,11 @@ console.log(result3);
 ### 第四轮对话 - 进一步测试记忆能力
 
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-enable-memory-for-agent-invoke-agent-4" exclude_imports
-const result4 = await aigne.invoke(
-  agent,
-  "How much have I invested in Ethereum?",
-);
+const result4 = await aigne.invoke(agent, {
+  message: "How much have I invested in Ethereum?",
+});
 console.log(result4);
-// Output: { $message: "You've invested $5000 in Ethereum." }
+// Output: { message: "You've invested $5000 in Ethereum." }
 ```
 
 **说明**：
@@ -128,32 +128,32 @@ const agent = AIAgent.from({
       url: `file:${memoryStoragePath}`, // Path to store memory data, such as 'file:./memory.db'
     },
   }),
+  inputKey: "message",
 });
 
-const result1 = await aigne.invoke(
-  agent,
-  "My name is John Doe and I like to invest in Bitcoin.",
-);
+const result1 = await aigne.invoke(agent, {
+  message: "My name is John Doe and I like to invest in Bitcoin.",
+});
 console.log(result1);
-// Output: { $message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
+// Output: { message: "Nice to meet you, John Doe! Bitcoin is an interesting cryptocurrency to invest in. How long have you been investing in crypto? Do you have a diversified portfolio?" }
 
-const result2 = await aigne.invoke(
-  agent,
-  "What is my favorite cryptocurrency?",
-);
+const result2 = await aigne.invoke(agent, {
+  message: "What is my favorite cryptocurrency?",
+});
 console.log(result2);
-// Output: { $message: "Your favorite cryptocurrency is Bitcoin." }
+// Output: { message: "Your favorite cryptocurrency is Bitcoin." }
 
-const result3 = await aigne.invoke(agent, "I've invested $5000 in Ethereum.");
+const result3 = await aigne.invoke(agent, {
+  message: "I've invested $5000 in Ethereum.",
+});
 console.log(result3);
-// Output: { $message: "Got it, you've invested $5000 in Ethereum! That's a good investment. If there's anything else you'd like to share about your crypto portfolio or have questions, feel free!" }
+// Output: { message: "Got it, you've invested $5000 in Ethereum! That's a good investment. If there's anything else you'd like to share about your crypto portfolio or have questions, feel free!" }
 
-const result4 = await aigne.invoke(
-  agent,
-  "How much have I invested in Ethereum?",
-);
+const result4 = await aigne.invoke(agent, {
+  message: "How much have I invested in Ethereum?",
+});
 console.log(result4);
-// Output: { $message: "You've invested $5000 in Ethereum." }
+// Output: { message: "You've invested $5000 in Ethereum." }
 ```
 
 ## 记忆功能的工作原理

--- a/docs/how-to-guides/enable-memory-for-client-agent.md
+++ b/docs/how-to-guides/enable-memory-for-client-agent.md
@@ -86,6 +86,7 @@ import { OpenAIChatModel } from "@aigne/openai";
 const agent = AIAgent.from({
   name: "chatbot",
   instructions: "You are a helpful assistant",
+  inputKey: "message",
 });
 
 const aigne = new AIGNE({
@@ -148,11 +149,11 @@ const chatbot = await client.getAgent({
     },
   }),
 });
-const result = await chatbot.invoke(
-  "What is the crypto price of ABT/USD on coinbase?",
-);
+const result = await chatbot.invoke({
+  message: "What is the crypto price of ABT/USD on coinbase?",
+});
 console.log(result);
-// Output: { $message: "The current price of ABT/USD on Coinbase is $0.9684." }
+// Output: { message: "The current price of ABT/USD on Coinbase is $0.9684." }
 ```
 
 **Explanation**:
@@ -165,9 +166,11 @@ console.log(result);
 ### Test Memory Capability
 
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-client-agent-memory-invoke-agent-1" exclude_imports
-const result1 = await chatbot.invoke("What question did I just ask?");
+const result1 = await chatbot.invoke({
+  message: "What question did I just ask?",
+});
 console.log(result1);
-// Output: { $message: "You just asked about the crypto price of ABT/USD on Coinbase." }
+// Output: { message: "You just asked about the crypto price of ABT/USD on Coinbase." }
 ```
 
 **Explanation**: The Agent can remember previous conversation content, proving that the memory functionality is working properly. Importantly, this memory data is stored entirely locally on the client.

--- a/docs/how-to-guides/enable-memory-for-client-agent.zh.md
+++ b/docs/how-to-guides/enable-memory-for-client-agent.zh.md
@@ -86,6 +86,7 @@ import { OpenAIChatModel } from "@aigne/openai";
 const agent = AIAgent.from({
   name: "chatbot",
   instructions: "You are a helpful assistant",
+  inputKey: "message",
 });
 
 const aigne = new AIGNE({
@@ -140,11 +141,11 @@ const chatbot = await client.getAgent({
     },
   }),
 });
-const result = await chatbot.invoke(
-  "What is the crypto price of ABT/USD on coinbase?",
-);
+const result = await chatbot.invoke({
+  message: "What is the crypto price of ABT/USD on coinbase?",
+});
 console.log(result);
-// Output: { $message: "The current price of ABT/USD on Coinbase is $0.9684." }
+// Output: { message: "The current price of ABT/USD on Coinbase is $0.9684." }
 ```
 
 **说明**：
@@ -157,9 +158,11 @@ console.log(result);
 ### 测试记忆能力
 
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-client-agent-memory-invoke-agent-1" exclude_imports
-const result1 = await chatbot.invoke("What question did I just ask?");
+const result1 = await chatbot.invoke({
+  message: "What question did I just ask?",
+});
 console.log(result1);
-// Output: { $message: "You just asked about the crypto price of ABT/USD on Coinbase." }
+// Output: { message: "You just asked about the crypto price of ABT/USD on Coinbase." }
 ```
 
 **说明**：Agent 能够记住之前的对话内容，证明记忆功能正常工作。重要的是，这些记忆数据完全存储在客户端本地。

--- a/docs/how-to-guides/serve-agent-as-api.md
+++ b/docs/how-to-guides/serve-agent-as-api.md
@@ -35,6 +35,7 @@ const agent = AIAgent.from({
       getSessionId: ({ userContext }) => userContext.userId as string, // Use userId from userContext as session ID
     },
   }),
+  inputKey: "message",
 });
 ```
 
@@ -114,6 +115,7 @@ const agent = AIAgent.from({
       getSessionId: ({ userContext }) => userContext.userId as string, // Use userId from userContext as session ID
     },
   }),
+  inputKey: "message",
 });
 
 const aigne = new AIGNE({
@@ -158,11 +160,11 @@ const client = new AIGNEHTTPClient({
 
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-aigne-http-client-invoke-agent" exclude_imports
 const chatbot = await client.getAgent({ name: "chatbot" });
-const result = await chatbot.invoke(
-  "What is the crypto price of ABT/USD on coinbase?",
-);
+const result = await chatbot.invoke({
+  message: "What is the crypto price of ABT/USD on coinbase?",
+});
 console.log(result);
-// Output: { $message: "The current price of ABT/USD on Coinbase is $0.9684." }
+// Output: { message: "The current price of ABT/USD on Coinbase is $0.9684." }
 ```
 
 **Explanation**:
@@ -187,9 +189,9 @@ const client = new AIGNEHTTPClient({
 });
 
 const chatbot = await client.getAgent({ name: "chatbot" });
-const result = await chatbot.invoke(
-  "What is the crypto price of ABT/USD on coinbase?",
-);
+const result = await chatbot.invoke({
+  message: "What is the crypto price of ABT/USD on coinbase?",
+});
 console.log(result);
-// Output: { $message: "The current price of ABT/USD on Coinbase is $0.9684." }
+// Output: { message: "The current price of ABT/USD on Coinbase is $0.9684." }
 ```

--- a/docs/how-to-guides/serve-agent-as-api.zh.md
+++ b/docs/how-to-guides/serve-agent-as-api.zh.md
@@ -33,6 +33,7 @@ const agent = AIAgent.from({
       getSessionId: ({ userContext }) => userContext.userId as string, // Use userId from userContext as session ID
     },
   }),
+  inputKey: "message",
 });
 ```
 
@@ -112,6 +113,7 @@ const agent = AIAgent.from({
       getSessionId: ({ userContext }) => userContext.userId as string, // Use userId from userContext as session ID
     },
   }),
+  inputKey: "message",
 });
 
 const aigne = new AIGNE({
@@ -156,11 +158,11 @@ const client = new AIGNEHTTPClient({
 
 ```ts file="../../docs-examples/test/build-first-agent.test.ts" region="example-aigne-http-client-invoke-agent" exclude_imports
 const chatbot = await client.getAgent({ name: "chatbot" });
-const result = await chatbot.invoke(
-  "What is the crypto price of ABT/USD on coinbase?",
-);
+const result = await chatbot.invoke({
+  message: "What is the crypto price of ABT/USD on coinbase?",
+});
 console.log(result);
-// Output: { $message: "The current price of ABT/USD on Coinbase is $0.9684." }
+// Output: { message: "The current price of ABT/USD on Coinbase is $0.9684." }
 ```
 
 **说明**：
@@ -185,9 +187,9 @@ const client = new AIGNEHTTPClient({
 });
 
 const chatbot = await client.getAgent({ name: "chatbot" });
-const result = await chatbot.invoke(
-  "What is the crypto price of ABT/USD on coinbase?",
-);
+const result = await chatbot.invoke({
+  message: "What is the crypto price of ABT/USD on coinbase?",
+});
 console.log(result);
-// Output: { $message: "The current price of ABT/USD on Coinbase is $0.9684." }
+// Output: { message: "The current price of ABT/USD on Coinbase is $0.9684." }
 ```

--- a/examples/browser/browser.test.ts
+++ b/examples/browser/browser.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert";
 import { exists, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { DefaultMemory } from "@aigne/agent-library/default-memory/index.js";
-import { AIAgent, AIGNE } from "@aigne/core";
+import { AIAgent, AIGNE, type Message } from "@aigne/core";
 import { stringToAgentResponseStream } from "@aigne/core/utils/stream-utils.js";
 import { OpenAIChatModel } from "@aigne/openai";
 import type {
@@ -44,11 +44,11 @@ test.each<Readonly<[AIGNEHTTPClientInvokeOptions, string, BrowserType]>>(
       page,
       aigneURL,
       agentName: "chatbot",
-      input: "Hello, AIGNE!",
+      input: { message: "Hello, AIGNE!" },
     });
 
     expect(result).toEqual({
-      $message: "Hello, How can I help you?",
+      message: "Hello, How can I help you?",
     });
 
     await browser.close();
@@ -71,10 +71,10 @@ test("AIGNE HTTP Client should work with client memory in browser", async () => 
     page,
     aigneURL,
     agentName: "chatbot",
-    input: "Hello, AIGNE!",
+    input: { message: "Hello, AIGNE!" },
   });
   expect(result).toEqual({
-    $message: "Hello, How can I help you?",
+    message: "Hello, How can I help you?",
   });
 
   const modelProcess = spyOn(aigne.model, "process").mockReturnValueOnce(
@@ -84,10 +84,10 @@ test("AIGNE HTTP Client should work with client memory in browser", async () => 
     page,
     aigneURL,
     agentName: "chatbot",
-    input: "What did I just say?",
+    input: { message: "What did I just say?" },
   });
   expect(result2).toEqual({
-    $message: 'You just said, "Hello, AIGNE!"',
+    message: 'You just said, "Hello, AIGNE!"',
   });
   expect(modelProcess).toHaveBeenLastCalledWith(
     expect.objectContaining({
@@ -119,6 +119,7 @@ async function startServer() {
   const agent = AIAgent.from({
     name: "chatbot",
     memory: [],
+    inputKey: "message",
   });
 
   const aigne = new AIGNE({
@@ -181,7 +182,7 @@ async function runAgentInBrowser({
   page: Page;
   aigneURL: string;
   agentName: string;
-  input: string;
+  input: Message;
   streaming?: boolean;
 }) {
   const result = await page.evaluate(
@@ -190,7 +191,7 @@ async function runAgentInBrowser({
       url,
       input,
       streaming,
-    }: { agentName: string; url: string; input: string; streaming?: boolean }) => {
+    }: { agentName: string; url: string; input: Message; streaming?: boolean }) => {
       const g = globalThis as unknown as typeof import("@aigne/core") & {
         AIGNEHTTPClient: typeof AIGNEHTTPClient;
         DefaultMemory: typeof DefaultMemory;

--- a/examples/mcp-github/usages.ts
+++ b/examples/mcp-github/usages.ts
@@ -36,32 +36,30 @@ You can perform various GitHub operations like:
 
 Always provide clear, concise responses with relevant information from GitHub.
 `,
+  inputKey: "message",
 });
 
 // Example 1: Search for repositories
 console.log("Example 1: Searching for repositories");
-const searchResult = await aigne.invoke(
-  agent,
-  "Search for repositories related to 'modelcontextprotocol' and limit to 3 results",
-);
+const searchResult = await aigne.invoke(agent, {
+  message: "Search for repositories related to 'modelcontextprotocol' and limit to 3 results",
+});
 console.log(searchResult);
 console.log("\n------------------------\n");
 
 // Example 2: Get file contents
 console.log("Example 2: Getting file contents");
-const fileResult = await aigne.invoke(
-  agent,
-  "Get the content of README.md from modelcontextprotocol/servers repository",
-);
+const fileResult = await aigne.invoke(agent, {
+  message: "Get the content of README.md from modelcontextprotocol/servers repository",
+});
 console.log(fileResult);
 console.log("\n------------------------\n");
 
 // Example 3: List commits
 console.log("Example 3: Listing commits");
-const commitsResult = await aigne.invoke(
-  agent,
-  "List the latest 3 commits from the modelcontextprotocol/servers repository",
-);
+const commitsResult = await aigne.invoke(agent, {
+  message: "List the latest 3 commits from the modelcontextprotocol/servers repository",
+});
 console.log(commitsResult);
 
 await aigne.shutdown();

--- a/examples/mcp-puppeteer/usages.ts
+++ b/examples/mcp-puppeteer/usages.ts
@@ -27,14 +27,17 @@ const agent = AIAgent.from({
 2. evaluate document.body.innerText to get the content
 `,
   memory: new DefaultMemory(),
+  inputKey: "message",
 });
 
-const result = await aigne.invoke(agent, "extract content from https://www.arcblock.io");
+const result = await aigne.invoke(agent, {
+  message: "extract content from https://www.arcblock.io",
+});
 
 console.log(result);
 // output:
 // {
-//   $message: "The content extracted from the website [ArcBlock](https://www.arcblock.io) is as follows:\n\n---\n\n**Redefining Software Architect and Ecosystems**\n\nA total solution for building decentralized applications ...",
+//   message: "The content extracted from the website [ArcBlock](https://www.arcblock.io) is as follows:\n\n---\n\n**Redefining Software Architect and Ecosystems**\n\nA total solution for building decentralized applications ...",
 // }
 
 await aigne.shutdown();

--- a/examples/mcp-sqlite/usages.ts
+++ b/examples/mcp-sqlite/usages.ts
@@ -24,26 +24,29 @@ const aigne = new AIGNE({
 const agent = AIAgent.from({
   instructions: "You are a database administrator",
   memory: new DefaultMemory(),
+  inputKey: "message",
 });
 
 console.log(
-  await aigne.invoke(agent, "create a product table with columns name description and createdAt"),
+  await aigne.invoke(agent, {
+    message: "create a product table with columns name description and createdAt",
+  }),
 );
 // output:
 // {
-//   $message: "The product table has been created successfully with the columns: `name`, `description`, and `createdAt`.",
+//   message: "The product table has been created successfully with the columns: `name`, `description`, and `createdAt`.",
 // }
 
-console.log(await aigne.invoke(agent, "create 10 products for test"));
+console.log(await aigne.invoke(agent, { message: "create 10 products for test" }));
 // output:
 // {
-//   $message: "I have successfully created 10 test products in the database. Here are the products that were added:\n\n1. Product 1: $10.99 - Description for Product 1\n2. Product 2: $15.99 - Description for Product 2\n3. Product 3: $20.99 - Description for Product 3\n4. Product 4: $25.99 - Description for Product 4\n5. Product 5: $30.99 - Description for Product 5\n6. Product 6: $35.99 - Description for Product 6\n7. Product 7: $40.99 - Description for Product 7\n8. Product 8: $45.99 - Description for Product 8\n9. Product 9: $50.99 - Description for Product 9\n10. Product 10: $55.99 - Description for Product 10\n\nIf you need any further assistance or operations, feel free to ask!",
+//   message: "I have successfully created 10 test products in the database. Here are the products that were added:\n\n1. Product 1: $10.99 - Description for Product 1\n2. Product 2: $15.99 - Description for Product 2\n3. Product 3: $20.99 - Description for Product 3\n4. Product 4: $25.99 - Description for Product 4\n5. Product 5: $30.99 - Description for Product 5\n6. Product 6: $35.99 - Description for Product 6\n7. Product 7: $40.99 - Description for Product 7\n8. Product 8: $45.99 - Description for Product 8\n9. Product 9: $50.99 - Description for Product 9\n10. Product 10: $55.99 - Description for Product 10\n\nIf you need any further assistance or operations, feel free to ask!",
 // }
 
-console.log(await aigne.invoke(agent, "how many products?"));
+console.log(await aigne.invoke(agent, { message: "how many products?" }));
 // output:
 // {
-//   $message: "There are 10 products in the database.",
+//   message: "There are 10 products in the database.",
 // }
 
 await aigne.shutdown();

--- a/examples/workflow-code-execution/usages.ts
+++ b/examples/workflow-code-execution/usages.ts
@@ -31,13 +31,14 @@ You are a proficient coder. You write code to solve problems.
 Work with the sandbox to execute your code.
 `,
   skills: [sandbox],
+  inputKey: "message",
 });
 
 const aigne = new AIGNE({ model });
 
-const result = await aigne.invoke(coder, "10! = ?");
+const result = await aigne.invoke(coder, { message: "10! = ?" });
 console.log(result);
 // Output:
 // {
-//   $message: "The value of \\(10!\\) (10 factorial) is 3,628,800.",
+//   message: "The value of \\(10!\\) (10 factorial) is 3,628,800.",
 // }

--- a/examples/workflow-group-chat/index.ts
+++ b/examples/workflow-group-chat/index.ts
@@ -10,8 +10,6 @@ import {
   FunctionAgent,
   PromptTemplate,
   UserAgent,
-  createMessage,
-  getMessage,
 } from "@aigne/core";
 import { OpenAIChatModel } from "@aigne/openai";
 import inquirer from "inquirer";
@@ -37,6 +35,7 @@ const writer = AIAgent.from({
   publishTopic: DEFAULT_TOPIC,
   memory: new DefaultMemory({ subscribeTopic: DEFAULT_TOPIC }),
   instructions: "You are a Writer. You produce good work.",
+  inputKey: "message",
 });
 
 const editor = AIAgent.from({
@@ -48,6 +47,7 @@ const editor = AIAgent.from({
 You are an Editor. Plan and guide the task given by the user.
 Provide critical feedbacks to the draft and illustration produced by Writer and Illustrator.
 Approve if the task is completed and the draft and illustration meets user's requirements.`,
+  inputKey: "message",
 });
 
 const generateImage = FunctionAgent.from({
@@ -83,6 +83,7 @@ Make sure the images have consistent characters and style.`,
       )
       .describe("The images created by the illustrator"),
   }),
+  inputKey: "message",
 });
 
 let isFirstQuestion = true;
@@ -105,7 +106,7 @@ const user = UserAgent.from({
       },
     ]);
     isFirstQuestion = false;
-    return createMessage(question);
+    return { message: question };
   },
 });
 
@@ -137,6 +138,7 @@ const manager = AIAgent.from({
       .union(assertZodUnionArray(roles.map((i) => z.literal(i.topic))))
       .describe("The next role to play"),
   }),
+  inputKey: "message",
 });
 
 aigne.addAgent(user, writer, editor, illustrator, manager);
@@ -145,7 +147,7 @@ aigne.subscribe(DEFAULT_TOPIC, (message) => {
   console.log(
     "------------- Received message -------------\n",
     `${message.source}:`,
-    getMessage(message.message) || message.message,
+    message.message.message || message.message,
     "\n--------------------------------------------",
   );
 });

--- a/examples/workflow-handoff/usages.ts
+++ b/examples/workflow-handoff/usages.ts
@@ -18,26 +18,28 @@ const agentA = AIAgent.from({
   instructions: "You are a helpful agent.",
   outputKey: "A",
   skills: [transferToB],
+  inputKey: "message",
 });
 
 const agentB = AIAgent.from({
   name: "AgentB",
   instructions: "Only speak in Haikus.",
   outputKey: "B",
+  inputKey: "message",
 });
 
 const aigne = new AIGNE({ model });
 
 const userAgent = aigne.invoke(agentA);
 
-const result1 = await userAgent.invoke("transfer to agent b");
+const result1 = await userAgent.invoke({ message: "transfer to agent b" });
 console.log(result1);
 // Output:
 // {
 //   B: "Transfer now complete,  \nAgent B is here to help.  \nWhat do you need, friend?",
 // }
 
-const result2 = await userAgent.invoke("It's a beautiful day");
+const result2 = await userAgent.invoke({ message: "It's a beautiful day" });
 console.log(result2);
 // Output:
 // {

--- a/examples/workflow-orchestrator/index.ts
+++ b/examples/workflow-orchestrator/index.ts
@@ -45,12 +45,14 @@ const agent = OrchestratorAgent.from({
   skills: [finder, writer],
   maxIterations: 3,
   tasksConcurrency: 1, // puppeteer can only run one task at a time
+  inputKey: "message",
 });
 
 await runWithAIGNE(agent, {
   modelOptions: { parallelToolCalls: false },
   chatLoopOptions: {
     welcome: "Welcome to the Orchestrator Agent!",
+    inputKey: "message",
     defaultQuestion: `\
   Conduct an in-depth research on ArcBlock using only the official website\
   (avoid search engines or third-party sources) and compile a detailed report saved as arcblock.md. \

--- a/examples/workflow-orchestrator/usage.ts
+++ b/examples/workflow-orchestrator/usage.ts
@@ -54,20 +54,20 @@ const agent = OrchestratorAgent.from({
   skills: [finder, writer],
   maxIterations: 3,
   tasksConcurrency: 1, // puppeteer can only run one task at a time
+  inputKey: "message",
 });
 
 const aigne = new AIGNE({ model });
 
-const result = await aigne.invoke(
-  agent,
-  `\
+const result = await aigne.invoke(agent, {
+  message: `\
 Conduct an in-depth research on ArcBlock using only the official website\
 (avoid search engines or third-party sources) and compile a detailed report saved as arcblock.md. \
 The report should include comprehensive insights into the company's products \
 (with detailed research findings and links), technical architecture, and future plans.`,
-);
+});
 console.log(result);
 // Output:
 // {
-//   $message: "The objective of conducting in-depth research on ArcBlock using only the official website has been successfully completed...",
+//   message: "The objective of conducting in-depth research on ArcBlock using only the official website has been successfully completed...",
 // }

--- a/examples/workflow-reflection/index.ts
+++ b/examples/workflow-reflection/index.ts
@@ -32,6 +32,7 @@ User's question:
   outputSchema: z.object({
     code: z.string().describe("Your code"),
   }),
+  inputKey: "message",
 });
 
 const reviewer = AIAgent.from({
@@ -78,6 +79,7 @@ await runWithAIGNE(
   },
   {
     chatLoopOptions: {
+      inputKey: "message",
       welcome: `Hello, I'm a coder with a reviewer. I can help you write code and get it reviewed.`,
       defaultQuestion: "Write a function to find the sum of all even numbers in a list.",
     },

--- a/examples/workflow-reflection/usages.ts
+++ b/examples/workflow-reflection/usages.ts
@@ -37,6 +37,7 @@ User's question:
   outputSchema: z.object({
     code: z.string().describe("Your code"),
   }),
+  inputKey: "message",
 });
 
 const reviewer = AIAgent.from({
@@ -69,7 +70,9 @@ Please review the code. If previous feedback was provided, see if it was address
 });
 
 const aigne = new AIGNE({ model, agents: [coder, reviewer] });
-aigne.publish(UserInputTopic, "Write a function to find the sum of all even numbers in a list.");
+aigne.publish(UserInputTopic, {
+  message: "Write a function to find the sum of all even numbers in a list.",
+});
 
 const { message } = await aigne.subscribe(UserOutputTopic);
 console.log(message);

--- a/examples/workflow-router/index.ts
+++ b/examples/workflow-router/index.ts
@@ -11,6 +11,7 @@ const productSupport = AIAgent.from({
   Your goal is to provide accurate and helpful information about the product.
   Be polite, professional, and ensure the user feels supported.`,
   memory: new DefaultMemory(),
+  inputKey: "message",
 });
 
 const feedback = AIAgent.from({
@@ -20,6 +21,7 @@ const feedback = AIAgent.from({
   Your goal is to listen to the user's feedback, acknowledge their input, and provide appropriate responses.
   Be empathetic, understanding, and ensure the user feels heard.`,
   memory: new DefaultMemory(),
+  inputKey: "message",
 });
 
 const other = AIAgent.from({
@@ -29,6 +31,7 @@ const other = AIAgent.from({
   Your goal is to provide accurate and helpful information on a wide range of topics.
   Be friendly, knowledgeable, and ensure the user feels satisfied with the information provided.`,
   memory: new DefaultMemory(),
+  inputKey: "message",
 });
 
 const triage = AIAgent.from({
@@ -39,6 +42,7 @@ You must always choose a tool — do not answer the question directly or leave t
 Be concise, accurate, and ensure efficient handoff to the correct agent.`,
   skills: [productSupport, feedback, other],
   toolChoice: AIAgentToolChoice.router,
+  inputKey: "message",
 });
 
 await runWithAIGNE(triage, {
@@ -53,5 +57,6 @@ I can help you with any questions you have, such as
 How can I assist you today?
 `,
     defaultQuestion: "How do I use this product?",
+    inputKey: "message",
   },
 });

--- a/examples/workflow-router/usages.ts
+++ b/examples/workflow-router/usages.ts
@@ -15,6 +15,7 @@ const productSupport = AIAgent.from({
   instructions: `You are an agent capable of handling any product-related questions.
   Your goal is to provide accurate and helpful information about the product.
   Be polite, professional, and ensure the user feels supported.`,
+  inputKey: "message",
   outputKey: "product_support",
 });
 
@@ -24,6 +25,7 @@ const feedback = AIAgent.from({
   instructions: `You are an agent capable of handling any feedback-related questions.
   Your goal is to listen to the user's feedback, acknowledge their input, and provide appropriate responses.
   Be empathetic, understanding, and ensure the user feels heard.`,
+  inputKey: "message",
   outputKey: "feedback",
 });
 
@@ -33,6 +35,7 @@ const other = AIAgent.from({
   instructions: `You are an agent capable of handling any general questions.
   Your goal is to provide accurate and helpful information on a wide range of topics.
   Be friendly, knowledgeable, and ensure the user feels satisfied with the information provided.`,
+  inputKey: "message",
   outputKey: "other",
 });
 
@@ -43,23 +46,24 @@ const triage = AIAgent.from({
   Be efficient, clear, and ensure the user is connected to the right resource quickly.`,
   skills: [productSupport, feedback, other],
   toolChoice: AIAgentToolChoice.router, // Set toolChoice to "router" to enable router mode
+  inputKey: "message",
 });
 
 const aigne = new AIGNE({ model });
 
-const result1 = await aigne.invoke(triage, "How to use this product?");
+const result1 = await aigne.invoke(triage, { message: "How to use this product?" });
 console.log(result1);
 // {
 //   product_support: "I’d be happy to help you with that! However, I need to know which specific product you’re referring to. Could you please provide me with the name or type of product you have in mind?",
 // }
 
-const result2 = await aigne.invoke(triage, "I have feedback about the app.");
+const result2 = await aigne.invoke(triage, { message: "I have feedback about the app." });
 console.log(result2);
 // {
 //   feedback: "Thank you for sharing your feedback! I'm here to listen. Please go ahead and let me know what you’d like to share about the app.",
 // }
 
-const result3 = await aigne.invoke(triage, "What is the weather today?");
+const result3 = await aigne.invoke(triage, { message: "What is the weather today?" });
 console.log(result3);
 // {
 //   other: "I can't provide real-time weather updates. However, you can check a reliable weather website or a weather app on your phone for the current conditions in your area. If you tell me your location, I can suggest a few sources where you can find accurate weather information!",

--- a/packages/agent-library/src/fs-memory/index.ts
+++ b/packages/agent-library/src/fs-memory/index.ts
@@ -81,7 +81,7 @@ export class FSMemory extends MemoryAgent {
 }
 
 interface FSMemoryRetrieverOptions
-  extends AIAgentOptions<FSMemoryRetrieverAgentInput, FSMemoryRetrieverAgentOutput> {
+  extends AIAgentOptions<any, FSMemoryRetrieverAgentInput, FSMemoryRetrieverAgentOutput> {
   memoryFileName: string;
 }
 
@@ -115,7 +115,7 @@ class FSMemoryRetriever extends MemoryRetriever {
     });
   }
 
-  agent: AIAgent<FSMemoryRetrieverAgentInput, FSMemoryRetrieverAgentOutput>;
+  agent: AIAgent<any, FSMemoryRetrieverAgentInput, FSMemoryRetrieverAgentOutput>;
 
   override async process(
     input: MemoryRetrieverInput,
@@ -136,7 +136,7 @@ class FSMemoryRetriever extends MemoryRetriever {
 }
 
 interface FSMemoryRecorderOptions
-  extends AIAgentOptions<FSMemoryRecorderAgentInput, FSMemoryRecorderAgentOutput> {
+  extends AIAgentOptions<any, FSMemoryRecorderAgentInput, FSMemoryRecorderAgentOutput> {
   memoryFileName: string;
 }
 
@@ -168,7 +168,7 @@ class FSMemoryRecorder extends MemoryRecorder {
     });
   }
 
-  agent: AIAgent<FSMemoryRecorderAgentInput, FSMemoryRecorderAgentOutput>;
+  agent: AIAgent<any, FSMemoryRecorderAgentInput, FSMemoryRecorderAgentOutput>;
 
   override async process(
     input: MemoryRecorderInput,

--- a/packages/agent-library/test/fs-memory/fs-memory.test.ts
+++ b/packages/agent-library/test/fs-memory/fs-memory.test.ts
@@ -28,11 +28,11 @@ test("FSMemory simple example", async () => {
     }),
   );
 
-  const result1 = await engine.invoke(agent, "I like blue color");
+  const result1 = await engine.invoke(agent, { message: "I like blue color" });
 
-  expect(result1).toEqual({ $message: "Great! I will remember that you like blue color." });
+  expect(result1).toEqual({ message: "Great! I will remember that you like blue color." });
   console.log(result1);
-  // Output: { $message: 'Great! I will remember that you like blue color.' }
+  // Output: { message: 'Great! I will remember that you like blue color.' }
 
   spyOn(memory, "retrieve").mockReturnValueOnce(
     Promise.resolve({
@@ -52,10 +52,10 @@ test("FSMemory simple example", async () => {
     }),
   );
 
-  const result2 = await engine.invoke(agent, "What color do I like?");
-  expect(result2).toEqual({ $message: "You like blue color." });
+  const result2 = await engine.invoke(agent, { message: "What color do I like?" });
+  expect(result2).toEqual({ message: "You like blue color." });
   console.log(result2);
-  // Output: { $message: 'You like blue color.' }
+  // Output: { message: 'You like blue color.' }
 
   // #endregion example-fs-memory-simple
 });

--- a/packages/agent-library/test/orchestrator/orchestrator.test.ts
+++ b/packages/agent-library/test/orchestrator/orchestrator.test.ts
@@ -4,7 +4,7 @@ import {
   OrchestratorAgent,
   getFullPlanSchema,
 } from "@aigne/agent-library/orchestrator/index.js";
-import { AIAgent, AIGNE, MESSAGE_KEY, createMessage } from "@aigne/core";
+import { AIAgent, AIGNE } from "@aigne/core";
 import { OpenAIChatModel } from "../_mocks_/mock-models.js";
 
 test("AIAgent.invoke", async () => {
@@ -23,6 +23,7 @@ test("AIAgent.invoke", async () => {
 
   const agent = OrchestratorAgent.from({
     skills: [finder, writer],
+    inputKey: "message",
   });
 
   spyOn(model, "process")
@@ -76,18 +77,17 @@ test("AIAgent.invoke", async () => {
   const finderCall = spyOn(finder, "invoke");
   const writerCall = spyOn(writer, "invoke");
 
-  const result = await aigne.invoke(
-    agent,
-    "Deep research ArcBlock and write a professional report",
-  );
+  const result = await aigne.invoke(agent, {
+    message: "Deep research ArcBlock and write a professional report",
+  });
 
-  expect(result).toEqual(createMessage("Task finished"));
+  expect(result).toEqual({ message: "Task finished" });
   expect(finderCall).toHaveBeenLastCalledWith(
-    { [MESSAGE_KEY]: expect.stringContaining("Find the closest match to a user's request") },
+    { message: expect.stringContaining("Find the closest match to a user's request") },
     expect.anything(),
   );
   expect(writerCall).toHaveBeenLastCalledWith(
-    { [MESSAGE_KEY]: expect.stringContaining("Write to the filesystem") },
+    { message: expect.stringContaining("Write to the filesystem") },
     expect.anything(),
   );
 });

--- a/packages/cli/src/utils/run-chat-loop.ts
+++ b/packages/cli/src/utils/run-chat-loop.ts
@@ -1,6 +1,8 @@
-import { type Message, type UserAgent, createMessage } from "@aigne/core";
+import type { Message, UserAgent } from "@aigne/core";
 import inquirer from "inquirer";
 import { TerminalTracer } from "../tracer/terminal.js";
+
+export const DEFAULT_CHAT_INPUT_KEY = "message";
 
 export interface ChatLoopOptions {
   initialCall?: Message | string;
@@ -10,7 +12,10 @@ export interface ChatLoopOptions {
   skipLoop?: boolean;
 }
 
-export async function runChatLoopInTerminal(userAgent: UserAgent, options: ChatLoopOptions = {}) {
+export async function runChatLoopInTerminal(
+  userAgent: UserAgent<any, any>,
+  options: ChatLoopOptions = {},
+) {
   const { initialCall = process.env.INITIAL_CALL, skipLoop = process.env.SKIP_LOOP === "true" } =
     options;
 
@@ -59,9 +64,7 @@ async function callAgent(userAgent: UserAgent, input: Message | string, options:
 
   await tracer.run(
     userAgent,
-    options.inputKey && typeof input === "string"
-      ? { [options.inputKey]: input }
-      : createMessage(input),
+    typeof input === "string" ? { [options.inputKey || DEFAULT_CHAT_INPUT_KEY]: input } : input,
   );
 }
 

--- a/packages/cli/src/utils/run-with-aigne.ts
+++ b/packages/cli/src/utils/run-with-aigne.ts
@@ -1,7 +1,7 @@
 import { fstat } from "node:fs";
 import { isatty } from "node:tty";
 import { promisify } from "node:util";
-import { AIGNE, type Agent, type ChatModelOptions, UserAgent, createMessage } from "@aigne/core";
+import { AIGNE, type Agent, type ChatModelOptions, UserAgent } from "@aigne/core";
 import { loadModel } from "@aigne/core/loader/index.js";
 import { LogLevel, getLevelFromEnv, logger } from "@aigne/core/utils/logger.js";
 import { readAllString } from "@aigne/core/utils/stream-utils.js";
@@ -11,7 +11,11 @@ import PrettyError from "pretty-error";
 import { ZodError, z } from "zod";
 import { availableModels } from "../constants.js";
 import { TerminalTracer } from "../tracer/terminal.js";
-import { type ChatLoopOptions, runChatLoopInTerminal } from "./run-chat-loop.js";
+import {
+  type ChatLoopOptions,
+  DEFAULT_CHAT_INPUT_KEY,
+  runChatLoopInTerminal,
+} from "./run-chat-loop.js";
 
 export interface RunAIGNECommandOptions {
   chat?: boolean;
@@ -164,9 +168,9 @@ export async function runAgentWithAIGNE(
 
   return await tracer.run(
     agent,
-    chatLoopOptions?.inputKey && typeof input === "string"
-      ? { [chatLoopOptions.inputKey]: input }
-      : createMessage(input),
+    typeof input === "string"
+      ? { [chatLoopOptions?.inputKey || DEFAULT_CHAT_INPUT_KEY]: input }
+      : input,
   );
 }
 

--- a/packages/cli/src/utils/serve-mcp.ts
+++ b/packages/cli/src/utils/serve-mcp.ts
@@ -1,4 +1,4 @@
-import { type AIGNE, getMessage } from "@aigne/core";
+import { AIAgent, type AIGNE } from "@aigne/core";
 import { promiseWithResolvers } from "@aigne/core/utils/promise.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -111,7 +111,9 @@ export function createMcpServer(aigne: AIGNE) {
         content: [
           {
             type: "text",
-            text: getMessage(result) || JSON.stringify(result),
+            text:
+              (agent instanceof AIAgent && (result[agent.outputKey] as string)) ||
+              JSON.stringify(result),
           },
         ],
       };

--- a/packages/cli/templates/default/chat.yaml
+++ b/packages/cli/templates/default/chat.yaml
@@ -3,6 +3,7 @@ description: Chat agent
 instructions: |
   You are a helpful assistant that can answer questions and provide information on a wide range of topics.
   Your goal is to assist users in finding the information they need and to engage in friendly conversation.
+input_key: message
 memory: true
 tools:
   - sandbox.js

--- a/packages/cli/test-agents/chat.yaml
+++ b/packages/cli/test-agents/chat.yaml
@@ -3,5 +3,6 @@ description: Chat agent
 instructions: |
   You are a helpful assistant that can answer questions and provide information on a wide range of topics.
   Your goal is to assist users in finding the information they need and to engage in friendly conversation.
+input_key: message
 tools:
   - sandbox.js

--- a/packages/cli/test/tracer/__snapshots__/terminal.test.ts.snap
+++ b/packages/cli/test/tracer/__snapshots__/terminal.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`TerminalTracer should work correctly 1`] = `
 {
-  "$message": "hello, this is a test response message",
+  "message": "hello, this is a test response message",
 }
 `;
 

--- a/packages/cli/test/tracer/terminal.test.ts
+++ b/packages/cli/test/tracer/terminal.test.ts
@@ -1,6 +1,6 @@
 import { expect, spyOn, test } from "bun:test";
 import { TerminalTracer } from "@aigne/cli/tracer/terminal.js";
-import { AIAgent, AIGNE, createMessage } from "@aigne/core";
+import { AIAgent, AIGNE } from "@aigne/core";
 import { arrayToAgentProcessAsyncGenerator } from "@aigne/core/utils/stream-utils.js";
 import { OpenAIChatModel } from "@aigne/openai";
 
@@ -10,7 +10,9 @@ test("TerminalTracer should work correctly", async () => {
   const aigne = new AIGNE({ model });
   const context = aigne.newContext();
 
-  const testAgent = AIAgent.from({});
+  const testAgent = AIAgent.from({
+    inputKey: "message",
+  });
 
   spyOn(model, "process").mockReturnValue(
     Promise.resolve({ text: "hello, this is a test response message" }),
@@ -20,7 +22,7 @@ test("TerminalTracer should work correctly", async () => {
 
   const tracer = new TerminalTracer(context, { printRequest: true });
 
-  const { result } = await tracer.run(userAgent, createMessage("hello"));
+  const { result } = await tracer.run(userAgent, { message: "hello" });
 
   expect(result).toMatchSnapshot();
 });
@@ -29,7 +31,9 @@ test("TerminalTracer should raise error correctly", async () => {
   const aigne = new AIGNE();
   const context = aigne.newContext();
 
-  const testAgent = AIAgent.from({});
+  const testAgent = AIAgent.from({
+    inputKey: "message",
+  });
 
   spyOn(testAgent, "process").mockReturnValueOnce(
     arrayToAgentProcessAsyncGenerator([new Error("test error")]),
@@ -39,7 +43,7 @@ test("TerminalTracer should raise error correctly", async () => {
 
   const tracer = new TerminalTracer(context);
 
-  const result = tracer.run(userAgent, createMessage("hello"));
+  const result = tracer.run(userAgent, { message: "hello" });
 
   expect(result).rejects.toThrowError("test error");
 });
@@ -53,9 +57,8 @@ test("TerminalTracer should render output message with markdown highlight", asyn
   const tracer = new TerminalTracer(context);
 
   expect(
-    tracer.formatResult(
-      context,
-      createMessage("## Hello\nI am from [**AIGNE**](https://www.aigne.io)"),
-    ),
+    tracer.formatResult(new AIAgent({ inputKey: "message" }), context, {
+      message: "## Hello\nI am from [**AIGNE**](https://www.aigne.io)",
+    }),
   ).toMatchSnapshot();
 });

--- a/packages/cli/test/utils/run-chat-loop.test.ts
+++ b/packages/cli/test/utils/run-chat-loop.test.ts
@@ -1,6 +1,6 @@
 import { expect, spyOn, test } from "bun:test";
 import { runChatLoopInTerminal } from "@aigne/cli/utils/run-chat-loop.js";
-import { AIAgent, AIGNE, UserAgent, createMessage } from "@aigne/core";
+import { AIAgent, AIGNE, UserAgent } from "@aigne/core";
 import { arrayToAgentProcessAsyncGenerator } from "@aigne/core/utils/stream-utils.js";
 import inquirer from "inquirer";
 
@@ -30,7 +30,9 @@ test("runChatLoopInTerminal should respond /help /exit commands", async () => {
 test("runChatLoopInTerminal should trigger initial call", async () => {
   const aigne = new AIGNE({});
 
-  const agent = AIAgent.from({});
+  const agent = AIAgent.from({
+    inputKey: "message",
+  });
 
   const user = aigne.invoke(agent);
 
@@ -49,13 +51,15 @@ test("runChatLoopInTerminal should trigger initial call", async () => {
   });
   expect(await result).toBeUndefined();
   expect(agentProcess).toHaveBeenCalledWith(
-    createMessage("hello, this is a test message"),
+    { message: "hello, this is a test message" },
     expect.anything(),
   );
 });
 
 test("runChatLoopInTerminal should invoke agent correctly", async () => {
-  const agent = AIAgent.from({});
+  const agent = AIAgent.from({
+    inputKey: "message",
+  });
 
   const aigne = new AIGNE({});
 
@@ -78,14 +82,16 @@ test("runChatLoopInTerminal should invoke agent correctly", async () => {
 
   expect(await runChatLoopInTerminal(userAgent)).toBeUndefined();
   expect(agentProcess).toHaveBeenCalledWith(
-    createMessage("hello, this is a test message"),
+    { message: "hello, this is a test message" },
     expect.anything(),
   );
 });
 
 test("runChatLoopInTerminal should skip loop If initialCall is provided and skipLoop is true", async () => {
   const aigne = new AIGNE({});
-  const agent = AIAgent.from({});
+  const agent = AIAgent.from({
+    inputKey: "message",
+  });
   const userAgent = aigne.invoke(agent);
 
   const agentProcess = spyOn(agent, "process").mockReturnValueOnce(
@@ -101,7 +107,7 @@ test("runChatLoopInTerminal should skip loop If initialCall is provided and skip
 
   expect(agentProcess).toHaveBeenCalledTimes(1);
   expect(agentProcess).toHaveBeenCalledWith(
-    createMessage("hello, this is a test message"),
+    { message: "hello, this is a test message" },
     expect.anything(),
   );
 });

--- a/packages/cli/test/utils/serve-mcp.test.ts
+++ b/packages/cli/test/utils/serve-mcp.test.ts
@@ -48,7 +48,7 @@ test("serveMCPServer should work", async () => {
     ],
   });
 
-  expect(client.callTool({ name: "chat", arguments: { $message: "hello" } })).resolves.toEqual({
+  expect(client.callTool({ name: "chat", arguments: { message: "hello" } })).resolves.toEqual({
     content: [{ type: "text", text: "hello, how can I help you?" }],
   });
 
@@ -111,7 +111,7 @@ test("serveMCPServer should respond error from agent processing", async () => {
 
   await client.connect(transport);
 
-  expect(client.callTool({ name: "chat", arguments: { $message: "hello" } })).resolves.toEqual({
+  expect(client.callTool({ name: "chat", arguments: { message: "hello" } })).resolves.toEqual({
     isError: true,
     content: [
       {

--- a/packages/core/src/agents/guide-rail-agent.ts
+++ b/packages/core/src/agents/guide-rail-agent.ts
@@ -66,7 +66,7 @@ export interface GuideRailAgentOutput extends Message {
  */
 export type GuideRailAgent = Agent<GuideRailAgentInput, GuideRailAgentOutput>;
 
-export const guideRailAgentOptions: AgentOptions<GuideRailAgentInput, GuideRailAgentOutput> = {
+export const guideRailAgentOptions: AgentOptions<any, GuideRailAgentOutput> = {
   inputSchema: z.object({
     input: z.unknown(),
     output: z.unknown(),

--- a/packages/core/src/agents/user-agent.ts
+++ b/packages/core/src/agents/user-agent.ts
@@ -49,7 +49,7 @@ export class UserAgent<I extends Message = Message, O extends Message = Message>
     if (this._process) super.publishToTopics(output, options);
   }
 
-  override invoke = ((input: string | I, options: Partial<AgentInvokeOptions> = {}) => {
+  override invoke = ((input: I, options: Partial<AgentInvokeOptions> = {}) => {
     if (!options.context) this.context = this.context.newContext({ reset: true });
 
     return super.invoke(input, { ...options, context: this.context });

--- a/packages/core/src/aigne/aigne.ts
+++ b/packages/core/src/aigne/aigne.ts
@@ -190,14 +190,14 @@ export class AIGNE<U extends UserContext = UserContext> {
    * This overload is useful when you need to track which agent was ultimately responsible for generating the response.
    *
    * @param agent - Target agent to invoke
-   * @param message - Input message to send to the agent (can be a string or a structured message object)
+   * @param message - Input message to send to the agent
    * @param options.returnActiveAgent - Must be true to return the final active agent
    * @param options.streaming - Must be false to return a response stream
    * @returns A promise resolving to a tuple containing the agent's response and the final active agent
    */
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message: I | string,
+    message: I,
     options: InvokeOptions<U> & { returnActiveAgent: true; streaming?: false },
   ): Promise<[O, Agent]>;
 
@@ -206,14 +206,14 @@ export class AIGNE<U extends UserContext = UserContext> {
    * This overload is useful when you need streaming responses while also tracking which agent provided them.
    *
    * @param agent - Target agent to invoke
-   * @param message - Input message to send to the agent (can be a string or a structured message object)
+   * @param message - Input message to send to the agent
    * @param options.returnActiveAgent - Must be true to return the final active agent
    * @param options.streaming - Must be true to return a response stream
    * @returns A promise resolving to a tuple containing the agent's response stream and a promise for the final agent
    */
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message: I | string,
+    message: I,
     options: InvokeOptions<U> & { returnActiveAgent: true; streaming: true },
   ): Promise<[AgentResponseStream<O>, Promise<Agent>]>;
 
@@ -222,7 +222,7 @@ export class AIGNE<U extends UserContext = UserContext> {
    * This is the standard way to invoke an agent when you only need the response.
    *
    * @param agent - Target agent to invoke
-   * @param message - Input message to send to the agent (can be a string or a structured message object)
+   * @param message - Input message to send to the agent
    * @param options - Optional configuration parameters for the invocation
    * @returns A promise resolving to the agent's complete response
    *
@@ -232,7 +232,7 @@ export class AIGNE<U extends UserContext = UserContext> {
    */
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message: I | string,
+    message: I,
     options?: InvokeOptions<U> & { returnActiveAgent?: false; streaming?: false },
   ): Promise<O>;
 
@@ -241,7 +241,7 @@ export class AIGNE<U extends UserContext = UserContext> {
    * This allows processing the response incrementally as it's being generated.
    *
    * @param agent - Target agent to invoke
-   * @param message - Input message to send to the agent (can be a string or a structured message object)
+   * @param message - Input message to send to the agent
    * @param options - Configuration with streaming enabled to receive incremental response chunks
    * @returns A promise resolving to a stream of the agent's response that can be consumed incrementally
    *
@@ -251,7 +251,7 @@ export class AIGNE<U extends UserContext = UserContext> {
    */
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message: I | string,
+    message: I,
     options: InvokeOptions<U> & { returnActiveAgent?: false; streaming: true },
   ): Promise<AgentResponseStream<O>>;
 
@@ -267,13 +267,13 @@ export class AIGNE<U extends UserContext = UserContext> {
    */
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message?: I | string,
+    message?: I,
     options?: InvokeOptions<U>,
   ): UserAgent<I, O> | Promise<AgentResponse<O> | [AgentResponse<O>, Agent]>;
 
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message?: I | string,
+    message?: I,
     options?: InvokeOptions<U>,
   ): UserAgent<I, O> | Promise<AgentResponse<O> | [AgentResponse<O>, Agent]> {
     return new AIGNEContext(this).invoke(agent, message, options);
@@ -294,7 +294,7 @@ export class AIGNE<U extends UserContext = UserContext> {
    */
   publish(
     topic: string | string[],
-    payload: Omit<MessagePayload, "context"> | Message | string,
+    payload: Omit<MessagePayload, "context"> | Message,
     options?: InvokeOptions<U>,
   ) {
     return new AIGNEContext(this).publish(topic, payload, options);

--- a/packages/core/src/aigne/context.ts
+++ b/packages/core/src/aigne/context.ts
@@ -22,7 +22,6 @@ import {
 } from "../agents/types.js";
 import { UserAgent } from "../agents/user-agent.js";
 import type { Memory } from "../memory/memory.js";
-import { createMessage } from "../prompt/prompt-builder.js";
 import { AgentResponseProgressStream } from "../utils/event-stream.js";
 import { promiseWithResolvers } from "../utils/promise.js";
 import {
@@ -133,12 +132,12 @@ export interface Context<U extends UserContext = UserContext>
    */
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message: I | string,
+    message: I,
     options: InvokeOptions & { returnActiveAgent: true; streaming?: false },
   ): Promise<[O, Agent]>;
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message: I | string,
+    message: I,
     options: InvokeOptions & { returnActiveAgent: true; streaming: true },
   ): Promise<[AgentResponseStream<O>, Promise<Agent>]>;
   /**
@@ -149,17 +148,17 @@ export interface Context<U extends UserContext = UserContext>
    */
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message: I | string,
+    message: I,
     options?: InvokeOptions & { streaming?: false },
   ): Promise<O>;
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message: I | string,
+    message: I,
     options: InvokeOptions & { streaming: true },
   ): Promise<AgentResponseStream<O>>;
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message?: I | string,
+    message?: I,
     options?: InvokeOptions,
   ): UserAgent<I, O> | Promise<AgentResponse<O> | [AgentResponse<O>, Agent]>;
 
@@ -170,7 +169,7 @@ export interface Context<U extends UserContext = UserContext>
    */
   publish(
     topic: string | string[],
-    payload: Omit<MessagePayload, "context"> | Message | string,
+    payload: Omit<MessagePayload, "context"> | Message,
     options?: InvokeOptions,
   ): void;
 
@@ -279,9 +278,8 @@ export class AIGNEContext implements Context {
     }
 
     const newContext = this.newContext();
-    const msg = createMessage(message);
 
-    return Promise.resolve(newContext.internal.invoke(agent, msg, newContext, options)).then(
+    return Promise.resolve(newContext.internal.invoke(agent, message, newContext, options)).then(
       async (response) => {
         if (!options?.streaming) {
           let { __activeAgent__: activeAgent, ...output } =

--- a/packages/core/src/aigne/message-queue.ts
+++ b/packages/core/src/aigne/message-queue.ts
@@ -1,7 +1,6 @@
 import { Emitter, type EventMap } from "strict-event-emitter";
 import { z } from "zod";
 import type { Message } from "../agents/agent.js";
-import { createMessage } from "../prompt/prompt-builder.js";
 import { checkArguments, isNil, orArrayToArray } from "../utils/type-utils.js";
 import type { Context } from "./context.js";
 
@@ -43,16 +42,16 @@ function isMessagePayload(payload: unknown): payload is Omit<MessagePayload, "co
  * @hidden
  */
 export function toMessagePayload(
-  payload: Omit<MessagePayload, "context"> | string | Message,
+  payload: Omit<MessagePayload, "context"> | Message,
   options?: Partial<Pick<MessagePayload, "role" | "source">>,
 ): Omit<MessagePayload, "context"> {
   if (isMessagePayload(payload)) {
-    return { ...payload, message: createMessage(payload.message), ...options };
+    return { ...payload, ...options };
   }
   return {
     role: options?.role || "user",
     source: options?.source,
-    message: createMessage(payload),
+    message: payload,
   };
 }
 

--- a/packages/core/src/aigne/usage.ts
+++ b/packages/core/src/aigne/usage.ts
@@ -5,6 +5,7 @@ export interface ContextUsage {
   inputTokens: number;
   outputTokens: number;
   agentCalls: number;
+  duration: number;
 }
 
 /**
@@ -15,6 +16,7 @@ export function newEmptyContextUsage(): ContextUsage {
     inputTokens: 0,
     outputTokens: 0,
     agentCalls: 0,
+    duration: 0,
   };
 }
 

--- a/packages/core/src/loader/agent-yaml.ts
+++ b/packages/core/src/loader/agent-yaml.ts
@@ -19,6 +19,10 @@ const agentFileSchema = z.discriminatedUnion("type", [
       .string()
       .nullish()
       .transform((v) => v ?? undefined),
+    input_key: z
+      .string()
+      .nullish()
+      .transform((v) => v ?? undefined),
     input_schema: inputOutputSchema
       .nullish()
       .transform((v) => (v ? jsonSchemaToZod<ZodObject<Record<string, ZodType>>>(v) : undefined)),

--- a/packages/core/src/prompt/prompt-builder.ts
+++ b/packages/core/src/prompt/prompt-builder.ts
@@ -15,7 +15,7 @@ import type {
 } from "../agents/chat-model.js";
 import type { Memory } from "../memory/memory.js";
 import { outputSchemaToResponseFormatSchema } from "../utils/json-schema.js";
-import { isNil, unique } from "../utils/type-utils.js";
+import { unique } from "../utils/type-utils.js";
 import { MEMORY_MESSAGE_TEMPLATE } from "./prompts/memory-message-template.js";
 import {
   AgentMessageTemplate,
@@ -25,44 +25,12 @@ import {
   UserMessageTemplate,
 } from "./template.js";
 
-export const MESSAGE_KEY = "$message";
-
-export function createMessage<V extends Message>(
-  message: string,
-  variables?: V,
-): { [MESSAGE_KEY]: string } & typeof variables;
-export function createMessage<I extends Message, V extends Message>(
-  message: I,
-  variables?: V,
-): I & typeof variables;
-export function createMessage<I extends Message, V extends Message>(
-  message: string | I,
-  variables?: V,
-): ({ [MESSAGE_KEY]: string } | I) & typeof variables;
-export function createMessage<I extends Message, V extends Message>(
-  message: string | I,
-  variables?: V,
-): ({ [MESSAGE_KEY]: string } | I) & typeof variables {
-  return (
-    typeof message === "string"
-      ? { [MESSAGE_KEY]: message, ...variables }
-      : { ...message, ...variables }
-  ) as ({ [MESSAGE_KEY]: string } | I) & typeof variables;
-}
-
-export function getMessage(input: Message): string | undefined {
-  const userInputMessage = input[MESSAGE_KEY];
-  if (typeof userInputMessage === "string") return userInputMessage;
-  if (!isNil(userInputMessage)) return JSON.stringify(userInputMessage);
-  return undefined;
-}
-
 export interface PromptBuilderOptions {
   instructions?: string | ChatMessagesTemplate;
 }
 
 export interface PromptBuildOptions extends Pick<AgentInvokeOptions, "context"> {
-  agent?: AIAgent;
+  agent?: AIAgent<any, any, any>;
   input?: Message;
   model?: ChatModel;
   outputSchema?: Agent["outputSchema"];
@@ -139,6 +107,9 @@ export class PromptBuilder {
   private async buildMessages(options: PromptBuildOptions): Promise<ChatModelInputMessage[]> {
     const { input } = options;
 
+    const inputKey = options.agent?.inputKey;
+    const message = inputKey && typeof input?.[inputKey] === "string" ? input[inputKey] : undefined;
+
     const messages =
       (typeof this.instructions === "string"
         ? ChatMessagesTemplate.from([SystemMessageTemplate.from(this.instructions)])
@@ -147,8 +118,8 @@ export class PromptBuilder {
 
     const memories: Pick<Memory, "content">[] = [];
 
-    if (options.agent) {
-      memories.push(...(await options.agent.retrieveMemories({ search: options.input }, options)));
+    if (options.agent?.inputKey) {
+      memories.push(...(await options.agent.retrieveMemories({ search: message }, options)));
     }
 
     if (options.context.memories?.length) {
@@ -157,10 +128,11 @@ export class PromptBuilder {
 
     if (memories.length) messages.push(...this.convertMemoriesToMessages(memories, options));
 
-    const content = input && getMessage(input);
-    // add user input if it's not the same as the last message
-    if (content && messages.at(-1)?.content !== content) {
-      messages.push({ role: "user", content });
+    if (message) {
+      messages.push({
+        role: "user",
+        content: message,
+      });
     }
 
     return messages;

--- a/packages/core/src/prompt/prompt-builder.ts
+++ b/packages/core/src/prompt/prompt-builder.ts
@@ -37,15 +37,7 @@ export interface PromptBuildOptions extends Pick<AgentInvokeOptions, "context"> 
 }
 
 export class PromptBuilder {
-  static from(instructions: string): PromptBuilder;
-  static from(instructions: GetPromptResult): PromptBuilder;
-  static from(instructions: { path: string }): Promise<PromptBuilder>;
-  static from(
-    instructions: string | { path: string } | GetPromptResult,
-  ): PromptBuilder | Promise<PromptBuilder>;
-  static from(
-    instructions: string | { path: string } | GetPromptResult,
-  ): PromptBuilder | Promise<PromptBuilder> {
+  static from(instructions: string | { path: string } | GetPromptResult): PromptBuilder {
     if (typeof instructions === "string") return new PromptBuilder({ instructions });
 
     if (isFromPromptResult(instructions)) return PromptBuilder.fromMCPPromptResult(instructions);
@@ -55,8 +47,8 @@ export class PromptBuilder {
     throw new Error(`Invalid instructions ${instructions}`);
   }
 
-  private static async fromFile(path: string): Promise<PromptBuilder> {
-    const text = await nodejs.fs.readFile(path, "utf-8");
+  private static fromFile(path: string): PromptBuilder {
+    const text = nodejs.fsSync.readFileSync(path, "utf-8");
     return PromptBuilder.from(text);
   }
 

--- a/packages/core/src/utils/stream-utils.ts
+++ b/packages/core/src/utils/stream-utils.ts
@@ -7,7 +7,6 @@ import {
   isAgentResponseDelta,
   isEmptyChunk,
 } from "../agents/agent.js";
-import type { MESSAGE_KEY } from "../prompt/prompt-builder.js";
 import { type PromiseOrValue, omitBy } from "./type-utils.js";
 import "./stream-polyfill.js";
 import type { ReadableStreamDefaultReadResult } from "bun";
@@ -210,7 +209,7 @@ export async function readableStreamToArray<T>(
 
 export function stringToAgentResponseStream(
   str: string,
-  key: "text" | typeof MESSAGE_KEY | string = "text",
+  key: "text" | string = "text",
 ): AgentResponseStream<Message> {
   const segmenter = new Intl.Segmenter(undefined, { granularity: "word" });
   const segments = segmenter.segment(str);

--- a/packages/core/src/utils/type-utils.ts
+++ b/packages/core/src/utils/type-utils.ts
@@ -92,6 +92,21 @@ export function omit<T extends Record<string, unknown>, K extends keyof T>(
   ) as Omit<T, K>;
 }
 
+export function omitDeep<T, K>(obj: T, ...keys: (K | K[])[]): unknown {
+  if (Array.isArray(obj)) {
+    return obj.map((item) => omitDeep(item, ...keys));
+  }
+  if (isRecord(obj)) {
+    const flattenedKeys = new Set(keys.flat());
+    return Object.fromEntries(
+      Object.entries(obj)
+        .filter(([key]) => !flattenedKeys.has(key as K))
+        .map(([key, value]) => [key, omitDeep(value, ...keys)]),
+    );
+  }
+  return obj;
+}
+
 export function omitBy<T extends Record<string, unknown>, K extends keyof T>(
   obj: T,
   predicate: (value: T[K], key: K) => boolean,

--- a/packages/core/test-agents/chat.yaml
+++ b/packages/core/test-agents/chat.yaml
@@ -3,6 +3,7 @@ description: Chat agent
 instructions: |
   You are a helpful assistant that can answer questions and provide information on a wide range of topics.
   Your goal is to assist users in finding the information they need and to engage in friendly conversation.
+input_key: message
 memory: true
 tools:
   - sandbox.js

--- a/packages/core/test/agents/__snapshots__/ai-agent.test.ts.snap
+++ b/packages/core/test/agents/__snapshots__/ai-agent.test.ts.snap
@@ -5,77 +5,77 @@ exports[`AIAgent.invoke with streaming true 1`] = `
   {
     "delta": {
       "text": {
-        "$message": "Here",
+        "message": "Here",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "is",
+        "message": "is",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "a",
+        "message": "a",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "beautiful",
+        "message": "beautiful",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "T",
+        "message": "T",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "-",
+        "message": "-",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "shirt",
+        "message": "shirt",
       },
     },
   },
@@ -84,7 +84,7 @@ exports[`AIAgent.invoke with streaming true 1`] = `
 
 exports[`AIAgent.invoke with streaming false 1`] = `
 {
-  "$message": "Here is a beautiful T-shirt",
+  "message": "Here is a beautiful T-shirt",
 }
 `;
 
@@ -93,77 +93,77 @@ exports[`AIAgent with router toolChoice should return router result with streami
   {
     "delta": {
       "text": {
-        "$message": "Here",
+        "message": "Here",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "is",
+        "message": "is",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "a",
+        "message": "a",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "beautiful",
+        "message": "beautiful",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "T",
+        "message": "T",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "-",
+        "message": "-",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "shirt",
+        "message": "shirt",
       },
     },
   },
@@ -172,6 +172,6 @@ exports[`AIAgent with router toolChoice should return router result with streami
 
 exports[`AIAgent with router toolChoice should return router result with streaming false 1`] = `
 {
-  "$message": "Here is a beautiful T-shirt",
+  "message": "Here is a beautiful T-shirt",
 }
 `;

--- a/packages/core/test/agents/agent.test.ts
+++ b/packages/core/test/agents/agent.test.ts
@@ -35,7 +35,7 @@ test("Custom agent", async () => {
 
   const agent = new MyAgent();
 
-  const result = await agent.invoke("hello");
+  const result = await agent.invoke({ message: "hello" });
 
   console.log(result); // { text: "Hello, How can I assist you today?" }
 
@@ -93,7 +93,7 @@ test("Agent returning a ReadableStream", async () => {
   }
 
   const agent = new StreamResponseAgent();
-  const stream = await agent.invoke("Hello", { streaming: true });
+  const stream = await agent.invoke({ message: "Hello" }, { streaming: true });
 
   let fullText = "";
   for await (const chunk of stream) {
@@ -132,7 +132,7 @@ test("Agent using AsyncGenerator", async () => {
   }
 
   const agent = new AsyncGeneratorAgent();
-  const stream = await agent.invoke("Hello", { streaming: true });
+  const stream = await agent.invoke({ message: "Hello" }, { streaming: true });
 
   const message: string[] = [];
   let json: Message | undefined;
@@ -176,7 +176,7 @@ test("Agent returning another agent (transfer agent)", async () => {
   const aigne = new AIGNE({});
   const mainAgent = new MainAgent();
 
-  const result = await aigne.invoke(mainAgent, "technical question");
+  const result = await aigne.invoke(mainAgent, { message: "technical question" });
   console.log(result); // { response: "This is a specialist response", expertise: "technical" }
 
   expect(result).toEqual({ response: "This is a specialist response", expertise: "technical" });
@@ -203,14 +203,15 @@ test("Agent.invoke with regular response", async () => {
   const agent = AIAgent.from({
     name: "chat",
     description: "A chat agent",
+    inputKey: "message",
   });
 
   // Invoke the agent
-  const result = await aigne.invoke(agent, "hello");
+  const result = await aigne.invoke(agent, { message: "hello" });
 
-  console.log(result); // Output: { $message: "Hello, How can I assist you today?" }
+  console.log(result); // Output: { message: "Hello, How can I assist you today?" }
 
-  expect(result).toEqual({ $message: "Hello, How can I assist you today?" });
+  expect(result).toEqual({ message: "Hello, How can I assist you today?" });
 
   // #endregion example-invoke
 });
@@ -234,17 +235,18 @@ test("Agent.invoke with streaming response", async () => {
   const agent = AIAgent.from({
     name: "chat",
     description: "A chat agent",
+    inputKey: "message",
   });
 
   // Invoke the agent with streaming enabled
-  const stream = await aigne.invoke(agent, "hello", { streaming: true });
+  const stream = await aigne.invoke(agent, { message: "hello" }, { streaming: true });
 
   const chunks: string[] = [];
 
   // Read the stream using an async iterator
   for await (const chunk of stream) {
     if (isAgentResponseDelta(chunk)) {
-      const text = chunk.delta.text?.$message;
+      const text = chunk.delta.text?.message;
       if (text) {
         chunks.push(text);
       }
@@ -420,7 +422,7 @@ test("Agent should return the original error from guide rails", async () => {
     }),
   );
 
-  const result = await agent.invoke("What will be the price of Bitcoin next year?");
+  const result = await agent.invoke({ message: "What will be the price of Bitcoin next year?" });
 
   expect(result).toEqual({
     $status: "GuideRailError",
@@ -473,18 +475,20 @@ test("Agent can be intercepted by guide rails", async () => {
     }),
   );
 
-  const result = await aigne.invoke(agent, "What will be the price of Bitcoin next month?");
+  const result = await aigne.invoke(agent, {
+    message: "What will be the price of Bitcoin next month?",
+  });
 
   console.log(result);
   // Output:
   // {
   //   "$status": "GuideRailError",
-  //   "$message": "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading."
+  //   "message": "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading."
   // }
 
   expect(result).toEqual({
     $status: "GuideRailError",
-    $message:
+    message:
       "I cannot provide cryptocurrency price predictions as they are speculative and potentially misleading.",
   });
 
@@ -514,6 +518,7 @@ test("Agent should respond result if no any guide rails error", async () => {
 
   const agent = AIAgent.from({
     guideRails: [financial],
+    inputKey: "message",
   });
 
   spyOn(model, "process").mockReturnValueOnce(
@@ -531,10 +536,10 @@ test("Agent should respond result if no any guide rails error", async () => {
     }),
   );
 
-  const result = await aigne.invoke(agent, "How to create an agent?");
+  const result = await aigne.invoke(agent, { message: "How to create an agent?" });
 
   expect(result).toEqual({
-    $message: "You can use AIGNE Framework create a useful agent!",
+    message: "You can use AIGNE Framework create a useful agent!",
   });
 });
 
@@ -614,6 +619,7 @@ test("Agent hooks simple example", async () => {
       },
     },
     skills: [weather],
+    inputKey: "message",
   });
 
   const onStart = spyOn(agent.hooks, "onStart");
@@ -625,19 +631,19 @@ test("Agent hooks simple example", async () => {
     .mockReturnValueOnce({ toolCalls: [createToolCallResponse("weather", { city: "Paris" })] })
     .mockReturnValueOnce({ text: "The weather in Paris is 25 degrees." });
 
-  const result = await aigne.invoke(agent, "What is the weather in Paris?");
+  const result = await aigne.invoke(agent, { message: "What is the weather in Paris?" });
 
   console.log(result);
-  // Output: { $message: "The weather in Paris is 25 degrees." }
+  // Output: { message: "The weather in Paris is 25 degrees." }
 
-  expect(result).toEqual({ $message: "The weather in Paris is 25 degrees." });
+  expect(result).toEqual({ message: "The weather in Paris is 25 degrees." });
   expect(onStart).toHaveBeenLastCalledWith(
-    expect.objectContaining({ input: { $message: "What is the weather in Paris?" } }),
+    expect.objectContaining({ input: { message: "What is the weather in Paris?" } }),
   );
   expect(onEnd).toHaveBeenLastCalledWith(
     expect.objectContaining({
-      input: { $message: "What is the weather in Paris?" },
-      output: { $message: "The weather in Paris is 25 degrees." },
+      input: { message: "What is the weather in Paris?" },
+      output: { message: "The weather in Paris is 25 degrees." },
     }),
   );
   expect(onSkillStart).toHaveBeenLastCalledWith(
@@ -674,17 +680,20 @@ test("Agent hook onHandoff should work correctly", async () => {
       },
     ],
     toolChoice: AIAgentToolChoice.router,
+    inputKey: "message",
   });
 
   const onHandoff = spyOn(triage.hooks, "onHandoff");
 
-  const feedback = AIAgent.from({});
+  const feedback = AIAgent.from({
+    inputKey: "message",
+  });
 
   spyOn(model, "process")
     .mockReturnValueOnce({ toolCalls: [createToolCallResponse("transferToFeedback", {})] })
     .mockReturnValueOnce({ text: "Hello, I am feedback agent." });
 
-  const result = await aigne.invoke(triage, "I want to give feedback");
+  const result = await aigne.invoke(triage, { message: "I want to give feedback" });
 
   console.log(result);
 
@@ -692,9 +701,9 @@ test("Agent hook onHandoff should work correctly", async () => {
     expect.objectContaining({
       source: triage,
       target: feedback,
-      input: { $message: "I want to give feedback" },
+      input: { message: "I want to give feedback" },
     }),
   );
 
-  expect(result).toEqual({ $message: "Hello, I am feedback agent." });
+  expect(result).toEqual({ message: "Hello, I am feedback agent." });
 });

--- a/packages/core/test/agents/model-simple-usage.test.ts
+++ b/packages/core/test/agents/model-simple-usage.test.ts
@@ -13,6 +13,7 @@ test("Example model usage with AIGNE", async () => {
   const agent = AIAgent.from({
     model,
     instructions: "You are a helpful assistant.",
+    inputKey: "message",
   });
 
   spyOn(model, "process").mockReturnValueOnce(
@@ -21,15 +22,15 @@ test("Example model usage with AIGNE", async () => {
     }),
   );
 
-  const result = await aigne.invoke(agent, "Hello");
+  const result = await aigne.invoke(agent, { message: "Hello" });
 
   expect(result).toEqual({
-    $message: "Hello! How can I assist you today?",
+    message: "Hello! How can I assist you today?",
   });
 
   console.log(result);
   // Output:
   // {
-  //   $message: "Hello! How can I assist you today?",
+  //   message: "Hello! How can I assist you today?",
   // }
 });

--- a/packages/core/test/agents/team-agent.test.ts
+++ b/packages/core/test/agents/team-agent.test.ts
@@ -98,10 +98,12 @@ test.each(processModes)(
 
     const first = AIAgent.from({
       outputKey: "first",
+      inputKey: "message",
     });
 
     const second = AIAgent.from({
       outputKey: "second",
+      inputKey: "message",
     });
 
     spyOn(model, "process")
@@ -113,7 +115,7 @@ test.each(processModes)(
       mode,
     });
 
-    const stream = await aigne.invoke(team, "hello", { streaming: true });
+    const stream = await aigne.invoke(team, { message: "hello" }, { streaming: true });
 
     expect(readableStreamToArray(stream)).resolves.toMatchSnapshot();
   },
@@ -143,7 +145,7 @@ test.each(processModes)(
       mode,
     });
 
-    const stream = await aigne.invoke(team, "hello", { streaming: true });
+    const stream = await aigne.invoke(team, { message: "hello" }, { streaming: true });
 
     expect(readableStreamToArray(stream)).resolves.toMatchSnapshot();
   },

--- a/packages/core/test/agents/user-agent.test.ts
+++ b/packages/core/test/agents/user-agent.test.ts
@@ -1,5 +1,5 @@
 import { expect, mock, spyOn, test } from "bun:test";
-import { AIAgent, AIGNE, UserAgent, createMessage } from "@aigne/core";
+import { AIAgent, AIGNE, UserAgent } from "@aigne/core";
 import { arrayToAgentProcessAsyncGenerator } from "@aigne/core/utils/stream-utils.js";
 
 test("UserAgent.stream", async () => {
@@ -12,12 +12,12 @@ test("UserAgent.stream", async () => {
   });
 
   const reader = userAgent.stream.getReader();
-  userAgent.publish("test_topic", "hello");
+  userAgent.publish("test_topic", { message: "hello" });
   expect(reader.read()).resolves.toEqual({
     value: {
       topic: "test_topic",
       role: "user",
-      message: createMessage("hello"),
+      message: { message: "hello" },
       source: "user_agent",
       context: expect.anything(),
     },
@@ -36,8 +36,8 @@ test("UserAgent.invoke should invoke process correctly", async () => {
     process: (input) => input,
   });
 
-  const result = await aigne.invoke(userAgent, "hello");
-  expect(result).toEqual(createMessage("hello"));
+  const result = await aigne.invoke(userAgent, { message: "hello" });
+  expect(result).toEqual({ message: "hello" });
 });
 
 test("UserAgent.invoke should invoke activeAgent correctly", async () => {
@@ -52,12 +52,12 @@ test("UserAgent.invoke should invoke activeAgent correctly", async () => {
   });
 
   const testAgentProcess = spyOn(testAgent, "process").mockReturnValueOnce(
-    arrayToAgentProcessAsyncGenerator([{ delta: { json: createMessage("world") } }]),
+    arrayToAgentProcessAsyncGenerator([{ delta: { json: { message: "world" } } }]),
   );
 
-  const result = await aigne.invoke(userAgent, "hello");
-  expect(result).toEqual(createMessage("world"));
-  expect(testAgentProcess).toHaveBeenLastCalledWith(createMessage("hello"), expect.anything());
+  const result = await aigne.invoke(userAgent, { message: "hello" });
+  expect(result).toEqual({ message: "world" });
+  expect(testAgentProcess).toHaveBeenLastCalledWith({ message: "hello" }, expect.anything());
 });
 
 test("UserAgent.invoke should publish topic correctly", async () => {
@@ -71,11 +71,11 @@ test("UserAgent.invoke should publish topic correctly", async () => {
 
   const sub = aigne.subscribe("test_publish_topic");
 
-  await aigne.invoke(userAgent, "hello");
+  await aigne.invoke(userAgent, { message: "hello" });
 
   expect(sub).resolves.toEqual(
     expect.objectContaining({
-      message: createMessage("hello"),
+      message: { message: "hello" },
     }),
   );
 });
@@ -92,14 +92,14 @@ test("UserAgent pub/sub should work correctly", async () => {
   const listener = mock();
   userAgent.subscribe("test_sub", listener);
 
-  userAgent.publish("test_sub", "hello");
+  userAgent.publish("test_sub", { message: "hello" });
   expect(listener).toHaveBeenLastCalledWith(
     expect.objectContaining({
-      message: createMessage("hello"),
+      message: { message: "hello" },
     }),
   );
 
   userAgent.unsubscribe("test_sub", listener);
-  userAgent.publish("test_sub", "hello");
+  userAgent.publish("test_sub", { message: "hello" });
   expect(listener).toHaveBeenCalledTimes(1);
 });

--- a/packages/core/test/aigne/__snapshots__/aigne.test.ts.snap
+++ b/packages/core/test/aigne/__snapshots__/aigne.test.ts.snap
@@ -257,6 +257,7 @@ exports[`AIGNE.invoke should respond $meta field with usage metrics with {
         "$meta": {
           "usage": {
             "agentCalls": 4,
+            "duration": 8,
             "inputTokens": 13,
             "outputTokens": 24,
           },

--- a/packages/core/test/aigne/__snapshots__/aigne.test.ts.snap
+++ b/packages/core/test/aigne/__snapshots__/aigne.test.ts.snap
@@ -257,7 +257,6 @@ exports[`AIGNE.invoke should respond $meta field with usage metrics with {
         "$meta": {
           "usage": {
             "agentCalls": 4,
-            "duration": 8,
             "inputTokens": 13,
             "outputTokens": 24,
           },

--- a/packages/core/test/aigne/__snapshots__/aigne.test.ts.snap
+++ b/packages/core/test/aigne/__snapshots__/aigne.test.ts.snap
@@ -9,7 +9,7 @@ exports[`AIGNE.invoke should respond progressing chunks correctly 1`] = `
       },
       "event": "agentStarted",
       "input": {
-        "$message": "hello",
+        "message": "hello",
       },
     },
   },
@@ -36,91 +36,91 @@ exports[`AIGNE.invoke should respond progressing chunks correctly 1`] = `
   {
     "delta": {
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": ",",
+        "message": ",",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "How",
+        "message": "How",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "can",
+        "message": "can",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "I",
+        "message": "I",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "assist",
+        "message": "assist",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "you",
+        "message": "you",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
@@ -138,14 +138,14 @@ exports[`AIGNE.invoke should respond progressing chunks correctly 1`] = `
   {
     "delta": {
       "text": {
-        "$message": "today",
+        "message": "today",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": "?",
+        "message": "?",
       },
     },
   },
@@ -156,7 +156,7 @@ exports[`AIGNE.invoke should respond progressing chunks correctly 1`] = `
       },
       "event": "agentSucceed",
       "output": {
-        "$message": "Hello, How can I assist you today?",
+        "message": "Hello, How can I assist you today?",
       },
     },
   },
@@ -172,7 +172,7 @@ exports[`AIGNE.invoke should respond progressing chunks (with failed chunks) cor
       },
       "event": "agentStarted",
       "input": {
-        "$message": "hello",
+        "message": "hello",
       },
     },
   },
@@ -208,7 +208,7 @@ exports[`AIGNE.invoke should respond progressing chunks (with failed chunks) cor
   {
     "delta": {
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
@@ -224,7 +224,7 @@ exports[`AIGNE.invoke should respond progressing chunks (with failed chunks) cor
   {
     "delta": {
       "text": {
-        "$message": " world",
+        "message": " world",
       },
     },
   },
@@ -240,21 +240,20 @@ exports[`AIGNE.invoke should respond $meta field with usage metrics with {
   {
     "delta": {
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "$message": " world",
+        "message": " world",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello world",
         "$meta": {
           "usage": {
             "agentCalls": 4,
@@ -262,6 +261,7 @@ exports[`AIGNE.invoke should respond $meta field with usage metrics with {
             "outputTokens": 24,
           },
         },
+        "message": "Hello world",
       },
     },
   },

--- a/packages/core/test/aigne/aigne.test.ts
+++ b/packages/core/test/aigne/aigne.test.ts
@@ -17,7 +17,7 @@ import {
   readableStreamToArray,
   stringToAgentResponseStream,
 } from "@aigne/core/utils/stream-utils.js";
-import { omit } from "@aigne/core/utils/type-utils.js";
+import { omit, omitDeep } from "@aigne/core/utils/type-utils.js";
 import { OpenAIChatModel } from "../_mocks/mock-models.js";
 import { createToolCallResponse } from "../_utils/openai-like-utils.js";
 
@@ -567,14 +567,15 @@ test.each<[InvokeOptions]>([
 
   if (options.streaming) {
     assert(response instanceof ReadableStream);
-    expect(await readableStreamToArray(response, { catchError: true })).toMatchSnapshot();
+    expect(
+      omitDeep(await readableStreamToArray(response, { catchError: true }), "duration"),
+    ).toMatchSnapshot();
   } else {
-    expect(response).toMatchInlineSnapshot(`
+    expect(omitDeep(response, "duration")).toMatchInlineSnapshot(`
         {
           "$meta": {
             "usage": {
               "agentCalls": 4,
-              "duration": 3,
               "inputTokens": 13,
               "outputTokens": 24,
             },

--- a/packages/core/test/aigne/aigne.test.ts
+++ b/packages/core/test/aigne/aigne.test.ts
@@ -574,6 +574,7 @@ test.each<[InvokeOptions]>([
           "$meta": {
             "usage": {
               "agentCalls": 4,
+              "duration": 3,
               "inputTokens": 13,
               "outputTokens": 24,
             },

--- a/packages/core/test/aigne/aigne.test.ts
+++ b/packages/core/test/aigne/aigne.test.ts
@@ -8,7 +8,6 @@ import {
   type MessageQueueListener,
   UserInputTopic,
   UserOutputTopic,
-  createMessage,
   isAgentResponseDelta,
   isAgentResponseProgress,
 } from "@aigne/core";
@@ -38,12 +37,13 @@ test("AIGNE simple example", async () => {
   const agent = AIAgent.from({
     name: "chat",
     description: "A chat agent",
+    inputKey: "message",
   });
 
-  const result = await aigne.invoke(agent, "hello");
-  console.log(result); // { $message: "Hello, How can I assist you today?" }
+  const result = await aigne.invoke(agent, { message: "hello" });
+  console.log(result); // { message: "Hello, How can I assist you today?" }
 
-  expect(result).toEqual({ $message: "Hello, How can I assist you today?" });
+  expect(result).toEqual({ message: "Hello, How can I assist you today?" });
   // #endregion example-simple
 });
 
@@ -63,14 +63,15 @@ test("AIGNE example with streaming response", async () => {
   const agent = AIAgent.from({
     name: "chat",
     description: "A chat agent",
+    inputKey: "message",
   });
 
   let text = "";
 
-  const stream = await aigne.invoke(agent, "hello", { streaming: true });
+  const stream = await aigne.invoke(agent, { message: "hello" }, { streaming: true });
   for await (const chunk of stream) {
-    if (isAgentResponseDelta(chunk) && chunk.delta.text?.$message) {
-      text += chunk.delta.text.$message;
+    if (isAgentResponseDelta(chunk) && chunk.delta.text?.message) {
+      text += chunk.delta.text.message;
     }
   }
 
@@ -97,9 +98,10 @@ test("AIGNE example shutdown", async () => {
   const agent = AIAgent.from({
     name: "chat",
     description: "A chat agent",
+    inputKey: "message",
   });
 
-  await aigne.invoke(agent, "hello");
+  await aigne.invoke(agent, { message: "hello" });
 
   await aigne.shutdown();
   // #endregion example-shutdown
@@ -121,9 +123,10 @@ test("AIGNE example shutdown by `using` statement", async () => {
   const agent = AIAgent.from({
     name: "chat",
     description: "A chat agent",
+    inputKey: "message",
   });
 
-  await aigne.invoke(agent, "hello");
+  await aigne.invoke(agent, { message: "hello" });
 
   // aigne will be automatically shutdown when exiting the using block
 
@@ -148,19 +151,20 @@ test("AIGNE example invoke get an user agent ", async () => {
   const agent = AIAgent.from({
     name: "chat",
     description: "A chat agent",
+    inputKey: "message",
   });
 
   const userAgent = aigne.invoke(agent);
 
-  const result1 = await userAgent.invoke("hello");
-  console.log(result1); // { $message: "Hello, How can I assist you today?" }
+  const result1 = await userAgent.invoke({ message: "hello" });
+  console.log(result1); // { message: "Hello, How can I assist you today?" }
 
-  expect(result1).toEqual({ $message: "Hello, How can I assist you today?" });
+  expect(result1).toEqual({ message: "Hello, How can I assist you today?" });
 
-  const result2 = await userAgent.invoke("I'm Bob!");
-  console.log(result2); // { $message: "Nice to meet you, Bob!" }
+  const result2 = await userAgent.invoke({ message: "I'm Bob!" });
+  console.log(result2); // { message: "Nice to meet you, Bob!" }
 
-  expect(result2).toEqual({ $message: "Nice to meet you, Bob!" });
+  expect(result2).toEqual({ message: "Nice to meet you, Bob!" });
   // #endregion example-user-agent
 });
 
@@ -177,6 +181,7 @@ test("AIGNE example publish message", async () => {
     description: "A chat agent",
     subscribeTopic: "test_topic",
     publishTopic: "result_topic",
+    inputKey: "message",
   });
 
   // AIGNE: Main execution engine of AIGNE Framework.
@@ -188,13 +193,13 @@ test("AIGNE example publish message", async () => {
 
   const subscription = aigne.subscribe("result_topic");
 
-  aigne.publish("test_topic", "hello");
+  aigne.publish("test_topic", { message: "hello" });
 
   const { message } = await subscription;
 
-  console.log(message); // { $message: "Hello, How can I assist you today?" }
+  console.log(message); // { message: "Hello, How can I assist you today?" }
 
-  expect(message).toEqual({ $message: "Hello, How can I assist you today?" });
+  expect(message).toEqual({ message: "Hello, How can I assist you today?" });
   // #endregion example-publish-message
 });
 
@@ -211,6 +216,7 @@ test("AIGNE example subscribe topic", async () => {
     description: "A chat agent",
     subscribeTopic: "test_topic",
     publishTopic: "result_topic",
+    inputKey: "message",
   });
 
   // AIGNE: Main execution engine of AIGNE Framework.
@@ -221,12 +227,12 @@ test("AIGNE example subscribe topic", async () => {
   });
 
   const unsubscribe = aigne.subscribe("result_topic", ({ message }) => {
-    console.log(message); // { $message: "Hello, How can I assist you today?" }
+    console.log(message); // { message: "Hello, How can I assist you today?" }
 
     unsubscribe();
   });
 
-  aigne.publish("test_topic", "hello");
+  aigne.publish("test_topic", { message: "hello" });
 
   // #endregion example-subscribe-topic
 });
@@ -314,7 +320,9 @@ test("AIGNE should throw error if reached max tokens", async () => {
     },
   });
 
-  const agent = AIAgent.from({});
+  const agent = AIAgent.from({
+    inputKey: "message",
+  });
 
   const aigne = new AIGNE({
     model,
@@ -323,10 +331,10 @@ test("AIGNE should throw error if reached max tokens", async () => {
     },
   });
 
-  expect(aigne.invoke(agent, "test")).resolves.toEqual(createMessage("hello"));
-  expect(aigne.invoke(TeamAgent.from({ skills: [agent, agent] }), "test")).rejects.toThrow(
-    "Exceeded max tokens 300/200",
-  );
+  expect(aigne.invoke(agent, { message: "test" })).resolves.toEqual({ message: "hello" });
+  expect(
+    aigne.invoke(TeamAgent.from({ skills: [agent, agent] }), { message: "test" }),
+  ).rejects.toThrow("Exceeded max tokens 300/200");
 });
 
 test("AIGNE should throw timeout error", async () => {
@@ -355,14 +363,12 @@ test("AIGNEContext should subscribe/unsubscribe correctly", async () => {
 
   aigne.subscribe("test_topic", listener);
 
-  aigne.publish("test_topic", "hello");
+  aigne.publish("test_topic", { message: "hello" });
   expect(listener).toBeCalledTimes(1);
-  expect(listener).toHaveBeenCalledWith(
-    expect.objectContaining({ message: createMessage("hello") }),
-  );
+  expect(listener).toHaveBeenCalledWith(expect.objectContaining({ message: { message: "hello" } }));
 
   aigne.unsubscribe("test_topic", listener);
-  aigne.publish("test_topic", "hello");
+  aigne.publish("test_topic", { message: "hello" });
   expect(listener).toBeCalledTimes(1);
 });
 
@@ -382,9 +388,13 @@ test("AIGNE.invoke support custom user context", async () => {
   const agentProcess = spyOn(agent, "process");
   const childAgentProcess = spyOn(childAgent, "process");
 
-  const result = await aigne.invoke(agent, "hello", {
-    userContext: { id: "test_user_id", name: "test_user_name" },
-  });
+  const result = await aigne.invoke(
+    agent,
+    { message: "hello" },
+    {
+      userContext: { id: "test_user_id", name: "test_user_name" },
+    },
+  );
   expect(result).toEqual({ text: "I am a child agent" });
   expect(agentProcess).toHaveBeenLastCalledWith(
     expect.anything(),
@@ -428,9 +438,13 @@ test("AIGNE.publish support custom user context", async () => {
     text: "I am a test agent",
   });
   const result = aigne.subscribe("test_topic");
-  aigne.publish("test_topic1", "hello", {
-    userContext: { id: "test_user_id", name: "test_user_name" },
-  });
+  aigne.publish(
+    "test_topic1",
+    { message: "hello" },
+    {
+      userContext: { id: "test_user_id", name: "test_user_name" },
+    },
+  );
   const { message: response } = await result;
   expect(response).toEqual({ text: "I am a test agent" });
   expect(agentProcess).toHaveBeenLastCalledWith(
@@ -456,12 +470,17 @@ test("AIGNE.invoke should respond progressing chunks correctly", async () => {
 
   const agent = AIAgent.from({
     name: "chat",
+    inputKey: "message",
   });
 
-  const stream = await aigne.invoke(agent, "hello", {
-    streaming: true,
-    returnProgressChunks: true,
-  });
+  const stream = await aigne.invoke(
+    agent,
+    { message: "hello" },
+    {
+      streaming: true,
+      returnProgressChunks: true,
+    },
+  );
   expect(
     (await readableStreamToArray(stream)).map((i) =>
       isAgentResponseProgress(i)
@@ -489,12 +508,17 @@ test("AIGNE.invoke should respond progressing chunks (with failed chunks) correc
 
   const agent = AIAgent.from({
     name: "chat",
+    inputKey: "message",
   });
 
-  const stream = await aigne.invoke(agent, "hello", {
-    streaming: true,
-    returnProgressChunks: true,
-  });
+  const stream = await aigne.invoke(
+    agent,
+    { message: "hello" },
+    {
+      streaming: true,
+      returnProgressChunks: true,
+    },
+  );
   expect(
     (await readableStreamToArray(stream, { catchError: true })).map((i) =>
       !(i instanceof Error) && isAgentResponseProgress(i)
@@ -533,13 +557,13 @@ test.each<[InvokeOptions]>([
       FunctionAgent.from({
         name: "greet",
         process: () => ({
-          $message: "Hello world",
+          message: "Hello world",
         }),
       }),
     ],
   });
 
-  const response = await aigne.invoke(agent, "hello", options);
+  const response = await aigne.invoke(agent, { message: "hello" }, options);
 
   if (options.streaming) {
     assert(response instanceof ReadableStream);
@@ -547,7 +571,6 @@ test.each<[InvokeOptions]>([
   } else {
     expect(response).toMatchInlineSnapshot(`
         {
-          "$message": "Hello world",
           "$meta": {
             "usage": {
               "agentCalls": 4,
@@ -555,6 +578,7 @@ test.each<[InvokeOptions]>([
               "outputTokens": 24,
             },
           },
+          "message": "Hello world",
         }
       `);
   }

--- a/packages/core/test/aigne/message-queue.test.ts
+++ b/packages/core/test/aigne/message-queue.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { AIGNE, MessageQueue, createMessage } from "@aigne/core";
+import { AIGNE, MessageQueue } from "@aigne/core";
 
 test("MessageQueue.subscribe should resolve a message", async () => {
   const context = new AIGNE().newContext();
@@ -9,13 +9,13 @@ test("MessageQueue.subscribe should resolve a message", async () => {
   const message = messageQueue.subscribe("test_topic");
   messageQueue.publish("test_topic", {
     role: "user",
-    message: createMessage("hello"),
+    message: { message: "hello" },
     source: "test_user",
     context,
   });
   expect(message).resolves.toEqual({
     role: "user",
-    message: createMessage("hello"),
+    message: { message: "hello" },
     source: "test_user",
     context,
   });

--- a/packages/core/test/loader/loader.test.ts
+++ b/packages/core/test/loader/loader.test.ts
@@ -1,7 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
 import assert from "node:assert";
 import { join } from "node:path";
-import { AIAgent, AIGNE, ChatModel, MCPAgent, createMessage } from "@aigne/core";
+import { AIAgent, AIGNE, ChatModel, MCPAgent } from "@aigne/core";
 import { load, loadAgent } from "@aigne/core/loader/index.js";
 import { nodejs } from "@aigne/platform-helpers/nodejs/index.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -50,8 +50,8 @@ test("AIGNE.load should load agents correctly", async () => {
     )
     .mockReturnValueOnce(Promise.resolve({ text: "1 + 2 = 3" }));
 
-  const result = await aigne.invoke(chat, "1 + 2 = ?");
-  expect(result).toEqual(expect.objectContaining(createMessage("1 + 2 = 3")));
+  const result = await aigne.invoke(chat, { message: "1 + 2 = ?" });
+  expect(result).toEqual(expect.objectContaining({ message: "1 + 2 = 3" }));
 });
 
 test("loader should use override options", async () => {

--- a/packages/core/test/memory/memory.test.ts
+++ b/packages/core/test/memory/memory.test.ts
@@ -5,5 +5,5 @@ test("should add a new memory if it is not the same as the last one", async () =
   const memoryAgent = new MemoryAgent({});
 
   expect(memoryAgent.isCallable).toBe(false);
-  expect(memoryAgent.invoke("hello")).rejects.toThrow("not implemented");
+  expect(memoryAgent.invoke({ message: "hello" })).rejects.toThrow("not implemented");
 });

--- a/packages/core/test/prompt/prompt-builder.test.ts
+++ b/packages/core/test/prompt/prompt-builder.test.ts
@@ -7,21 +7,13 @@ import {
   AIGNE,
   FunctionAgent,
   MCPAgent,
-  MESSAGE_KEY,
   PromptBuilder,
   TeamAgent,
-  createMessage,
 } from "@aigne/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { MockMemory } from "../_mocks/mock-memory.js";
-
-test("userInput function should return correct object", () => {
-  const message = "Hello";
-  const result = createMessage(message);
-  expect(result).toEqual({ [MESSAGE_KEY]: message });
-});
 
 test("PromptBuilder should build messages correctly", async () => {
   const context = new AIGNE().newContext();
@@ -32,7 +24,7 @@ test("PromptBuilder should build messages correctly", async () => {
   await memory.record(
     {
       role: "agent",
-      content: [createMessage("Hello, How can I help you?")],
+      content: [{ message: "Hello, How can I help you?" }],
       source: "TestAgent",
     },
 
@@ -41,11 +33,12 @@ test("PromptBuilder should build messages correctly", async () => {
 
   const agent = AIAgent.from({
     memory,
+    inputKey: "message",
   });
 
   const prompt1 = await builder.build({
     agent,
-    input: createMessage("Hello"),
+    input: { message: "Hello" },
     context,
   });
 
@@ -65,7 +58,7 @@ test("PromptBuilder should build messages correctly", async () => {
   ]);
 
   const prompt2 = await builder.build({
-    input: createMessage({ name: "foo" }),
+    input: { name: "foo" },
     context,
   });
   expect(prompt2.messages).toEqual([

--- a/packages/core/test/prompt/prompt-builder.test.ts
+++ b/packages/core/test/prompt/prompt-builder.test.ts
@@ -353,7 +353,7 @@ test("PromptBuilder from file", async () => {
   const path = join(import.meta.dirname, "test-prompt.txt");
   const content = await readFile(path, "utf-8");
 
-  const builder = await PromptBuilder.from({ path });
+  const builder = PromptBuilder.from({ path });
 
   const prompt = await builder.build({ input: { agentName: "Alice" }, context });
 

--- a/packages/core/test/utils/type-utils.test.ts
+++ b/packages/core/test/utils/type-utils.test.ts
@@ -11,6 +11,7 @@ import {
   isRecord,
   omit,
   omitBy,
+  omitDeep,
   orArrayToArray,
   remove,
   tryOrThrow,
@@ -90,6 +91,14 @@ test("type-utils.omit", async () => {
   expect(omit({ foo: 1, bar: 2 }, "foo")).toEqual({ bar: 2 });
 
   expect(omit({ foo: 1, bar: 2 }, ["foo"])).toEqual({ bar: 2 });
+});
+
+test("type-utils.omitDeep should omit nested properties", async () => {
+  expect(omitDeep({ foo: { bar: 1, baz: 2 }, qux: 3 }, "bar")).toEqual({ foo: { baz: 2 }, qux: 3 });
+  expect(omitDeep([{ foo: { bar: 1, baz: 2 } }, { qux: 3 }], "bar")).toEqual([
+    { foo: { baz: 2 } },
+    { qux: 3 },
+  ]);
 });
 
 test("type-utils.omitBy", async () => {

--- a/packages/platform-helpers/src/nodejs/index.browser.ts
+++ b/packages/platform-helpers/src/nodejs/index.browser.ts
@@ -13,6 +13,10 @@ export const nodejs = {
     throw new Error("This code must run in a Node.js environment.");
   },
 
+  get fsSync(): typeof import("node:fs") {
+    throw new Error("This code must run in a Node.js environment.");
+  },
+
   get path(): typeof import("node:path") {
     throw new Error("This code must run in a Node.js environment.");
   },

--- a/packages/platform-helpers/src/nodejs/index.node.ts
+++ b/packages/platform-helpers/src/nodejs/index.node.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { inspect } from "node:util";
@@ -19,6 +20,10 @@ export const nodejs = {
 
   get fs(): typeof import("node:fs/promises") {
     return fs;
+  },
+
+  get fsSync(): typeof import("node:fs") {
+    return fsSync;
   },
 
   get path(): typeof import("node:path") {

--- a/packages/transport/src/http-client/client-agent.ts
+++ b/packages/transport/src/http-client/client-agent.ts
@@ -6,7 +6,6 @@ import {
   type AgentResponse,
   type AgentResponseStream,
   type Message,
-  createMessage,
   replaceTransferAgentToName,
 } from "@aigne/core";
 import type { MemoryAgent } from "@aigne/core/memory/memory.js";
@@ -31,19 +30,16 @@ export class ClientAgent<I extends Message = Message, O extends Message = Messag
   }
 
   override async invoke(
-    input: string | I,
+    input: I,
     options?: Partial<AgentInvokeOptions> & { streaming?: false },
   ): Promise<O>;
   override async invoke(
-    input: string | I,
+    input: I,
     options: Partial<AgentInvokeOptions> & { streaming: true },
   ): Promise<AgentResponseStream<O>>;
+  override async invoke(input: I, options?: Partial<AgentInvokeOptions>): Promise<AgentResponse<O>>;
   override async invoke(
-    input: string | I,
-    options?: Partial<AgentInvokeOptions>,
-  ): Promise<AgentResponse<O>>;
-  override async invoke(
-    input: I | string,
+    input: I,
     options?: Partial<AgentInvokeOptions>,
   ): Promise<AgentResponse<O>> {
     const memories = await this.retrieveMemories(
@@ -57,7 +53,7 @@ export class ClientAgent<I extends Message = Message, O extends Message = Messag
       memories,
     });
     if (!(result instanceof ReadableStream)) {
-      await this.postprocess(createMessage(input) as I, result as O, {
+      await this.postprocess(input, result as O, {
         ...options,
         context: this.client,
       });
@@ -66,7 +62,7 @@ export class ClientAgent<I extends Message = Message, O extends Message = Messag
 
     return onAgentResponseStreamEnd(result, {
       onResult: async (result) => {
-        await this.postprocess(createMessage(input) as I, result as O, {
+        await this.postprocess(input, result, {
           ...options,
           context: this.client,
         });

--- a/packages/transport/src/http-client/client.ts
+++ b/packages/transport/src/http-client/client.ts
@@ -77,37 +77,37 @@ export class AIGNEHTTPClient<U extends UserContext = UserContext> implements Con
   invoke<I extends Message, O extends Message>(agent: Agent<I, O> | string): UserAgent<I, O>;
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O> | string,
-    message: I | string,
+    message: I,
     options: AIGNEHTTPClientInvokeOptions & { returnActiveAgent: true; streaming?: false },
   ): Promise<[O, Agent]>;
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O> | string,
-    message: I | string,
+    message: I,
     options: AIGNEHTTPClientInvokeOptions & { returnActiveAgent: true; streaming: true },
   ): Promise<[AgentResponseStream<O>, Promise<Agent>]>;
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O> | string,
-    message: I | string,
+    message: I,
     options?: AIGNEHTTPClientInvokeOptions & { returnActiveAgent?: false; streaming?: false },
   ): Promise<O>;
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O> | string,
-    message: I | string,
+    message: I,
     options: AIGNEHTTPClientInvokeOptions & { returnActiveAgent?: false; streaming: true },
   ): Promise<AgentResponseStream<O>>;
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O> | string,
-    message: I | string,
+    message: I,
     options: AIGNEHTTPClientInvokeOptions & { returnActiveAgent?: false },
   ): Promise<O | AgentResponseStream<O>>;
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O> | string,
-    message?: I | string,
+    message?: I,
     options?: AIGNEHTTPClientInvokeOptions,
   ): UserAgent<I, O> | Promise<AgentResponse<O> | [AgentResponse<O>, Agent]>;
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O> | string,
-    message?: I | string,
+    message?: I,
     options?: AIGNEHTTPClientInvokeOptions,
   ): UserAgent<I, O> | Promise<AgentResponse<O> | [AgentResponse<O>, Agent]> {
     if (options?.returnActiveAgent) throw new Error("Method not implemented.");

--- a/packages/transport/src/http-server/server.ts
+++ b/packages/transport/src/http-server/server.ts
@@ -23,7 +23,7 @@ const DEFAULT_MAXIMUM_BODY_SIZE = "4mb";
  */
 export const invokePayloadSchema = z.object({
   agent: z.string(),
-  input: z.union([z.string(), z.record(z.string(), z.unknown())]),
+  input: z.record(z.string(), z.unknown()),
   options: z
     .object({
       streaming: z

--- a/packages/transport/test/http-client/__snapshots__/http-client.test.ts.snap
+++ b/packages/transport/test/http-client/__snapshots__/http-client.test.ts.snap
@@ -7,40 +7,40 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello ",
+        "message": "Hello ",
       },
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello world",
+        "message": "Hello world",
       },
       "text": {
-        "$message": "world",
+        "message": "world",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello world!",
+        "message": "Hello world!",
       },
       "text": {
-        "$message": "!",
+        "message": "!",
       },
     },
   },
@@ -60,7 +60,7 @@ exports[`AIGNEClient should return correct process options {
       "contextId": "TEST_CONTEXT_ID",
       "event": "agentStarted",
       "input": {
-        "$message": "hello",
+        "message": "hello",
       },
       "parentContextId": "TEST_PARENT_CONTEXT_ID",
       "timestamp": 123456,
@@ -88,10 +88,10 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
@@ -112,20 +112,20 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello ",
+        "message": "Hello ",
       },
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello world",
+        "message": "Hello world",
       },
       "text": {
-        "$message": "world",
+        "message": "world",
       },
     },
   },
@@ -137,7 +137,7 @@ exports[`AIGNEClient should return correct process options {
       "contextId": "TEST_CONTEXT_ID",
       "event": "agentSucceed",
       "output": {
-        "$message": "Hello world!",
+        "message": "Hello world!",
       },
       "parentContextId": "TEST_PARENT_CONTEXT_ID",
       "timestamp": 123456,
@@ -146,10 +146,10 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello world!",
+        "message": "Hello world!",
       },
       "text": {
-        "$message": "!",
+        "message": "!",
       },
     },
   },
@@ -160,7 +160,7 @@ exports[`AIGNEClient should return correct process options {
   streaming: false,
 } for express server 1`] = `
 {
-  "$message": "Hello world!",
+  "message": "Hello world!",
 }
 `;
 
@@ -171,40 +171,40 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello ",
+        "message": "Hello ",
       },
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello world",
+        "message": "Hello world",
       },
       "text": {
-        "$message": "world",
+        "message": "world",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello world!",
+        "message": "Hello world!",
       },
       "text": {
-        "$message": "!",
+        "message": "!",
       },
     },
   },
@@ -224,7 +224,7 @@ exports[`AIGNEClient should return correct process options {
       "contextId": "TEST_CONTEXT_ID",
       "event": "agentStarted",
       "input": {
-        "$message": "hello",
+        "message": "hello",
       },
       "parentContextId": "TEST_PARENT_CONTEXT_ID",
       "timestamp": 123456,
@@ -252,10 +252,10 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
@@ -276,20 +276,20 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello ",
+        "message": "Hello ",
       },
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello world",
+        "message": "Hello world",
       },
       "text": {
-        "$message": "world",
+        "message": "world",
       },
     },
   },
@@ -301,7 +301,7 @@ exports[`AIGNEClient should return correct process options {
       "contextId": "TEST_CONTEXT_ID",
       "event": "agentSucceed",
       "output": {
-        "$message": "Hello world!",
+        "message": "Hello world!",
       },
       "parentContextId": "TEST_PARENT_CONTEXT_ID",
       "timestamp": 123456,
@@ -310,10 +310,10 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello world!",
+        "message": "Hello world!",
       },
       "text": {
-        "$message": "!",
+        "message": "!",
       },
     },
   },
@@ -324,7 +324,7 @@ exports[`AIGNEClient should return correct process options {
   streaming: false,
 } for express (with json middleware) server 1`] = `
 {
-  "$message": "Hello world!",
+  "message": "Hello world!",
 }
 `;
 
@@ -335,40 +335,40 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello ",
+        "message": "Hello ",
       },
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello world",
+        "message": "Hello world",
       },
       "text": {
-        "$message": "world",
+        "message": "world",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello world!",
+        "message": "Hello world!",
       },
       "text": {
-        "$message": "!",
+        "message": "!",
       },
     },
   },
@@ -388,7 +388,7 @@ exports[`AIGNEClient should return correct process options {
       "contextId": "TEST_CONTEXT_ID",
       "event": "agentStarted",
       "input": {
-        "$message": "hello",
+        "message": "hello",
       },
       "parentContextId": "TEST_PARENT_CONTEXT_ID",
       "timestamp": 123456,
@@ -416,10 +416,10 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
@@ -440,20 +440,20 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello ",
+        "message": "Hello ",
       },
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello world",
+        "message": "Hello world",
       },
       "text": {
-        "$message": "world",
+        "message": "world",
       },
     },
   },
@@ -465,7 +465,7 @@ exports[`AIGNEClient should return correct process options {
       "contextId": "TEST_CONTEXT_ID",
       "event": "agentSucceed",
       "output": {
-        "$message": "Hello world!",
+        "message": "Hello world!",
       },
       "parentContextId": "TEST_PARENT_CONTEXT_ID",
       "timestamp": 123456,
@@ -474,10 +474,10 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello world!",
+        "message": "Hello world!",
       },
       "text": {
-        "$message": "!",
+        "message": "!",
       },
     },
   },
@@ -488,7 +488,7 @@ exports[`AIGNEClient should return correct process options {
   streaming: false,
 } for express (with compression middleware) server 1`] = `
 {
-  "$message": "Hello world!",
+  "message": "Hello world!",
 }
 `;
 
@@ -499,40 +499,40 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello ",
+        "message": "Hello ",
       },
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello world",
+        "message": "Hello world",
       },
       "text": {
-        "$message": "world",
+        "message": "world",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello world!",
+        "message": "Hello world!",
       },
       "text": {
-        "$message": "!",
+        "message": "!",
       },
     },
   },
@@ -552,7 +552,7 @@ exports[`AIGNEClient should return correct process options {
       "contextId": "TEST_CONTEXT_ID",
       "event": "agentStarted",
       "input": {
-        "$message": "hello",
+        "message": "hello",
       },
       "parentContextId": "TEST_PARENT_CONTEXT_ID",
       "timestamp": 123456,
@@ -580,10 +580,10 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
@@ -604,20 +604,20 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello ",
+        "message": "Hello ",
       },
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello world",
+        "message": "Hello world",
       },
       "text": {
-        "$message": "world",
+        "message": "world",
       },
     },
   },
@@ -629,7 +629,7 @@ exports[`AIGNEClient should return correct process options {
       "contextId": "TEST_CONTEXT_ID",
       "event": "agentSucceed",
       "output": {
-        "$message": "Hello world!",
+        "message": "Hello world!",
       },
       "parentContextId": "TEST_PARENT_CONTEXT_ID",
       "timestamp": 123456,
@@ -638,10 +638,10 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello world!",
+        "message": "Hello world!",
       },
       "text": {
-        "$message": "!",
+        "message": "!",
       },
     },
   },
@@ -652,7 +652,7 @@ exports[`AIGNEClient should return correct process options {
   streaming: false,
 } for express (pass body directly) server 1`] = `
 {
-  "$message": "Hello world!",
+  "message": "Hello world!",
 }
 `;
 
@@ -663,40 +663,40 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello ",
+        "message": "Hello ",
       },
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello world",
+        "message": "Hello world",
       },
       "text": {
-        "$message": "world",
+        "message": "world",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello world!",
+        "message": "Hello world!",
       },
       "text": {
-        "$message": "!",
+        "message": "!",
       },
     },
   },
@@ -716,7 +716,7 @@ exports[`AIGNEClient should return correct process options {
       "contextId": "TEST_CONTEXT_ID",
       "event": "agentStarted",
       "input": {
-        "$message": "hello",
+        "message": "hello",
       },
       "parentContextId": "TEST_PARENT_CONTEXT_ID",
       "timestamp": 123456,
@@ -744,10 +744,10 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
@@ -768,20 +768,20 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello ",
+        "message": "Hello ",
       },
       "text": {
-        "$message": " ",
+        "message": " ",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello world",
+        "message": "Hello world",
       },
       "text": {
-        "$message": "world",
+        "message": "world",
       },
     },
   },
@@ -793,7 +793,7 @@ exports[`AIGNEClient should return correct process options {
       "contextId": "TEST_CONTEXT_ID",
       "event": "agentSucceed",
       "output": {
-        "$message": "Hello world!",
+        "message": "Hello world!",
       },
       "parentContextId": "TEST_PARENT_CONTEXT_ID",
       "timestamp": 123456,
@@ -802,10 +802,10 @@ exports[`AIGNEClient should return correct process options {
   {
     "delta": {
       "json": {
-        "$message": "Hello world!",
+        "message": "Hello world!",
       },
       "text": {
-        "$message": "!",
+        "message": "!",
       },
     },
   },
@@ -816,7 +816,7 @@ exports[`AIGNEClient should return correct process options {
   streaming: false,
 } for hono server 1`] = `
 {
-  "$message": "Hello world!",
+  "message": "Hello world!",
 }
 `;
 
@@ -827,20 +827,20 @@ exports[`AIGNEClient should return error with options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello, world",
+        "message": "Hello, world",
       },
       "text": {
-        "$message": ", world",
+        "message": ", world",
       },
     },
   },
@@ -861,7 +861,7 @@ exports[`AIGNEClient should return error with options {
       "contextId": "TEST_CONTEXT_ID",
       "event": "agentStarted",
       "input": {
-        "$message": "hello",
+        "message": "hello",
       },
       "parentContextId": "TEST_PARENT_CONTEXT_ID",
       "timestamp": 123456,
@@ -901,10 +901,10 @@ exports[`AIGNEClient should return error with options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
@@ -923,10 +923,10 @@ exports[`AIGNEClient should return error with options {
   {
     "delta": {
       "json": {
-        "$message": "Hello, world",
+        "message": "Hello, world",
       },
       "text": {
-        "$message": ", world",
+        "message": ", world",
       },
     },
   },
@@ -941,20 +941,20 @@ exports[`AIGNEClient should return error with options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello, world",
+        "message": "Hello, world",
       },
       "text": {
-        "$message": ", world",
+        "message": ", world",
       },
     },
   },
@@ -975,7 +975,7 @@ exports[`AIGNEClient should return error with options {
       "contextId": "TEST_CONTEXT_ID",
       "event": "agentStarted",
       "input": {
-        "$message": "hello",
+        "message": "hello",
       },
       "parentContextId": "TEST_PARENT_CONTEXT_ID",
       "timestamp": 123456,
@@ -1015,10 +1015,10 @@ exports[`AIGNEClient should return error with options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
@@ -1037,10 +1037,10 @@ exports[`AIGNEClient should return error with options {
   {
     "delta": {
       "json": {
-        "$message": "Hello, world",
+        "message": "Hello, world",
       },
       "text": {
-        "$message": ", world",
+        "message": ", world",
       },
     },
   },
@@ -1055,20 +1055,20 @@ exports[`AIGNEClient should return error with options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello, world",
+        "message": "Hello, world",
       },
       "text": {
-        "$message": ", world",
+        "message": ", world",
       },
     },
   },
@@ -1089,7 +1089,7 @@ exports[`AIGNEClient should return error with options {
       "contextId": "TEST_CONTEXT_ID",
       "event": "agentStarted",
       "input": {
-        "$message": "hello",
+        "message": "hello",
       },
       "parentContextId": "TEST_PARENT_CONTEXT_ID",
       "timestamp": 123456,
@@ -1129,10 +1129,10 @@ exports[`AIGNEClient should return error with options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
@@ -1151,10 +1151,10 @@ exports[`AIGNEClient should return error with options {
   {
     "delta": {
       "json": {
-        "$message": "Hello, world",
+        "message": "Hello, world",
       },
       "text": {
-        "$message": ", world",
+        "message": ", world",
       },
     },
   },
@@ -1169,20 +1169,20 @@ exports[`AIGNEClient should return error with options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello, world",
+        "message": "Hello, world",
       },
       "text": {
-        "$message": ", world",
+        "message": ", world",
       },
     },
   },
@@ -1203,7 +1203,7 @@ exports[`AIGNEClient should return error with options {
       "contextId": "TEST_CONTEXT_ID",
       "event": "agentStarted",
       "input": {
-        "$message": "hello",
+        "message": "hello",
       },
       "parentContextId": "TEST_PARENT_CONTEXT_ID",
       "timestamp": 123456,
@@ -1243,10 +1243,10 @@ exports[`AIGNEClient should return error with options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
@@ -1265,10 +1265,10 @@ exports[`AIGNEClient should return error with options {
   {
     "delta": {
       "json": {
-        "$message": "Hello, world",
+        "message": "Hello, world",
       },
       "text": {
-        "$message": ", world",
+        "message": ", world",
       },
     },
   },
@@ -1283,20 +1283,20 @@ exports[`AIGNEClient should return error with options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
   {
     "delta": {
       "json": {
-        "$message": "Hello, world",
+        "message": "Hello, world",
       },
       "text": {
-        "$message": ", world",
+        "message": ", world",
       },
     },
   },
@@ -1317,7 +1317,7 @@ exports[`AIGNEClient should return error with options {
       "contextId": "TEST_CONTEXT_ID",
       "event": "agentStarted",
       "input": {
-        "$message": "hello",
+        "message": "hello",
       },
       "parentContextId": "TEST_PARENT_CONTEXT_ID",
       "timestamp": 123456,
@@ -1357,10 +1357,10 @@ exports[`AIGNEClient should return error with options {
   {
     "delta": {
       "json": {
-        "$message": "Hello",
+        "message": "Hello",
       },
       "text": {
-        "$message": "Hello",
+        "message": "Hello",
       },
     },
   },
@@ -1379,10 +1379,10 @@ exports[`AIGNEClient should return error with options {
   {
     "delta": {
       "json": {
-        "$message": "Hello, world",
+        "message": "Hello, world",
       },
       "text": {
-        "$message": ", world",
+        "message": ", world",
       },
     },
   },

--- a/packages/transport/test/http-client/http-client.test.ts
+++ b/packages/transport/test/http-client/http-client.test.ts
@@ -6,7 +6,6 @@ import {
   ChatModel,
   type ContextEventMap,
   type Message,
-  createMessage,
   isAgentResponseDelta,
 } from "@aigne/core";
 import {
@@ -40,11 +39,11 @@ test("AIGNEClient example simple", async () => {
 
   const client = new AIGNEHTTPClient({ url });
 
-  const response = await client.invoke("chat", { $message: "hello" });
+  const response = await client.invoke("chat", { message: "hello" });
 
-  console.log(response); // Output: {$message: "Hello world!"}
+  console.log(response); // Output: {message: "Hello world!"}
 
-  expect(response).toEqual({ $message: "Hello world!" });
+  expect(response).toEqual({ message: "Hello world!" });
 
   // #endregion example-aigne-client-simple
 
@@ -64,12 +63,12 @@ test("AIGNEClient example with streaming", async () => {
 
   const client = new AIGNEHTTPClient({ url });
 
-  const stream = await client.invoke("chat", { $message: "hello" }, { streaming: true });
+  const stream = await client.invoke("chat", { message: "hello" }, { streaming: true });
 
   let text = "";
   for await (const chunk of stream) {
     if (isAgentResponseDelta(chunk)) {
-      if (chunk.delta.text?.$message) text += chunk.delta.text.$message;
+      if (chunk.delta.text?.message) text += chunk.delta.text.message;
     }
   }
 
@@ -126,7 +125,7 @@ test.each(table)(
       );
 
       const client = new AIGNEHTTPClient({ url });
-      const response = await client.invoke("chat", { $message: "hello" }, options);
+      const response = await client.invoke("chat", { message: "hello" }, options);
 
       if (options.streaming) {
         assert(response instanceof ReadableStream);
@@ -159,7 +158,7 @@ test.each(table)(
       );
 
       const client = new AIGNEHTTPClient({ url });
-      const response = client.invoke("chat", { $message: "hello" }, options);
+      const response = client.invoke("chat", { message: "hello" }, options);
 
       if (options.streaming) {
         const stream = await response;
@@ -226,7 +225,7 @@ test.each(table)(
       const response = client.invoke("chat", [] as unknown as Message, options);
 
       expect(response).rejects.toThrow(
-        "status 400: Invoke agent chat check arguments error: input: Expected string or object, received array",
+        "status 400: Invoke agent chat check arguments error: input: Expected object, received array",
       );
     } finally {
       await close();
@@ -276,20 +275,20 @@ test("AIGNEClient should support custom memory for client agent", async () => {
 
     const { storage } = memory;
 
-    const response = await clientAgent.invoke("Hello, I'm Bob!");
-    expect(response).toEqual({ $message: "Hello Bob, How can I help you?" });
+    const response = await clientAgent.invoke({ message: "Hello, I'm Bob!" });
+    expect(response).toEqual({ message: "Hello Bob, How can I help you?" });
 
     expect(storage).toEqual([
       expect.objectContaining({
         content: expect.objectContaining({
           role: "user",
-          content: createMessage("Hello, I'm Bob!"),
+          content: { message: "Hello, I'm Bob!" },
         }),
       }),
       expect.objectContaining({
         content: expect.objectContaining({
           role: "agent",
-          content: createMessage("Hello Bob, How can I help you?"),
+          content: { message: "Hello Bob, How can I help you?" },
         }),
       }),
     ]);
@@ -298,8 +297,8 @@ test("AIGNEClient should support custom memory for client agent", async () => {
       stringToAgentResponseStream("Your name is Bob."),
     );
 
-    const response2 = await clientAgent.invoke("My name is?");
-    expect(response2).toEqual({ $message: "Your name is Bob." });
+    const response2 = await clientAgent.invoke({ message: "My name is?" });
+    expect(response2).toEqual({ message: "Your name is Bob." });
     expect(modelProcess).toHaveBeenLastCalledWith(
       expect.objectContaining({
         messages: expect.arrayContaining([
@@ -387,6 +386,7 @@ async function createAIGNE() {
 
   const chat = AIAgent.from({
     name: "chat",
+    inputKey: "message",
   });
 
   return new AIGNE({ model, agents: [chat] });

--- a/packages/transport/test/http-server/__snapshots__/http-server.test.ts.snap
+++ b/packages/transport/test/http-server/__snapshots__/http-server.test.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`AIGNEServer example with expression 1`] = `
 {
-  "$message": "Hello world!",
+  "message": "Hello world!",
 }
 `;
 
 exports[`AIGNEServer example with hono 1`] = `
 {
-  "$message": "Hello world!",
+  "message": "Hello world!",
 }
 `;

--- a/packages/transport/test/http-server/http-server.test.ts
+++ b/packages/transport/test/http-server/http-server.test.ts
@@ -45,9 +45,9 @@ test("AIGNEServer example with expression", async () => {
   const client = new AIGNEHTTPClient({ url });
 
   // Invoke the agent by client
-  const response = await client.invoke("chat", { $message: "hello" });
+  const response = await client.invoke("chat", { message: "hello" });
 
-  console.log(response); // Output: {$message: "Hello world!"}
+  console.log(response); // Output: {message: "Hello world!"}
 
   expect(response).toMatchSnapshot();
 
@@ -92,8 +92,8 @@ test("AIGNEServer example with hono", async () => {
   const client = new AIGNEHTTPClient({ url });
 
   // Invoke the agent by client
-  const response = await client.invoke("chat", { $message: "hello" });
-  console.log(response); // Output: {$message: "Hello world!"}
+  const response = await client.invoke("chat", { message: "hello" });
+  console.log(response); // Output: {message: "Hello world!"}
 
   expect(response).toMatchSnapshot();
 

--- a/tests/nodejs/cli.test.ts
+++ b/tests/nodejs/cli.test.ts
@@ -24,6 +24,6 @@ test("AIGNE cli should work in Node.js", async () => {
   });
 
   expect(result?.result).toEqual({
-    $message: "Hello, I am a chatbot!",
+    message: "Hello, I am a chatbot!",
   });
 });

--- a/tests/nodejs/core.test.ts
+++ b/tests/nodejs/core.test.ts
@@ -6,6 +6,7 @@ test("AIGNE core should work in Node.js", async () => {
   const agent = AIAgent.from({
     name: "memory_example",
     instructions: "You are a friendly chatbot",
+    inputKey: "message",
   });
 
   const aigne = new AIGNE({
@@ -17,9 +18,9 @@ test("AIGNE core should work in Node.js", async () => {
     text: "Hello, I am a chatbot!",
   });
 
-  const result = await aigne.invoke(agent, "Hello, What is your name?");
+  const result = await aigne.invoke(agent, { message: "Hello, What is your name?" });
 
   expect(result).toEqual({
-    $message: "Hello, I am a chatbot!",
+    message: "Hello, I am a chatbot!",
   });
 });


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix: use `inputKey` instead of implicit $message for AIAgent
2. fix: refactor PromptBuilder.from to be synchronous
3. fix: add `duration` field in context.usage

### Checklist

- [x] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

Release Notes:

Major Changes:
- Refactor: Standardized message handling across all agents with explicit input/output keys
- Breaking Change: Removed string-only input support in favor of structured Message objects
- New Feature: Added configurable input keys for more flexible agent communication

Developer Experience:
- Bug Fix: Enhanced error handling and message validation
- Documentation: Updated examples and tests to reflect new message structure
- Refactor: Streamlined HTTP client/server communication patterns

This update improves message handling consistency and type safety across the framework. Users will need to update their code to use structured Message objects instead of plain strings. The new input key configuration offers more flexibility in agent communication patterns.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->