### PR TITLE
feat: support remember custom fields from message

### DIFF
--- a/packages/agent-library/src/default-memory/default-memory-storage/migrations/001-init.ts
+++ b/packages/agent-library/src/default-memory/default-memory-storage/migrations/001-init.ts
@@ -10,5 +10,11 @@ CREATE TABLE "Memories" (
   "content" JSON NOT NULL
 )
 `,
+    `\
+CREATE VIRTUAL TABLE "Memories_fts" USING fts5(
+  id UNINDEXED,
+  content
+)
+`,
   ],
 };

--- a/packages/agent-library/src/default-memory/index.ts
+++ b/packages/agent-library/src/default-memory/index.ts
@@ -1,5 +1,6 @@
 import {
   type AgentInvokeOptions,
+  type AgentOptions,
   type Memory,
   MemoryAgent,
   type MemoryAgentOptions,
@@ -9,8 +10,8 @@ import {
   MemoryRetriever,
   type MemoryRetrieverInput,
   type MemoryRetrieverOutput,
+  type Message,
 } from "@aigne/core";
-import equal from "fast-deep-equal";
 import {
   DefaultMemoryStorage,
   type DefaultMemoryStorageOptions,
@@ -21,48 +22,88 @@ const DEFAULT_RETRIEVE_MEMORY_COUNT = 10;
 
 export interface DefaultMemoryOptions extends Partial<MemoryAgentOptions> {
   storage?: MemoryStorage | DefaultMemoryStorageOptions;
+  recorderOptions?: Omit<DefaultMemoryRecorderOptions, "storage">;
+  retrieverOptions?: Omit<DefaultMemoryRetrieverOptions, "storage">;
 }
 
 export class DefaultMemory extends MemoryAgent {
   constructor(options: DefaultMemoryOptions = {}) {
-    super({
-      ...options,
-      autoUpdate: options.autoUpdate ?? true,
-    });
-
-    this.storage =
+    const storage =
       options.storage instanceof MemoryStorage
         ? options.storage
         : new DefaultMemoryStorage(options.storage);
 
-    if (!this.recorder) this.recorder = new DefaultMemoryRecorder(this);
-    if (!this.retriever) this.retriever = new DefaultMemoryRetriever(this);
+    super({
+      ...options,
+      recorder:
+        options.recorder ??
+        new DefaultMemoryRecorder({
+          ...options.recorderOptions,
+          storage,
+        }),
+      retriever:
+        options.retriever ??
+        new DefaultMemoryRetriever({
+          ...options.retrieverOptions,
+          storage,
+        }),
+      autoUpdate: options.autoUpdate ?? true,
+    });
+
+    this.storage = storage;
   }
 
   storage: MemoryStorage;
 }
 
+export interface DefaultMemoryRetrieverOptions
+  extends AgentOptions<MemoryRetrieverInput, MemoryRetrieverOutput> {
+  storage: MemoryStorage;
+  defaultRetrieveMemoryCount?: number;
+}
+
 class DefaultMemoryRetriever extends MemoryRetriever {
-  constructor(public readonly memory: DefaultMemory) {
-    super({});
+  constructor(options: DefaultMemoryRetrieverOptions) {
+    super(options);
+    this.storage = options.storage;
+    this.defaultRetrieveMemoryCount = options.defaultRetrieveMemoryCount;
   }
+
+  private storage: MemoryStorage;
+
+  private defaultRetrieveMemoryCount?: number;
 
   async process(
     input: MemoryRetrieverInput,
     options: AgentInvokeOptions,
   ): Promise<MemoryRetrieverOutput> {
-    const { result } = await this.memory.storage.search(
-      { ...input, limit: input.limit ?? DEFAULT_RETRIEVE_MEMORY_COUNT },
+    const { result } = await this.storage.search(
+      {
+        ...input,
+        limit: input.limit ?? this.defaultRetrieveMemoryCount ?? DEFAULT_RETRIEVE_MEMORY_COUNT,
+      },
       options,
     );
     return { memories: result };
   }
 }
 
+export interface DefaultMemoryRecorderOptions
+  extends AgentOptions<MemoryRecorderInput, MemoryRecorderOutput> {
+  storage: MemoryStorage;
+  rememberFromMessageKey?: string | string[];
+}
+
 class DefaultMemoryRecorder extends MemoryRecorder {
-  constructor(public readonly memory: DefaultMemory) {
-    super({});
+  constructor(options: DefaultMemoryRecorderOptions) {
+    super(options);
+    this.storage = options.storage;
+    this.rememberFromMessageKey = options.rememberFromMessageKey;
   }
+
+  private storage: MemoryStorage;
+
+  private rememberFromMessageKey?: string | string[];
 
   async process(
     input: MemoryRecorderInput,
@@ -70,18 +111,35 @@ class DefaultMemoryRecorder extends MemoryRecorder {
   ): Promise<MemoryRecorderOutput> {
     const newMemories: Memory[] = [];
 
-    for (const content of input.content) {
-      const {
-        result: [last],
-      } = await this.memory.storage.search({ limit: 1 }, options);
-      if (!equal(last?.content, content)) {
-        const { result } = await this.memory.storage.create({ content }, options);
-        newMemories.push(result);
-      }
+    for (const item of input.content) {
+      const { result } = await this.storage.create(
+        {
+          content: {
+            ...item,
+            content: this.processMemoryInput(item.content),
+          },
+        },
+        options,
+      );
+      newMemories.push(result);
     }
 
     return {
       memories: newMemories,
     };
+  }
+
+  private processMemoryInput(content: Message) {
+    const keys = Array.isArray(this.rememberFromMessageKey)
+      ? this.rememberFromMessageKey
+      : this.rememberFromMessageKey
+        ? [this.rememberFromMessageKey]
+        : [];
+    if (!keys.length) return content;
+
+    return Object.entries(content)
+      .filter(([key]) => keys.includes(key))
+      .map(([_, value]) => (typeof value === "string" ? value : JSON.stringify(value)))
+      .join("\n");
   }
 }

--- a/packages/agent-library/src/fs-memory/index.ts
+++ b/packages/agent-library/src/fs-memory/index.ts
@@ -62,21 +62,20 @@ export class FSMemory extends MemoryAgent {
 
     super({
       ...options,
+      recorder:
+        options.recorder ??
+        new FSMemoryRecorder({
+          memoryFileName,
+          ...options.recorderOptions,
+        }),
+      retriever:
+        options.retriever ??
+        new FSMemoryRetriever({
+          memoryFileName,
+          ...options.retrieverOptions,
+        }),
       autoUpdate: options.autoUpdate ?? true,
     });
-
-    this.recorder =
-      options.recorder ??
-      new FSMemoryRecorder({
-        memoryFileName,
-        ...options.recorderOptions,
-      });
-    this.retriever =
-      options.retriever ??
-      new FSMemoryRetriever({
-        memoryFileName,
-        ...options.retrieverOptions,
-      });
   }
 }
 

--- a/packages/agent-library/test/default-memory/__snapshots__/default-memory-storage.test.ts.snap
+++ b/packages/agent-library/test/default-memory/__snapshots__/default-memory-storage.test.ts.snap
@@ -1,0 +1,12 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DefaultMemoryStorage should search by fts 1`] = `
+[
+  {
+    "content": "我讨厌绿色",
+    "createdAt": Any<String>,
+    "id": Any<String>,
+    "sessionId": null,
+  },
+]
+`;

--- a/packages/agent-library/test/default-memory/__snapshots__/default-memory.test.ts.snap
+++ b/packages/agent-library/test/default-memory/__snapshots__/default-memory.test.ts.snap
@@ -1,0 +1,94 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DefaultMemory should remember memories for AIAgent correctly 1`] = `
+[
+  {
+    "content": 
+"You are a helpful assistant.
+Please answer in zh."
+,
+    "name": undefined,
+    "role": "system",
+  },
+  {
+    "content": "I like blue color",
+    "role": "user",
+  },
+]
+`;
+
+exports[`DefaultMemory should remember memories for AIAgent correctly 2`] = `
+[
+  {
+    "content": 
+"You are a helpful assistant.
+Please answer in zh."
+,
+    "name": undefined,
+    "role": "system",
+  },
+  {
+    "content": 
+"Here are some useful memories to consider:
+
+<memories>
+- role: user
+  content: I like blue color
+- role: agent
+  content: Great, the blue color is nice!
+  source: AIAgent
+
+</memories>
+"
+,
+    "role": "system",
+  },
+  {
+    "content": "I also like red color",
+    "role": "user",
+  },
+]
+`;
+
+exports[`DefaultMemory should remember memories for AIAgent correctly 3`] = `
+[
+  {
+    "content": {
+      "content": "I like blue color",
+      "role": "user",
+    },
+    "createdAt": Any<String>,
+    "id": Any<String>,
+    "sessionId": null,
+  },
+  {
+    "content": {
+      "content": "Great, the blue color is nice!",
+      "role": "agent",
+      "source": "AIAgent",
+    },
+    "createdAt": Any<String>,
+    "id": Any<String>,
+    "sessionId": null,
+  },
+  {
+    "content": {
+      "content": "I also like red color",
+      "role": "user",
+    },
+    "createdAt": Any<String>,
+    "id": Any<String>,
+    "sessionId": null,
+  },
+  {
+    "content": {
+      "content": "Red is also a nice color!",
+      "role": "agent",
+      "source": "AIAgent",
+    },
+    "createdAt": Any<String>,
+    "id": Any<String>,
+    "sessionId": null,
+  },
+]
+`;

--- a/packages/agent-library/test/default-memory/default-memory-storage.test.ts
+++ b/packages/agent-library/test/default-memory/default-memory-storage.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test";
+import { DefaultMemoryStorage } from "@aigne/agent-library/default-memory/default-memory-storage";
+import { AIGNE } from "@aigne/core";
+
+test("DefaultMemoryStorage should search by fts", async () => {
+  const context = new AIGNE().newContext();
+
+  const storage = new DefaultMemoryStorage({
+    enableFTS: true,
+  });
+  await storage.create({ content: "我喜欢红色" }, { context });
+  await storage.create({ content: "我讨厌绿色" }, { context });
+
+  const { result } = await storage.search({ search: "绿色", limit: 10 }, { context });
+  expect(result).toMatchSnapshot([
+    {
+      id: expect.any(String),
+      createdAt: expect.any(String),
+    },
+  ]);
+});

--- a/packages/agent-library/test/default-memory/default-memory.test.ts
+++ b/packages/agent-library/test/default-memory/default-memory.test.ts
@@ -1,12 +1,14 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import assert from "node:assert";
 import { rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DefaultMemoryStorage } from "@aigne/agent-library/default-memory/default-memory-storage/index.js";
 import { DefaultMemory } from "@aigne/agent-library/default-memory/index.js";
-import { AIGNE } from "@aigne/core";
+import { AIAgent, AIGNE, type MemoryRecorderInput, stringToAgentResponseStream } from "@aigne/core";
+import { OpenAIChatModel } from "@aigne/openai";
 import { v7 } from "uuid";
+import { z } from "zod";
 
 test("should add a new memory if it is not the same as the last one", async () => {
   const context = new AIGNE().newContext();
@@ -15,7 +17,10 @@ test("should add a new memory if it is not the same as the last one", async () =
   const storage = memoryAgent.storage;
   assert(storage instanceof DefaultMemoryStorage);
 
-  const memory = { role: "user", content: { text: "Hello" } };
+  const memory: MemoryRecorderInput["content"][number] = {
+    role: "user",
+    content: { text: "Hello" },
+  };
 
   await memoryAgent.record({ content: [memory] }, context);
 
@@ -29,23 +34,6 @@ test("should add a new memory if it is not the same as the last one", async () =
   );
 });
 
-test("should not add a new memory if it is the same as the last one", async () => {
-  const context = new AIGNE().newContext();
-
-  const memoryAgent = new DefaultMemory({});
-  const storage = memoryAgent.storage;
-  assert(storage instanceof DefaultMemoryStorage);
-
-  const memory = { role: "user", content: { text: "Hello" } };
-
-  await memoryAgent.record({ content: [memory] }, context);
-  await memoryAgent.record({ content: [memory] }, context);
-
-  const { result: allMemories } = await storage.search({}, { context });
-
-  expect(allMemories).toHaveLength(1);
-});
-
 test("should add multiple different memories", async () => {
   const context = new AIGNE().newContext();
 
@@ -53,8 +41,14 @@ test("should add multiple different memories", async () => {
   const storage = memoryAgent.storage;
   assert(storage instanceof DefaultMemoryStorage);
 
-  const memory1 = { role: "user", content: { text: "Hello" } };
-  const memory2 = { role: "agent", content: { text: "Hi there" } };
+  const memory1: MemoryRecorderInput["content"][number] = {
+    role: "user",
+    content: { text: "Hello" },
+  };
+  const memory2: MemoryRecorderInput["content"][number] = {
+    role: "agent",
+    content: { text: "Hi there" },
+  };
 
   await memoryAgent.record({ content: [memory1] }, context);
   await memoryAgent.record({ content: [memory2] }, context);
@@ -75,7 +69,10 @@ test("DefaultMemory should add memory with correct sessionId", async () => {
   const storage = memoryAgent.storage;
   assert(storage instanceof DefaultMemoryStorage);
 
-  const memory = { role: "user", content: { text: "Hello" } };
+  const memory: MemoryRecorderInput["content"][number] = {
+    role: "user",
+    content: { text: "Hello" },
+  };
 
   await memoryAgent.record({ content: [memory] }, context);
 
@@ -101,7 +98,10 @@ test("DefaultMemory should persist memories if path options is provided", async 
     const storage = memoryAgent.storage;
     assert(storage instanceof DefaultMemoryStorage);
 
-    const memory = { role: "user", content: { text: "Hello" } };
+    const memory: MemoryRecorderInput["content"][number] = {
+      role: "user",
+      content: { text: "Hello" },
+    };
 
     await memoryAgent.record({ content: [memory] }, context);
 
@@ -109,4 +109,48 @@ test("DefaultMemory should persist memories if path options is provided", async 
   } finally {
     await rm(path, { force: true, recursive: true });
   }
+});
+
+test("DefaultMemory should remember memories for AIAgent correctly", async () => {
+  const model = new OpenAIChatModel();
+
+  const memory = new DefaultMemory({
+    recorderOptions: {
+      rememberFromMessageKey: "message",
+    },
+  });
+
+  const agent = AIAgent.from({
+    memory: [memory],
+    inputSchema: z.object({
+      language: z.string(),
+    }),
+    instructions: "You are a helpful assistant.\nPlease answer in {{language}}.",
+    inputKey: "message",
+    outputKey: "message",
+  });
+
+  const aigne = new AIGNE({ model, agents: [agent] });
+
+  const modelProcess = spyOn(model, "process");
+
+  modelProcess.mockReturnValueOnce(stringToAgentResponseStream("Great, the blue color is nice!"));
+  await aigne.invoke(agent, { message: "I like blue color", language: "zh" });
+  expect(modelProcess.mock.lastCall?.[0].messages).toMatchSnapshot();
+
+  modelProcess.mockReturnValueOnce(stringToAgentResponseStream("Red is also a nice color!"));
+  await aigne.invoke(agent, { message: "I also like red color", language: "zh" });
+  expect(modelProcess.mock.lastCall?.[0].messages).toMatchSnapshot();
+
+  const storage = memory.storage;
+  assert(storage instanceof DefaultMemoryStorage);
+
+  const { result: allMemories } = await storage.search({}, { context: aigne.newContext() });
+  expect(allMemories).toMatchSnapshot(
+    new Array(allMemories.length).fill(0).map(() => ({
+      createdAt: expect.any(String),
+      id: expect.any(String),
+      sessionId: null,
+    })),
+  );
 });

--- a/packages/agent-library/test/fs-memory/fs-memory.test.ts
+++ b/packages/agent-library/test/fs-memory/fs-memory.test.ts
@@ -138,7 +138,7 @@ test("FSMemory retrieve should write all memory into memory file", async () => {
 
     const result = await memory.record(
       {
-        content: [{ role: "user", content: "I like blue color." }],
+        content: [{ role: "user", content: { message: "I like blue color." } }],
       },
       engine.newContext(),
     );

--- a/packages/core/src/agents/ai-agent.ts
+++ b/packages/core/src/agents/ai-agent.ts
@@ -181,7 +181,7 @@ export const aiAgentOptionsSchema: ZodObject<{
  * Basic AIAgent creation:
  * {@includeCode ../../test/agents/ai-agent.test.ts#example-ai-agent-basic}
  */
-export class AIAgent<I extends Message = Message, O extends Message = Message> extends Agent<I, O> {
+export class AIAgent<I extends Message = any, O extends Message = any> extends Agent<I, O> {
   tag = "AIAgent";
 
   /**

--- a/packages/core/src/agents/mcp-agent.ts
+++ b/packages/core/src/agents/mcp-agent.ts
@@ -421,7 +421,7 @@ class ClientWithReconnect extends Client {
   }
 }
 
-export interface MCPBaseOptions<I extends Message = Message, O extends Message = Message>
+export interface MCPBaseOptions<I extends Message = any, O extends Message = any>
   extends AgentOptions<I, O> {
   client: ClientWithReconnect;
 }

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -9,8 +9,18 @@ import {
 import type { Context } from "../aigne/context.js";
 import type { MessagePayload } from "../aigne/message-queue.js";
 import { checkArguments, remove } from "../utils/type-utils.js";
-import type { MemoryRecorder, MemoryRecorderInput, MemoryRecorderOutput } from "./recorder.js";
-import type { MemoryRetriever, MemoryRetrieverInput, MemoryRetrieverOutput } from "./retriever.js";
+import {
+  MemoryRecorder,
+  type MemoryRecorderInput,
+  type MemoryRecorderOptions,
+  type MemoryRecorderOutput,
+} from "./recorder.js";
+import {
+  MemoryRetriever,
+  type MemoryRetrieverInput,
+  type MemoryRetrieverOptions,
+  type MemoryRetrieverOutput,
+} from "./retriever.js";
 
 export interface Memory {
   id: string;
@@ -22,8 +32,11 @@ export interface Memory {
 export const newMemoryId = () => v7();
 
 export interface MemoryAgentOptions
-  extends Partial<Pick<MemoryAgent, "recorder" | "retriever" | "autoUpdate">>,
-    Pick<AgentOptions, "subscribeTopic" | "skills"> {}
+  extends Partial<Pick<MemoryAgent, "autoUpdate">>,
+    Pick<AgentOptions, "subscribeTopic" | "skills"> {
+  recorder?: MemoryRecorder | MemoryRecorderOptions["process"] | MemoryRecorderOptions;
+  retriever?: MemoryRetriever | MemoryRetrieverOptions["process"] | MemoryRetrieverOptions;
+}
 
 /**
  * A specialized agent responsible for managing, storing, and retrieving memories within the agent system.
@@ -46,8 +59,24 @@ export class MemoryAgent extends Agent {
       skills: options.skills,
     });
 
-    this.recorder = options.recorder;
-    this.retriever = options.retriever;
+    this.recorder =
+      options.recorder instanceof MemoryRecorder
+        ? options.recorder
+        : options.recorder &&
+          new MemoryRecorder(
+            typeof options.recorder === "function"
+              ? { process: options.recorder }
+              : options.recorder,
+          );
+    this.retriever =
+      options.retriever instanceof MemoryRetriever
+        ? options.retriever
+        : options.retriever &&
+          new MemoryRetriever(
+            typeof options.retriever === "function"
+              ? { process: options.retriever }
+              : options.retriever,
+          );
     this.autoUpdate = options.autoUpdate;
   }
 

--- a/packages/core/test/prompt/prompt-builder.test.ts
+++ b/packages/core/test/prompt/prompt-builder.test.ts
@@ -24,7 +24,7 @@ test("PromptBuilder should build messages correctly", async () => {
   await memory.record(
     {
       role: "agent",
-      content: [{ message: "Hello, How can I help you?" }],
+      content: [{ role: "agent", content: { message: "Hello, How can I help you?" } }],
       source: "TestAgent",
     },
 


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. feat: support remember custom fields from message
```ts

  const memory = new DefaultMemory({
    recorderOptions: {
      rememberFromMessageKey: "message",
    },
  });
```

### Checklist
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

**Release Notes**

Refactor: Major overhaul of the memory system architecture
- New Feature: Flexible memory configuration through function handlers
- New Feature: Custom field extraction capabilities in message processing
- New Feature: Enhanced message structure with role-based content organization
- Refactor: Improved agent type system for better message handling flexibility
- Test: Comprehensive test coverage for new memory system features

These changes provide developers with more control over memory handling and message processing while maintaining backward compatibility. The new architecture enables more sophisticated memory management patterns and custom field extraction capabilities.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->