### PR TITLE
feat(cli): support executing aigne.yaml via shebang (#!/usr/bin/env aigne)

### DIFF
--- a/examples/chat-bot/aigne.yaml
+++ b/examples/chat-bot/aigne.yaml
@@ -1,3 +1,5 @@
+#!/usr/bin/env aigne
+
 chat_model:
   name: gpt-4o-mini
   temperature: 0.8

--- a/examples/chat-bot/index.js
+++ b/examples/chat-bot/index.js
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-
-import { spawnSync } from "node:child_process";
-import { argv } from "node:process";
-
-spawnSync("aigne", ["run", "--path", import.meta.dirname, ...argv.slice(2)], { stdio: "inherit" });

--- a/examples/chat-bot/package.json
+++ b/examples/chat-bot/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/AIGNE-io/aigne-framework"
   },
   "type": "module",
-  "bin": "index.js",
+  "bin": "aigne.yaml",
   "scripts": {
     "test": "aigne test",
     "test:llm": "aigne run"

--- a/examples/mcp-server/aigne.yaml
+++ b/examples/mcp-server/aigne.yaml
@@ -1,3 +1,5 @@
+#!/usr/bin/env aigne
+
 chat_model:
   name: gpt-4.1
   temperature: 0.8

--- a/examples/mcp-server/index.js
+++ b/examples/mcp-server/index.js
@@ -1,9 +1,0 @@
-#!/usr/bin/env node
-
-import { spawnSync } from "node:child_process";
-import { argv } from "node:process";
-
-spawnSync("aigne", [...argv.slice(2)], {
-  stdio: "inherit",
-  cwd: import.meta.dirname,
-});

--- a/examples/mcp-server/package.json
+++ b/examples/mcp-server/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/AIGNE-io/aigne-framework"
   },
   "type": "module",
-  "bin": "index.js",
+  "bin": "aigne.yaml",
   "scripts": {
     "test": "aigne test",
     "test:llm": "aigne run"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,13 +1,25 @@
 #!/usr/bin/env node
 
+import { existsSync, realpathSync, statSync } from "node:fs";
 import { config } from "dotenv-flow";
 import PrettyError from "pretty-error";
 import { createAIGNECommand } from "./commands/aigne.js";
 
 config({ silent: true });
 
-createAIGNECommand()
-  .parseAsync()
+function getAIGNEFilePath() {
+  let file = process.argv[2];
+  if (file) {
+    if (!existsSync(file)) return;
+    file = realpathSync(file);
+    if (statSync(file).isFile()) return file;
+  }
+}
+
+const aigneFilePath = getAIGNEFilePath();
+
+createAIGNECommand({ aigneFilePath })
+  .parseAsync(["", "", ...process.argv.slice(aigneFilePath ? 3 : 2)])
   .catch((error) => {
     console.error(new PrettyError().render(error));
     process.exit(1);

--- a/packages/cli/src/commands/aigne.ts
+++ b/packages/cli/src/commands/aigne.ts
@@ -7,21 +7,17 @@ import { createRunCommand } from "./run.js";
 import { createServeMCPCommand } from "./serve-mcp.js";
 import { createTestCommand } from "./test.js";
 
-export function createAIGNECommand({
-  aigneFilePath,
-}: {
-  aigneFilePath?: string;
-}): Command {
+export function createAIGNECommand(options?: { aigneFilePath?: string }): Command {
   console.log(asciiLogo);
 
   return new Command()
     .name("aigne")
     .description("CLI for AIGNE framework")
     .version(AIGNE_CLI_VERSION)
-    .addCommand(createRunCommand({ aigneFilePath }))
-    .addCommand(createTestCommand({ aigneFilePath }))
+    .addCommand(createRunCommand(options))
+    .addCommand(createTestCommand(options))
     .addCommand(createCreateCommand())
-    .addCommand(createServeMCPCommand({ aigneFilePath }))
+    .addCommand(createServeMCPCommand(options))
     .addCommand(createObservabilityCommand())
     .showHelpAfterError(true)
     .showSuggestionAfterError(true);

--- a/packages/cli/src/commands/aigne.ts
+++ b/packages/cli/src/commands/aigne.ts
@@ -7,17 +7,21 @@ import { createRunCommand } from "./run.js";
 import { createServeMCPCommand } from "./serve-mcp.js";
 import { createTestCommand } from "./test.js";
 
-export function createAIGNECommand(): Command {
+export function createAIGNECommand({
+  aigneFilePath,
+}: {
+  aigneFilePath?: string;
+}): Command {
   console.log(asciiLogo);
 
   return new Command()
     .name("aigne")
     .description("CLI for AIGNE framework")
     .version(AIGNE_CLI_VERSION)
-    .addCommand(createRunCommand())
-    .addCommand(createTestCommand())
+    .addCommand(createRunCommand({ aigneFilePath }))
+    .addCommand(createTestCommand({ aigneFilePath }))
     .addCommand(createCreateCommand())
-    .addCommand(createServeMCPCommand())
+    .addCommand(createServeMCPCommand({ aigneFilePath }))
     .addCommand(createObservabilityCommand())
     .showHelpAfterError(true)
     .showSuggestionAfterError(true);

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -26,7 +26,7 @@ interface RunOptions extends RunAIGNECommandOptions {
   cacheDir?: string;
 }
 
-export function createRunCommand(): Command {
+export function createRunCommand({ aigneFilePath }: { aigneFilePath?: string }): Command {
   return createRunAIGNECommand()
     .description("Run AIGNE from the specified agent")
     .option(
@@ -43,7 +43,7 @@ export function createRunCommand(): Command {
       "Directory to download the package to (defaults to the ~/.aigne/xxx)",
     )
     .action(async (options: RunOptions) => {
-      const { path } = options;
+      const path = aigneFilePath || options.path;
 
       if (options.logLevel) logger.level = options.logLevel;
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -26,7 +26,7 @@ interface RunOptions extends RunAIGNECommandOptions {
   cacheDir?: string;
 }
 
-export function createRunCommand({ aigneFilePath }: { aigneFilePath?: string }): Command {
+export function createRunCommand({ aigneFilePath }: { aigneFilePath?: string } = {}): Command {
   return createRunAIGNECommand()
     .description("Run AIGNE from the specified agent")
     .option(

--- a/packages/cli/src/commands/serve-mcp.ts
+++ b/packages/cli/src/commands/serve-mcp.ts
@@ -24,7 +24,7 @@ const DEFAULT_PORT = () =>
     (error) => new Error(`parse PORT error ${error.message}`),
   );
 
-export function createServeMCPCommand(): Command {
+export function createServeMCPCommand({ aigneFilePath }: { aigneFilePath?: string }): Command {
   return new Command("serve-mcp")
     .description("Serve the agents in the specified directory as a MCP server (streamable http)")
     .option(
@@ -40,7 +40,7 @@ export function createServeMCPCommand(): Command {
     .option("--port <port>", "Port to run the MCP server on", (s) => Number.parseInt(s))
     .option("--pathname <pathname>", "Pathname to the service", "/mcp")
     .action(async (options: ServeMCPOptions) => {
-      const { path } = options;
+      const path = aigneFilePath || options.path;
       const absolutePath = isAbsolute(path) ? path : resolve(process.cwd(), path);
       const port = options.port || DEFAULT_PORT();
 

--- a/packages/cli/src/commands/serve-mcp.ts
+++ b/packages/cli/src/commands/serve-mcp.ts
@@ -24,7 +24,7 @@ const DEFAULT_PORT = () =>
     (error) => new Error(`parse PORT error ${error.message}`),
   );
 
-export function createServeMCPCommand({ aigneFilePath }: { aigneFilePath?: string }): Command {
+export function createServeMCPCommand({ aigneFilePath }: { aigneFilePath?: string } = {}): Command {
   return new Command("serve-mcp")
     .description("Serve the agents in the specified directory as a MCP server (streamable http)")
     .option(

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import { isAbsolute, resolve } from "node:path";
 import { Command } from "commander";
 
-export function createTestCommand(): Command {
+export function createTestCommand({ aigneFilePath }: { aigneFilePath?: string }): Command {
   return new Command("test")
     .description("Run tests in the specified agents directory")
     .option(
@@ -11,7 +11,7 @@ export function createTestCommand(): Command {
       ".",
     )
     .action(async (options: { path: string }) => {
-      const { path } = options;
+      const path = aigneFilePath || options.path;
       const absolutePath = isAbsolute(path) ? path : resolve(process.cwd(), path);
 
       spawnSync("node", ["--test"], { cwd: absolutePath, stdio: "inherit" });

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import { isAbsolute, resolve } from "node:path";
 import { Command } from "commander";
 
-export function createTestCommand({ aigneFilePath }: { aigneFilePath?: string }): Command {
+export function createTestCommand({ aigneFilePath }: { aigneFilePath?: string } = {}): Command {
   return new Command("test")
     .description("Run tests in the specified agents directory")
     .option(

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,4 +1,5 @@
 import { expect, mock, spyOn, test } from "bun:test";
+import { join } from "node:path";
 import { Command } from "commander";
 import { withQuery } from "ufo";
 import { mockModule } from "./_mocks_/mock-module.js";
@@ -13,6 +14,30 @@ test("CLI imports and loads correctly", async () => {
   await import(withQuery("@aigne/cli/cli.js", { key: Date.now() }));
 
   expect(createAIGNECommand).toHaveBeenCalled();
+});
+
+test("CLI imports and loads correctly", async () => {
+  const createAIGNECommand = mock(() => new Command());
+
+  await using _ = await mockModule("@aigne/cli/commands/aigne.js", () => ({
+    createAIGNECommand,
+  }));
+
+  const originalArgv = process.argv;
+  process.argv = [
+    "node",
+    "cli.js",
+    join(import.meta.dirname, "../test-agents/aigne.yaml"),
+    ...originalArgv.slice(2),
+  ];
+
+  await import(withQuery("@aigne/cli/cli.js", { key: Date.now() }));
+
+  process.argv = originalArgv;
+
+  expect(createAIGNECommand).toHaveBeenLastCalledWith({
+    aigneFilePath: expect.stringContaining("test-agents/aigne.yaml"),
+  });
 });
 
 test("aigne cli should print pretty error message", async () => {


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. feat(cli): support executing aigne.yaml via shebang (#!/usr/bin/env aigne)

ainge.yaml
```yaml
#!/usr/bin/env aigne

chat_model:
  name: gpt-4o-mini
  temperature: 0.8
agents:
  - agents/chat.yaml

```


### Checklist

- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

**Release Notes**

- New Feature: Added shebang support for direct execution of AIGNE configuration files using `#!/usr/bin/env aigne`
- Refactor: Simplified example projects by removing Node.js wrapper scripts in favor of native AIGNE file execution
- Chore: Updated internal command handlers to support file-based execution mode

These changes streamline the workflow for AIGNE users by allowing configuration files to be executed directly as scripts, eliminating the need for separate wrapper files. Users can now run AIGNE files with standard Unix-like shebang syntax.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->