### PR TITLE
feat(cli): support pass named input to agent by --input-xxx

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -33,7 +33,8 @@
         "noExplicitAny": "off"
       },
       "complexity": {
-        "noForEach": "off"
+        "noForEach": "off",
+        "useLiteralKeys": "off"
       }
     }
   },

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,39 @@
+---
+labels: ["Get Started"]
+---
+
+# Getting Started
+
+Welcome to **AIGNE Framework** — a future-oriented AI application development framework designed for building modular, multi-agent collaborative application scenarios. Whether you're a beginner or an experienced developer, AIGNE helps you organize, compose, and deploy AI capabilities more efficiently.
+
+## Why Choose AIGNE?
+
+* 🧠 **Multi-Agent Support**: Agent-centric design for easily building collaborative workflows.
+* 🧩 **Modular Architecture**: Compose functional modules on demand with clear structure and easy extensibility.
+* 🔐 **Type Safety**: Built entirely with TypeScript to enhance development reliability.
+* ⚙️ **Multi-Model Compatibility**: Supports mainstream AI services including OpenAI, Claude, Gemini, Anthropic, and more.
+* 🛰 **Protocol-Based Communication**: Built-in MCP protocol supporting cross-system calls and collaboration.
+* 🌐 **Blocklet Integration**: Native support for Blocklet platform with one-click AI application deployment.
+
+## What Can I Build with AIGNE?
+
+* Build workflows composed of multiple AIs to achieve automated processing, content generation, information summarization, and more.
+* Design intelligent agents with state management and contextual understanding capabilities.
+* Unify AI service management across frontend, backend, and even edge devices.
+* Rapidly implement the full pipeline from prototype to production deployment, suitable for enterprise applications or personal projects.
+
+## Getting Started
+
+Follow the steps in the [Quick Start](./quick-start.md) documentation to get hands-on with AIGNE in just a few minutes:
+
+1. Install core modules;
+2. Create a simple Agent;
+3. Build workflows or connect external services;
+
+## Community & Support
+
+AIGNE is an open-source project built by a group of developers passionate about AI and systems engineering. We welcome you to:
+
+* Join our [developer community](https://community.arcblock.io/discussions/boards/aigne);
+* [Submit feedback and improvement suggestions](https://github.com/AIGNE-io/aigne-framework/issues) on GitHub;
+* [Contribute code or documentation](https://github.com/AIGNE-io/aigne-framework/blob/main/CHANGELOG.md) and help us shape the future of AI application development.

--- a/docs/getting-started/index.zh.md
+++ b/docs/getting-started/index.zh.md
@@ -1,0 +1,39 @@
+---
+labels: ["Get Started"]
+---
+
+# 入门指南
+
+欢迎使用 **AIGNE Framework** —— 一个面向未来的 AI 应用开发框架，专为构建模块化、多智能体协作的应用场景而设计。无论你是初学者还是资深开发者，AIGNE 都能帮助你更高效地组织、组合与部署 AI 能力。
+
+## 为什么选择 AIGNE？
+
+* 🧠 **多智能体支持**：以智能体为核心，轻松构建协作工作流。
+* 🧩 **模块化架构**：按需组合功能模块，结构清晰，易于扩展。
+* 🔐 **类型安全**：使用 TypeScript 全面构建，提升开发可靠性。
+* ⚙️ **多模型兼容**：支持主流 AI 服务，包括 OpenAI、Claude、Gemini、Anthropic 等。
+* 🛰 **协议化通信**：内置 MCP 协议，支持跨系统调用与协作。
+* 🌐 **Blocklet 集成**：原生支持 Blocklet 平台，一键部署 AI 应用。
+
+## 我可以用 AIGNE 做什么？
+
+* 构建由多个 AI 组成的工作流，实现自动化处理、内容生成、信息汇总等。
+* 设计具备状态管理、上下文理解能力的智能代理。
+* 在前端、后端甚至边缘设备中统一管理 AI 服务。
+* 快速实现从原型到生产部署的全流程，适用于企业级应用或个人项目。
+
+## 开始使用
+
+按照[快速开始](./quick-start.zh.md)文档中的步骤，你可以在几分钟内上手 AIGNE：
+
+1. 安装核心模块；
+2. 创建一个简单的 Agent；
+3. 构建工作流或连接外部服务；
+
+## 社区与支持
+
+AIGNE 是一个开源项目，由一群热爱 AI 和系统工程的开发者共同构建。欢迎你：
+
+* 加入我们的[开发者社区](https://community.arcblock.io/discussions/boards/aigne)；
+* 在 GitHub 上[提交反馈与改进建议](https://github.com/AIGNE-io/aigne-framework/issues)；
+* [贡献代码或文档](https://github.com/AIGNE-io/aigne-framework/blob/main/CHANGELOG.md)，与我们共同推动 AI 应用开发的未来。

--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -1,4 +1,4 @@
-* Getting Started
+* [Getting Started](/getting-started/index.md)
 
   * [What is AIGNE](/getting-started/what-is-aigne.md)
   * [Quick Start](/getting-started/quick-start.md)

--- a/examples/memory/package.json
+++ b/examples/memory/package.json
@@ -4,7 +4,7 @@
   "description": "A demonstration of using AIGNE Framework with memory.",
   "author": "Arcblock <blocklet@arcblock.io> https://github.com/blocklet",
   "homepage": "https://github.com/AIGNE-io/aigne-framework/tree/main/examples/memory",
-  "license": "ISC",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/AIGNE-io/aigne-framework"

--- a/packages/agent-library/src/fs-memory/index.ts
+++ b/packages/agent-library/src/fs-memory/index.ts
@@ -81,7 +81,7 @@ export class FSMemory extends MemoryAgent {
 }
 
 interface FSMemoryRetrieverOptions
-  extends AIAgentOptions<any, FSMemoryRetrieverAgentInput, FSMemoryRetrieverAgentOutput> {
+  extends AIAgentOptions<FSMemoryRetrieverAgentInput, FSMemoryRetrieverAgentOutput> {
   memoryFileName: string;
 }
 
@@ -115,7 +115,7 @@ class FSMemoryRetriever extends MemoryRetriever {
     });
   }
 
-  agent: AIAgent<any, FSMemoryRetrieverAgentInput, FSMemoryRetrieverAgentOutput>;
+  agent: AIAgent<FSMemoryRetrieverAgentInput, FSMemoryRetrieverAgentOutput>;
 
   override async process(
     input: MemoryRetrieverInput,
@@ -136,7 +136,7 @@ class FSMemoryRetriever extends MemoryRetriever {
 }
 
 interface FSMemoryRecorderOptions
-  extends AIAgentOptions<any, FSMemoryRecorderAgentInput, FSMemoryRecorderAgentOutput> {
+  extends AIAgentOptions<FSMemoryRecorderAgentInput, FSMemoryRecorderAgentOutput> {
   memoryFileName: string;
 }
 
@@ -168,7 +168,7 @@ class FSMemoryRecorder extends MemoryRecorder {
     });
   }
 
-  agent: AIAgent<any, FSMemoryRecorderAgentInput, FSMemoryRecorderAgentOutput>;
+  agent: AIAgent<FSMemoryRecorderAgentInput, FSMemoryRecorderAgentOutput>;
 
   override async process(
     input: MemoryRecorderInput,

--- a/packages/agent-library/src/orchestrator/index.ts
+++ b/packages/agent-library/src/orchestrator/index.ts
@@ -133,7 +133,7 @@ export class OrchestratorAgent<
     this.tasksConcurrency = options.tasksConcurrency;
     this.inputKey = options.inputKey;
 
-    this.planner = new AIAgent<"objective", FullPlanInput, FullPlanOutput>({
+    this.planner = new AIAgent<FullPlanInput, FullPlanOutput>({
       name: "llm_orchestration_planner",
       instructions: FULL_PLAN_PROMPT_TEMPLATE,
       outputSchema: () => getFullPlanSchema(this.skills),
@@ -146,9 +146,9 @@ export class OrchestratorAgent<
     });
   }
 
-  private planner: AIAgent<"objective", FullPlanInput, FullPlanOutput>;
+  private planner: AIAgent<FullPlanInput, FullPlanOutput>;
 
-  private completer: AIAgent<"objective", FullPlanInput, O>;
+  private completer: AIAgent<FullPlanInput, O>;
 
   inputKey: string;
 
@@ -291,7 +291,7 @@ export class OrchestratorAgent<
 
     const result = getMessageOrJsonString(
       await context.invoke(
-        AIAgent.from<"objective", SynthesizeStepPromptInput, Message>({
+        AIAgent.from<SynthesizeStepPromptInput, Message>({
           name: "llm_orchestration_step_synthesizer",
           instructions: SYNTHESIZE_STEP_PROMPT_TEMPLATE,
         }),

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -71,6 +71,7 @@
     "pretty-error": "^4.0.0",
     "tar": "^7.4.3",
     "wrap-ansi": "^9.0.0",
+    "yaml": "^2.7.1",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/packages/cli/src/utils/run-with-aigne.ts
+++ b/packages/cli/src/utils/run-with-aigne.ts
@@ -103,7 +103,7 @@ export const createRunAIGNECommand = (name = "run") =>
 
 export async function parseAgentInputByCommander(
   agent: Agent,
-  options: RunAIGNECommandOptions & { inputKey?: string },
+  options: RunAIGNECommandOptions & { inputKey?: string; argv?: string[] } = {},
 ): Promise<Message> {
   const cmd = new Command()
     .description(`Run agent ${agent.name} with AIGNE`)
@@ -139,16 +139,12 @@ export async function parseAgentInputByCommander(
             ).filter(isNonNullable),
           );
 
-          if (typeof agentInputOptions["input"] === "string") {
-            input[options.inputKey || DEFAULT_CHAT_INPUT_KEY] = agentInputOptions["input"];
-          }
-
           resolve(input);
         } catch (error) {
           reject(error);
         }
       })
-      .parseAsync(process.argv)
+      .parseAsync(options.argv ?? process.argv)
       .catch((error) => reject(error));
   });
 

--- a/packages/cli/src/utils/run-with-aigne.ts
+++ b/packages/cli/src/utils/run-with-aigne.ts
@@ -1,14 +1,31 @@
+import assert from "node:assert";
 import { fstat } from "node:fs";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join } from "node:path";
 import { isatty } from "node:tty";
 import { promisify } from "node:util";
-import { AIGNE, type Agent, type ChatModelOptions, UserAgent } from "@aigne/core";
+import { exists } from "@aigne/agent-library/utils/fs.js";
+import {
+  AIGNE,
+  type Agent,
+  type ChatModelOptions,
+  DEFAULT_OUTPUT_KEY,
+  type Message,
+  UserAgent,
+  readAllString,
+} from "@aigne/core";
 import { loadModel } from "@aigne/core/loader/index.js";
 import { LogLevel, getLevelFromEnv, logger } from "@aigne/core/utils/logger.js";
-import { readAllString } from "@aigne/core/utils/stream-utils.js";
-import { type PromiseOrValue, tryOrThrow } from "@aigne/core/utils/type-utils.js";
+import {
+  type PromiseOrValue,
+  isEmpty,
+  isNonNullable,
+  tryOrThrow,
+} from "@aigne/core/utils/type-utils.js";
 import { Command } from "commander";
 import PrettyError from "pretty-error";
-import { ZodError, z } from "zod";
+import { parse } from "yaml";
+import { ZodError, ZodObject, z } from "zod";
 import { availableModels } from "../constants.js";
 import { TerminalTracer } from "../tracer/terminal.js";
 import {
@@ -24,12 +41,17 @@ export interface RunAIGNECommandOptions {
   topP?: number;
   presencePenalty?: number;
   frequencyPenalty?: number;
-  input?: string;
+  input?: string[];
+  format?: "text" | "json" | "yaml";
+  output?: string;
   logLevel?: LogLevel;
+  force?: boolean;
 }
 
 export const createRunAIGNECommand = (name = "run") =>
   new Command(name)
+    .allowUnknownOption(true)
+    .allowExcessArguments(true)
     .description("Run agent with AIGNE in terminal")
     .option("--chat", "Run chat loop in terminal", false)
     .option(
@@ -56,13 +78,109 @@ export const createRunAIGNECommand = (name = "run") =>
       "Frequency penalty for the model (penalizes frequency of token usage). Range: -2.0 to 2.0",
       customZodError("--frequency-penalty", (s) => z.coerce.number().min(-2).max(2).parse(s)),
     )
-    .option("--input -i <input>", "Input to the agent")
+    .option("--input -i <input...>", "Input to the agent, use @<file> to read from a file")
+    .option(
+      "--format <format>",
+      "Input format for the agent (available: text, json, yaml default: text)",
+    )
+    .option("--output -o <output>", "Output file to save the result (default: stdout)")
+    .option(
+      "--output-key <output-key>",
+      "Key in the result to save to the output file",
+      DEFAULT_OUTPUT_KEY,
+    )
+    .option(
+      "--force",
+      "Truncate the output file if it exists, and create directory if the output path is not exists",
+      false,
+    )
     .option(
       "--log-level <level>",
       `Log level for detailed debugging information. Values: ${Object.values(LogLevel).join(", ")}`,
       customZodError("--log-level", (s) => z.nativeEnum(LogLevel).parse(s)),
       getLevelFromEnv(logger.options.ns) || LogLevel.INFO,
     );
+
+export async function parseAgentInputByCommander(
+  agent: Agent,
+  options: RunAIGNECommandOptions & { inputKey?: string },
+): Promise<Message> {
+  const cmd = new Command()
+    .description(`Run agent ${agent.name} with AIGNE`)
+    .allowUnknownOption(true)
+    .allowExcessArguments(true);
+
+  const inputSchemaShape =
+    agent.inputSchema instanceof ZodObject ? Object.keys(agent.inputSchema.shape) : [];
+
+  for (const option of inputSchemaShape) {
+    cmd.option(`--input-${option} <${option}>`);
+  }
+
+  const input = await new Promise<Message>((resolve, reject) => {
+    cmd
+      .action(async (agentInputOptions) => {
+        try {
+          const input = Object.fromEntries(
+            (
+              await Promise.all(
+                Object.entries(agentInputOptions).map(async ([key, value]) => {
+                  let k = key.replace(/^input/, "");
+                  k = k.charAt(0).toLowerCase() + k.slice(1);
+                  if (!k) return null;
+
+                  if (typeof value === "string" && value.startsWith("@")) {
+                    value = await readFile(value.slice(1), "utf8");
+                  }
+
+                  return [k, value];
+                }),
+              )
+            ).filter(isNonNullable),
+          );
+
+          if (typeof agentInputOptions["input"] === "string") {
+            input[options.inputKey || DEFAULT_CHAT_INPUT_KEY] = agentInputOptions["input"];
+          }
+
+          resolve(input);
+        } catch (error) {
+          reject(error);
+        }
+      })
+      .parseAsync(process.argv)
+      .catch((error) => reject(error));
+  });
+
+  const rawInput =
+    options.input ||
+    (isatty(process.stdin.fd) || !(await stdinHasData())
+      ? null
+      : [await readAllString(process.stdin)]);
+
+  if (rawInput?.length) {
+    for (let raw of rawInput) {
+      if (raw.startsWith("@")) {
+        raw = await readFile(raw.slice(1), "utf8");
+      }
+
+      if (options.format === "json") {
+        Object.assign(input, JSON.parse(raw));
+      } else if (options.format === "yaml") {
+        Object.assign(input, parse(raw));
+      } else {
+        Object.assign(
+          input,
+          typeof options.inputKey === "string"
+            ? { [options.inputKey]: raw }
+            : { [DEFAULT_CHAT_INPUT_KEY]: raw },
+        );
+      }
+    }
+  }
+
+  return input;
+}
 
 export const parseModelOption = (model?: string) => {
   const { provider, name } = model?.match(/(?<provider>[^:]+)(:(?<name>(\S+)))?/)?.groups ?? {};
@@ -76,10 +194,12 @@ export async function runWithAIGNE(
     argv = process.argv,
     chatLoopOptions,
     modelOptions,
+    outputKey,
   }: {
     argv?: typeof process.argv;
     chatLoopOptions?: ChatLoopOptions;
     modelOptions?: ChatModelOptions;
+    outputKey?: string;
   } = {},
 ) {
   await createRunAIGNECommand()
@@ -107,7 +227,22 @@ export async function runWithAIGNE(
       try {
         const agent = typeof agentCreator === "function" ? await agentCreator(aigne) : agentCreator;
 
-        await runAgentWithAIGNE(aigne, agent, { ...options, chatLoopOptions, modelOptions });
+        const input = await parseAgentInputByCommander(agent, {
+          ...options,
+          inputKey: chatLoopOptions?.inputKey,
+        });
+
+        if (isEmpty(input)) {
+          Object.assign(input, chatLoopOptions?.initialCall || chatLoopOptions?.defaultQuestion);
+        }
+
+        await runAgentWithAIGNE(aigne, agent, {
+          ...options,
+          outputKey,
+          chatLoopOptions,
+          modelOptions,
+          input,
+        });
       } finally {
         await aigne.shutdown();
       }
@@ -131,14 +266,33 @@ export async function runAgentWithAIGNE(
   aigne: AIGNE,
   agent: Agent,
   {
+    outputKey,
     chatLoopOptions,
     modelOptions,
     ...options
   }: {
+    outputKey?: string;
     chatLoopOptions?: ChatLoopOptions;
     modelOptions?: ChatModelOptions;
-  } & RunAIGNECommandOptions = {},
+    input?: Message;
+  } & Omit<RunAIGNECommandOptions, "input"> = {},
 ) {
+  if (options.output) {
+    const outputPath = isAbsolute(options.output)
+      ? options.output
+      : join(process.cwd(), options.output);
+    if (await exists(outputPath)) {
+      const s = await stat(outputPath);
+      if (!s.isFile()) throw new Error(`Output path ${outputPath} is not a file`);
+      if (s.size > 0 && !options.force) {
+        throw new Error(`Output file ${outputPath} already exists. Use --force to overwrite.`);
+      }
+    } else {
+      await mkdir(dirname(outputPath), { recursive: true });
+    }
+    await writeFile(outputPath, "", "utf8");
+  }
+
   if (options.chat) {
     if (!isatty(process.stdout.fd)) {
       throw new Error("--chat mode requires a TTY terminal");
@@ -153,25 +307,23 @@ export async function runAgentWithAIGNE(
     return;
   }
 
-  const input =
-    options.input ||
-    (isatty(process.stdin.fd) || !(await stdinHasData())
-      ? null
-      : await readAllString(process.stdin)) ||
-    chatLoopOptions?.initialCall ||
-    chatLoopOptions?.defaultQuestion ||
-    {};
-
   const tracer = new TerminalTracer(aigne.newContext(), {
     printRequest: logger.enabled(LogLevel.INFO),
+    outputKey,
   });
 
-  return await tracer.run(
-    agent,
-    typeof input === "string"
-      ? { [chatLoopOptions?.inputKey || DEFAULT_CHAT_INPUT_KEY]: input }
-      : input,
-  );
+  assert(options.input);
+  const { result } = await tracer.run(agent, options.input);
+
+  if (options.output) {
+    const message = result[outputKey || DEFAULT_OUTPUT_KEY];
+    const content = typeof message === "string" ? message : JSON.stringify(result, null, 2);
+    const path = isAbsolute(options.output) ? options.output : join(process.cwd(), options.output);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, content, "utf8");
+  }
+
+  return { result };
 }
 
 async function stdinHasData(): Promise<boolean> {

--- a/packages/cli/test/commands/run.test.ts
+++ b/packages/cli/test/commands/run.test.ts
@@ -33,7 +33,7 @@ test("run command should call run chat loop correctly", async () => {
   process.chdir(cwd);
 
   // should run in specified directory
-  await command.parseAsync(["", "run", testAgentsPath]);
+  await command.parseAsync(["", "run", "--path", testAgentsPath]);
   expect(runAgentWithAIGNE).toHaveBeenCalledTimes(2);
   expect(runAgentWithAIGNE).toHaveBeenLastCalledWith(
     expect.any(AIGNE),
@@ -43,7 +43,7 @@ test("run command should call run chat loop correctly", async () => {
 
   // should run in specified directory of relative path
   const relativePath = relative(cwd, testAgentsPath);
-  await command.parseAsync(["", "run", relativePath]);
+  await command.parseAsync(["", "run", "--path", relativePath]);
   expect(runAgentWithAIGNE).toHaveBeenCalledTimes(3);
   expect(runAgentWithAIGNE).toHaveBeenLastCalledWith(
     expect.any(AIGNE),
@@ -52,7 +52,7 @@ test("run command should call run chat loop correctly", async () => {
   );
 
   // should run specified agent
-  await command.parseAsync(["", "run", testAgentsPath, "--entry-agent", "chat"]);
+  await command.parseAsync(["", "run", "--path", testAgentsPath, "--entry-agent", "chat"]);
   expect(runAgentWithAIGNE).toHaveBeenCalledTimes(4);
   expect(runAgentWithAIGNE).toHaveBeenLastCalledWith(
     expect.any(AIGNE),
@@ -62,9 +62,9 @@ test("run command should call run chat loop correctly", async () => {
 
   // should error if agent not found
   spyOn(console, "error").mockReturnValueOnce(undefined);
-  expect(command.parseAsync(["", "run", testAgentsPath, "--entry-agent", "chat1"])).rejects.toThrow(
-    "not found",
-  );
+  expect(
+    command.parseAsync(["", "run", "--path", testAgentsPath, "--entry-agent", "chat1"]),
+  ).rejects.toThrow("not found");
 });
 
 test("run command should download package and run correctly", async () => {
@@ -82,7 +82,7 @@ test("run command should download package and run correctly", async () => {
 
   const url = new URL(`https://www.aigne.io/${randomUUID()}/test-agents.tgz`);
 
-  await command.parseAsync(["", "run", url.toString()]);
+  await command.parseAsync(["", "run", "--url", url.toString()]);
 
   const path = join(homedir(), ".aigne", url.hostname, url.pathname);
   expect((await stat(join(path, "aigne.yaml"))).isFile()).toBeTrue();
@@ -109,7 +109,7 @@ test("run command should convert package from v1 and run correctly", async () =>
 
   const url = new URL(`https://www.aigne.io/${randomUUID()}/test-agents.tgz`);
 
-  await command.parseAsync(["", "run", url.toString()]);
+  await command.parseAsync(["", "run", "--url", url.toString()]);
 
   const path = join(homedir(), ".aigne", url.hostname, url.pathname);
   expect((await stat(join(path, "aigne.yaml"))).isFile()).toBeTrue();
@@ -138,7 +138,7 @@ test("run command should download package to a special folder", async () => {
   const dir = join(tmpdir(), randomUUID());
 
   try {
-    await command.parseAsync(["", "run", url, "--cache-dir", dir]);
+    await command.parseAsync(["", "run", "--url", url, "--cache-dir", dir]);
 
     expect((await stat(join(dir, "aigne.yaml"))).isFile()).toBeTrue();
     expect(runAgentWithAIGNE).toHaveBeenLastCalledWith(
@@ -162,7 +162,7 @@ test("run command should parse model options correctly", async () => {
 
   const command = createRunCommand();
 
-  await command.parseAsync(["", "run", testAgentsPath, "--model", "xai:test-model"]);
+  await command.parseAsync(["", "run", "--path", testAgentsPath, "--model", "xai:test-model"]);
 
   expect(runAgentWithAIGNE).toHaveBeenLastCalledWith(
     expect.any(AIGNE),

--- a/packages/cli/test/tracer/__snapshots__/terminal.test.ts.snap
+++ b/packages/cli/test/tracer/__snapshots__/terminal.test.ts.snap
@@ -12,3 +12,18 @@ exports[`TerminalTracer should render output message with markdown highlight 1`]
 
 \x1B[0mI am from \x1B[34m\x1B[1mAIGNE\x1B[22m (\x1B[34m\x1B[4mhttps://www.aigne.io\x1B[24m\x1B[39m\x1B[34m)\x1B[39m\x1B[0m"
 `;
+
+exports[`TerminalTracer should render output message without markdown highlight in non-tty 1`] = `
+"\x1B[90m✔\x1B[39m 🤖 \x1B[90m(\x1B[39m\x1B[33m0\x1B[39m \x1B[90minput tokens\x1B[39m\x1B[32m, \x1B[39m\x1B[36m0\x1B[39m \x1B[90moutput tokens\x1B[39m\x1B[90m)\x1B[39m
+## Hello
+I am from [**AIGNE**](https://www.aigne.io)"
+`;
+
+exports[`TerminalTracer.marked should stripe code block meta 1`] = `
+"\x1B[0mhello\x1B[0m
+
+    \x1B[33m\x1B[34mfunction\x1B[39m\x1B[33m test() \x1B[39m{
+    }
+
+"
+`;

--- a/packages/cli/test/tracer/terminal.test.ts
+++ b/packages/cli/test/tracer/terminal.test.ts
@@ -56,9 +56,52 @@ test("TerminalTracer should render output message with markdown highlight", asyn
 
   const tracer = new TerminalTracer(context);
 
+  const originalIsTTY = process.stdout.isTTY;
+  process.stdout.isTTY = true;
+
   expect(
     tracer.formatResult(new AIAgent({ inputKey: "message" }), context, {
       message: "## Hello\nI am from [**AIGNE**](https://www.aigne.io)",
     }),
+  ).toMatchSnapshot();
+
+  process.stdout.isTTY = originalIsTTY;
+});
+
+test("TerminalTracer should render output message without markdown highlight in non-tty", async () => {
+  const model = new OpenAIChatModel({});
+
+  const aigne = new AIGNE({ model });
+  const context = aigne.newContext();
+
+  const tracer = new TerminalTracer(context);
+
+  const originalIsTTY = process.stdout.isTTY;
+  process.stdout.isTTY = false;
+
+  expect(
+    tracer.formatResult(new AIAgent({ outputKey: "message" }), context, {
+      message: "## Hello\nI am from [**AIGNE**](https://www.aigne.io)",
+    }),
+  ).toMatchSnapshot();
+
+  process.stdout.isTTY = originalIsTTY;
+});
+
+test("TerminalTracer.marked should stripe code block meta", async () => {
+  const aigne = new AIGNE();
+  const context = aigne.newContext();
+
+  const tracer = new TerminalTracer(context);
+
+  expect(
+    tracer["marked"].parse(`\
+hello
+
+${"```"}ts file="test.ts" region="test-region"
+function test() {
+}
+${"```"}
+`),
   ).toMatchSnapshot();
 });

--- a/packages/cli/test/utils/listr.test.ts
+++ b/packages/cli/test/utils/listr.test.ts
@@ -70,7 +70,6 @@ test("AIGNEListrRenderer should work correctly", async () => {
   const clear = mock();
   Object.assign(updater, { clear });
 
-  // biome-ignore lint/complexity/useLiteralKeys: updater is a private member
   renderer["updater"] = updater;
 
   renderer.update();

--- a/packages/cli/test/utils/run-with-aigne-test-input.json
+++ b/packages/cli/test/utils/run-with-aigne-test-input.json
@@ -1,0 +1,4 @@
+{
+  "name": "John Doe",
+  "age": 30
+}

--- a/packages/cli/test/utils/run-with-aigne-test-input.txt
+++ b/packages/cli/test/utils/run-with-aigne-test-input.txt
@@ -1,0 +1,1 @@
+Hello, I'm agent created by AIGNE.

--- a/packages/cli/test/utils/run-with-aigne-test-input.yaml
+++ b/packages/cli/test/utils/run-with-aigne-test-input.yaml
@@ -1,0 +1,2 @@
+name: John Doe
+age: 30

--- a/packages/core/src/agents/agent.ts
+++ b/packages/core/src/agents/agent.ts
@@ -427,7 +427,7 @@ export abstract class Agent<I extends Message = Message, O extends Message = Mes
 
   async onMessage({ message, context }: MessagePayload) {
     try {
-      await context.invoke(this, message);
+      await context.invoke(this, message as I);
     } catch (error) {
       context.emit("agentFailed", { agent: this, error });
     }
@@ -518,7 +518,10 @@ export abstract class Agent<I extends Message = Message, O extends Message = Mes
    * Here's an example of invoking an agent with regular mode:
    * {@includeCode ../../test/agents/agent.test.ts#example-invoke}
    */
-  async invoke(input: I, options?: Partial<AgentInvokeOptions> & { streaming?: false }): Promise<O>;
+  async invoke(
+    input: I & Message,
+    options?: Partial<AgentInvokeOptions> & { streaming?: false },
+  ): Promise<O>;
 
   /**
    * Invoke the agent with streaming response
@@ -536,7 +539,7 @@ export abstract class Agent<I extends Message = Message, O extends Message = Mes
    * {@includeCode ../../test/agents/agent.test.ts#example-invoke-streaming}
    */
   async invoke(
-    input: I,
+    input: I & Message,
     options: Partial<AgentInvokeOptions> & { streaming: true },
   ): Promise<AgentResponseStream<O>>;
 
@@ -549,9 +552,15 @@ export abstract class Agent<I extends Message = Message, O extends Message = Mes
    * @param options Invocation options
    * @returns Agent response (streaming or regular)
    */
-  async invoke(input: I, options?: Partial<AgentInvokeOptions>): Promise<AgentResponse<O>>;
+  async invoke(
+    input: I & Message,
+    options?: Partial<AgentInvokeOptions>,
+  ): Promise<AgentResponse<O>>;
 
-  async invoke(input: I, options: Partial<AgentInvokeOptions> = {}): Promise<AgentResponse<O>> {
+  async invoke(
+    input: I & Message,
+    options: Partial<AgentInvokeOptions> = {},
+  ): Promise<AgentResponse<O>> {
     const opts: AgentInvokeOptions = {
       ...options,
       context: options.context ?? (await this.newDefaultContext()),
@@ -625,7 +634,7 @@ export abstract class Agent<I extends Message = Message, O extends Message = Mes
 
   protected async invokeSkill<I extends Message, O extends Message>(
     skill: Agent<I, O>,
-    input: I,
+    input: I & Message,
     options: AgentInvokeOptions,
   ): Promise<O> {
     const { context } = options;

--- a/packages/core/src/agents/ai-agent.ts
+++ b/packages/core/src/agents/ai-agent.ts
@@ -22,7 +22,7 @@ import {
 import type { GuideRailAgentOutput } from "./guide-rail-agent.js";
 import { isTransferAgentOutput } from "./types.js";
 
-const DEFAULT_OUTPUT_KEY = "message";
+export const DEFAULT_OUTPUT_KEY = "message";
 
 /**
  * Configuration options for an AI Agent

--- a/packages/core/src/agents/ai-agent.ts
+++ b/packages/core/src/agents/ai-agent.ts
@@ -33,11 +33,8 @@ export const DEFAULT_OUTPUT_KEY = "message";
  * @template I The input message type the agent accepts
  * @template O The output message type the agent returns
  */
-export interface AIAgentOptions<
-  InputKey extends string = string,
-  I extends Message & InputMessage<InputKey> = Message & InputMessage<InputKey>,
-  O extends Message = Message,
-> extends AgentOptions<Omit<I, InputKey> & Partial<InputMessage<InputKey>>, O> {
+export interface AIAgentOptions<I extends Message = Message, O extends Message = Message>
+  extends AgentOptions<I, O> {
   /**
    * The language model to use for this agent
    *
@@ -56,7 +53,7 @@ export interface AIAgentOptions<
   /**
    * Pick a message from input to use as the user's message
    */
-  inputKey?: InputKey;
+  inputKey?: string;
 
   /**
    * Custom key to use for text output in the response
@@ -164,8 +161,6 @@ export const aiAgentOptionsSchema: ZodObject<{
   [key in keyof AIAgentOptions]: ZodType<AIAgentOptions[key]>;
 }>;
 
-type InputMessage<K> = K extends string ? { [key in K]: string } : Message;
-
 /**
  * AI-powered agent that leverages language models
  *
@@ -186,11 +181,7 @@ type InputMessage<K> = K extends string ? { [key in K]: string } : Message;
  * Basic AIAgent creation:
  * {@includeCode ../../test/agents/ai-agent.test.ts#example-ai-agent-basic}
  */
-export class AIAgent<
-  InputKey extends string = string,
-  I extends Message & InputMessage<InputKey> = Message & InputMessage<InputKey>,
-  O extends Message = Message,
-> extends Agent<I, O> {
+export class AIAgent<I extends Message = Message, O extends Message = Message> extends Agent<I, O> {
   /**
    * Create an AIAgent with the specified options
    *
@@ -203,11 +194,7 @@ export class AIAgent<
    * AI agent with custom instructions:
    * {@includeCode ../../test/agents/ai-agent.test.ts#example-ai-agent-instructions}
    */
-  static from<
-    InputKey extends string,
-    I extends Message & InputMessage<InputKey>,
-    O extends Message,
-  >(options: AIAgentOptions<InputKey, I, O>): AIAgent<InputKey, I, O> {
+  static from<I extends Message, O extends Message>(options: AIAgentOptions<I, O>): AIAgent<I, O> {
     return new AIAgent(options);
   }
 
@@ -216,8 +203,8 @@ export class AIAgent<
    *
    * @param options Configuration options for the AI agent
    */
-  constructor(options: AIAgentOptions<InputKey, I, O>) {
-    super({ ...options, inputSchema: options.inputSchema as ZodType<I> });
+  constructor(options: AIAgentOptions<I, O>) {
+    super(options);
     checkArguments("AIAgent", aiAgentOptionsSchema, options);
 
     this.model = options.model;
@@ -262,7 +249,7 @@ export class AIAgent<
   /**
    * Pick a message from input to use as the user's message
    */
-  inputKey?: InputKey;
+  inputKey?: string;
 
   /**
    * Custom key to use for text output in the response

--- a/packages/core/src/aigne/aigne.ts
+++ b/packages/core/src/aigne/aigne.ts
@@ -197,7 +197,7 @@ export class AIGNE<U extends UserContext = UserContext> {
    */
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message: I,
+    message: I & Message,
     options: InvokeOptions<U> & { returnActiveAgent: true; streaming?: false },
   ): Promise<[O, Agent]>;
 
@@ -213,7 +213,7 @@ export class AIGNE<U extends UserContext = UserContext> {
    */
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message: I,
+    message: I & Message,
     options: InvokeOptions<U> & { returnActiveAgent: true; streaming: true },
   ): Promise<[AgentResponseStream<O>, Promise<Agent>]>;
 
@@ -232,7 +232,7 @@ export class AIGNE<U extends UserContext = UserContext> {
    */
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message: I,
+    message: I & Message,
     options?: InvokeOptions<U> & { returnActiveAgent?: false; streaming?: false },
   ): Promise<O>;
 
@@ -251,7 +251,7 @@ export class AIGNE<U extends UserContext = UserContext> {
    */
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message: I,
+    message: I & Message,
     options: InvokeOptions<U> & { returnActiveAgent?: false; streaming: true },
   ): Promise<AgentResponseStream<O>>;
 
@@ -267,13 +267,13 @@ export class AIGNE<U extends UserContext = UserContext> {
    */
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message?: I,
+    message?: I & Message,
     options?: InvokeOptions<U>,
   ): UserAgent<I, O> | Promise<AgentResponse<O> | [AgentResponse<O>, Agent]>;
 
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message?: I,
+    message?: I & Message,
     options?: InvokeOptions<U>,
   ): UserAgent<I, O> | Promise<AgentResponse<O> | [AgentResponse<O>, Agent]> {
     return new AIGNEContext(this).invoke(agent, message, options);

--- a/packages/core/src/aigne/context.ts
+++ b/packages/core/src/aigne/context.ts
@@ -132,12 +132,12 @@ export interface Context<U extends UserContext = UserContext>
    */
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message: I,
+    message: I & Message,
     options: InvokeOptions & { returnActiveAgent: true; streaming?: false },
   ): Promise<[O, Agent]>;
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message: I,
+    message: I & Message,
     options: InvokeOptions & { returnActiveAgent: true; streaming: true },
   ): Promise<[AgentResponseStream<O>, Promise<Agent>]>;
   /**
@@ -148,17 +148,17 @@ export interface Context<U extends UserContext = UserContext>
    */
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message: I,
+    message: I & Message,
     options?: InvokeOptions & { streaming?: false },
   ): Promise<O>;
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message: I,
+    message: I & Message,
     options: InvokeOptions & { streaming: true },
   ): Promise<AgentResponseStream<O>>;
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    message?: I,
+    message?: I & Message,
     options?: InvokeOptions,
   ): UserAgent<I, O> | Promise<AgentResponse<O> | [AgentResponse<O>, Agent]>;
 
@@ -460,7 +460,7 @@ class AIGNEContextShared {
 
   invoke<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    input: I,
+    input: I & Message,
     context: Context,
     options?: InvokeOptions,
   ): AgentProcessAsyncGenerator<O & { __activeAgent__: Agent }> {
@@ -473,7 +473,7 @@ class AIGNEContextShared {
 
   private async *invokeAgent<I extends Message, O extends Message>(
     agent: Agent<I, O>,
-    input: I,
+    input: I & Message,
     context: Context,
     options?: InvokeOptions,
   ): AgentProcessAsyncGenerator<O & { __activeAgent__: Agent }> {

--- a/packages/core/src/loader/agent-js.ts
+++ b/packages/core/src/loader/agent-js.ts
@@ -1,6 +1,6 @@
 import { jsonSchemaToZod } from "@aigne/json-schema-to-zod";
 import { type ZodFunction, type ZodObject, type ZodTuple, type ZodType, z } from "zod";
-import type { Message } from "../agents/agent.js";
+import { Agent, type Message } from "../agents/agent.js";
 import { customCamelize } from "../utils/camelize.js";
 import { tryOrThrow } from "../utils/type-utils.js";
 import { inputOutputSchema } from "./schema.js";
@@ -25,6 +25,8 @@ export async function loadAgentFromJsFile(path: string) {
     () => import(path),
     (error) => new Error(`Failed to load agent definition from ${path}: ${error.message}`),
   );
+
+  if (agent instanceof Agent) return agent;
 
   if (typeof agent !== "function") {
     throw new Error(`Agent file ${path} must export a default function, but got ${typeof agent}`);

--- a/packages/core/src/prompt/prompt-builder.ts
+++ b/packages/core/src/prompt/prompt-builder.ts
@@ -30,7 +30,7 @@ export interface PromptBuilderOptions {
 }
 
 export interface PromptBuildOptions extends Pick<AgentInvokeOptions, "context"> {
-  agent?: AIAgent<any, any, any>;
+  agent?: AIAgent;
   input?: Message;
   model?: ChatModel;
   outputSchema?: Agent["outputSchema"];

--- a/packages/core/test-agents/aigne.yaml
+++ b/packages/core/test-agents/aigne.yaml
@@ -5,5 +5,7 @@ chat_model:
   temperature: 0.8
 agents:
   - chat.yaml
+  - chat-with-prompt.yaml
+  - team.yaml
 tools:
   - sandbox.js

--- a/packages/core/test-agents/chat-prompt.md
+++ b/packages/core/test-agents/chat-prompt.md
@@ -1,0 +1,1 @@
+You are a helper agent to answer everything about chat prompt in AIGNE.

--- a/packages/core/test-agents/chat-with-prompt.yaml
+++ b/packages/core/test-agents/chat-with-prompt.yaml
@@ -1,0 +1,8 @@
+name: chat-with-prompt
+description: Chat agent
+instructions:
+  url: chat-prompt.md
+input_key: message
+memory: true
+skills:
+  - sandbox.js

--- a/packages/core/test-agents/team.yaml
+++ b/packages/core/test-agents/team.yaml
@@ -1,0 +1,7 @@
+type: team
+name: test-team-agent
+description: Test team agent
+skills:
+  - sandbox.js
+  - chat.yaml
+mode: parallel

--- a/packages/core/test/loader/agent-yaml.test.ts
+++ b/packages/core/test/loader/agent-yaml.test.ts
@@ -1,13 +1,14 @@
 import { expect, spyOn, test } from "bun:test";
 import assert from "node:assert";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { AIAgent, FunctionAgent } from "@aigne/core";
+import { AIAgent, FunctionAgent, ProcessMode, TeamAgent } from "@aigne/core";
 import { loadAgentFromYamlFile } from "@aigne/core/loader/agent-yaml.js";
 import { loadAgent } from "@aigne/core/loader/index.js";
 import { outputSchemaToResponseFormatSchema } from "@aigne/core/utils/json-schema.js";
 import { nodejs } from "@aigne/platform-helpers/nodejs/index.js";
 
-test("loadAgentFromYaml should load agent correctly", async () => {
+test("loadAgentFromYaml should load AIAgent correctly", async () => {
   const agent = await loadAgent(join(import.meta.dirname, "../../test-agents/chat.yaml"));
 
   expect(agent).toBeInstanceOf(AIAgent);
@@ -103,4 +104,34 @@ args: ["-y", "@modelcontextprotocol/server-filesystem", "."]
     command: "npx",
     args: ["-y", "@modelcontextprotocol/server-filesystem", "."],
   });
+});
+
+test("loadAgentFromYaml should load TeamAgent correctly", async () => {
+  const agent = await loadAgent(join(import.meta.dirname, "../../test-agents/team.yaml"));
+
+  expect(agent).toBeInstanceOf(TeamAgent);
+  assert(agent instanceof TeamAgent, "agent should be an instance of AIAgent");
+
+  expect(agent).toEqual(
+    expect.objectContaining({
+      name: "test-team-agent",
+      description: "Test team agent",
+      mode: ProcessMode.parallel,
+    }),
+  );
+
+  expect(agent.skills.length).toBe(2);
+});
+
+test("loadAgentFromYaml should load AIAgent with prompt file correctly", async () => {
+  const agent = await loadAgent(
+    join(import.meta.dirname, "../../test-agents/chat-with-prompt.yaml"),
+  );
+
+  expect(agent).toBeInstanceOf(AIAgent);
+  assert(agent instanceof AIAgent, "agent should be an instance of AIAgent");
+
+  expect(agent.instructions.instructions).toEqual(
+    await readFile(join(import.meta.dirname, "../../test-agents/chat-prompt.md"), "utf8"),
+  );
 });

--- a/packages/core/test/loader/loader.test.ts
+++ b/packages/core/test/loader/loader.test.ts
@@ -20,7 +20,7 @@ test("AIGNE.load should load agents correctly", async () => {
     }),
   );
 
-  expect(aigne.agents.length).toBe(1);
+  expect(aigne.agents.length).toBe(3);
 
   const chat = aigne.agents[0];
   expect(chat).toEqual(
@@ -70,6 +70,12 @@ test("loader should use override options", async () => {
   expect([...aigne.agents]).toEqual([
     expect.objectContaining({
       name: "chat",
+    }),
+    expect.objectContaining({
+      name: "chat-with-prompt",
+    }),
+    expect.objectContaining({
+      name: "test-team-agent",
     }),
     testAgent,
   ]);

--- a/packages/publish-docs/package.json
+++ b/packages/publish-docs/package.json
@@ -49,6 +49,7 @@
     "@lexical/react": "^0.31.2",
     "@lexical/rich-text": "^0.31.2",
     "@lexical/table": "^0.31.2",
+    "gray-matter": "^4.0.3",
     "jsdom": "^26.1.0",
     "jsonwebtoken": "^9.0.2",
     "lexical": "^0.31.2",

--- a/packages/publish-docs/src/converter/index.ts
+++ b/packages/publish-docs/src/converter/index.ts
@@ -6,6 +6,7 @@ import { LinkNode } from "@lexical/link";
 import { ListItemNode, ListNode } from "@lexical/list";
 import { HeadingNode, QuoteNode } from "@lexical/rich-text";
 import { TableCellNode, TableNode, TableRowNode } from "@lexical/table";
+import matter from "gray-matter";
 import { JSDOM } from "jsdom";
 import {
   $getRoot,
@@ -35,17 +36,22 @@ export class Converter {
     filePath: string,
   ): Promise<{
     title: string | undefined;
+    labels?: string[];
     content: SerializedEditorState | null;
   }> {
+    const m = matter(markdown);
+    let markdownContent = m.content.trim();
+
+    const labels = Array.isArray(m.data.labels) ? m.data.labels : undefined;
     let title: string | undefined;
-    let content = markdown;
-    const titleMatch = markdown.trim().match(/^#\s+(.+)$/m);
+
+    const titleMatch = markdownContent.match(/^#\s+(.+)$/m);
     if (titleMatch?.[1]) {
       title = titleMatch[1].trim();
-      content = markdown.replace(/^#\s+.+$/m, "").trim();
+      markdownContent = markdownContent.replace(/^#\s+.+$/m, "").trim();
     }
 
-    if (content.trim() === "") {
+    if (markdownContent.trim() === "") {
       this.blankFilePaths.push(filePath);
       return { title, content: null };
     }
@@ -72,7 +78,7 @@ export class Converter {
     };
 
     marked.use({ renderer });
-    const html = await marked.parse(content);
+    const html = await marked.parse(markdownContent);
 
     const editor = createHeadlessEditor({
       namespace: "editor",
@@ -106,17 +112,19 @@ export class Converter {
       { discrete: true },
     );
 
-    return new Promise((resolve) => {
+    const content = await new Promise<SerializedEditorState>((resolve) => {
       setTimeout(
         () => {
           editor.update(() => {
             const state = editor.getEditorState();
             const json = state.toJSON();
-            resolve({ title, content: json });
+            resolve(json);
           });
         },
-        Math.min(content.length, 500),
+        Math.min(markdownContent.length, 500),
       );
     });
+
+    return { title, labels, content };
   }
 }

--- a/packages/publish-docs/src/generator.ts
+++ b/packages/publish-docs/src/generator.ts
@@ -15,6 +15,7 @@ export interface DocNode {
   children?: DocNode[];
   slug?: string;
   i18n?: Record<string, { title?: string; content?: string }>;
+  labels?: string[];
 }
 
 export interface GeneratorOptions {
@@ -94,6 +95,7 @@ export class Generator {
       const info = await this.getInfoFromFile(filePath);
       if (info?.title) node.h1 = info.title;
       if (info?.content) node.content = JSON.stringify(info.content);
+      if (info?.labels) node.labels = info.labels;
 
       const i18n = await this.getI18nInfoFromFile(filePath);
       if (Object.keys(i18n).length > 0) node.i18n = i18n;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -843,6 +843,9 @@ importers:
       wrap-ansi:
         specifier: ^9.0.0
         version: 9.0.0
+      yaml:
+        specifier: ^2.7.1
+        version: 2.7.1
       zod:
         specifier: ^3.24.4
         version: 3.25.23
@@ -1116,6 +1119,9 @@ importers:
       '@lexical/table':
         specifier: ^0.31.2
         version: 0.31.2
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -2694,6 +2700,9 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -3357,6 +3366,11 @@ packages:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -3400,6 +3414,10 @@ packages:
   express@5.1.0:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
     engines: {node: '>= 18'}
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -3584,6 +3602,10 @@ packages:
   gradient-string@3.0.0:
     resolution: {integrity: sha512-frdKI4Qi8Ihp4C6wZNB565de/THpIaw3DjP5ku87M+N9rNSGmPTjfkq61SdRXB7eCaL8O1hkKDvf6CDMtOzIAg==}
     engines: {node: '>=14'}
+
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -3793,6 +3815,10 @@ packages:
   is-empty@1.2.0:
     resolution: {integrity: sha512-F2FnH/otLNJv0J6wc73A5Xo7oHLNnqplYqZhUu01tD54DIPvxIRSTSLkrUB/M0nHO4vo1O9PDfN4KoTxCzLh/w==}
 
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -3931,6 +3957,10 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@3.14.1:
+    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+
   jsbn@1.1.0:
     resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
 
@@ -3976,6 +4006,10 @@ packages:
 
   jws@3.2.2:
     resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
@@ -4954,6 +4988,10 @@ packages:
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
@@ -5097,6 +5135,9 @@ packages:
   spdx-license-ids@3.0.21:
     resolution: {integrity: sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
@@ -5182,6 +5223,10 @@ packages:
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -7605,6 +7650,10 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   array-buffer-byte-length@1.0.2:
@@ -8285,6 +8334,8 @@ snapshots:
 
   escape-string-regexp@1.0.5: {}
 
+  esprima@4.0.1: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.7
@@ -8343,6 +8394,10 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
 
   extend@3.0.2: {}
 
@@ -8559,6 +8614,13 @@ snapshots:
     dependencies:
       chalk: 5.4.1
       tinygradient: 1.1.5
+
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.1
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
 
   has-bigints@1.1.0: {}
 
@@ -8778,6 +8840,8 @@ snapshots:
 
   is-empty@1.2.0: {}
 
+  is-extendable@0.1.1: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -8898,6 +8962,11 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-yaml@3.14.1:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   jsbn@1.1.0:
     optional: true
 
@@ -8963,6 +9032,8 @@ snapshots:
     dependencies:
       jwa: 1.4.1
       safe-buffer: 5.2.1
+
+  kind-of@6.0.3: {}
 
   lazystream@1.0.1:
     dependencies:
@@ -10330,6 +10401,11 @@ snapshots:
 
   scheduler@0.26.0: {}
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   semver@5.7.2: {}
 
   semver@6.3.1: {}
@@ -10501,6 +10577,8 @@ snapshots:
 
   spdx-license-ids@3.0.21: {}
 
+  sprintf-js@1.0.3: {}
+
   sprintf-js@1.1.3:
     optional: true
 
@@ -10621,6 +10699,8 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
+
+  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 

--- a/tests/nodejs/cli.test.ts
+++ b/tests/nodejs/cli.test.ts
@@ -7,6 +7,7 @@ test("AIGNE cli should work in Node.js", async () => {
   const agent = AIAgent.from({
     name: "memory_example",
     instructions: "You are a friendly chatbot",
+    inputKey: "message",
   });
 
   const aigne = new AIGNE({
@@ -20,7 +21,7 @@ test("AIGNE cli should work in Node.js", async () => {
 
   const result = await runAgentWithAIGNE(aigne, agent, {
     chat: false,
-    input: "Hello, What is your name?",
+    input: { message: "Hello, What is your name?" },
   });
 
   expect(result?.result).toEqual({


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

- feat(cli): support pass named input to agent by `--input-xxx`
- feat(core): support load agent from js/ts & team agent from yaml
- fix: support set labels in markdowns
- docs: add get started home page

### Checklist

- [x] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [x] This change adds dependencies, and they are placed in dependencies and devDependencies

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

Release Notes:

New Features:
- Added support for multiple output formats (text/json/yaml) in CLI
- Introduced file-based inputs using `@file` syntax
- Added custom output key support for more flexible data handling
- Implemented conditional output streaming in team agents

Enhancements:
- Improved agent loading system with class-based instances and TypeScript support
- Enhanced terminal handling with better TTY awareness
- Extended YAML schema with team type and URL-based instructions

Documentation:
- Added label support in documentation generation
- Improved team agent example outputs for better clarity

These changes focus on improving CLI flexibility, agent system capabilities, and documentation quality while maintaining backward compatibility.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->