### PR TITLE
fix(cli): set run as the default command

### DIFF
--- a/packages/cli/src/commands/aigne.ts
+++ b/packages/cli/src/commands/aigne.ts
@@ -14,7 +14,7 @@ export function createAIGNECommand(options?: { aigneFilePath?: string }): Comman
     .name("aigne")
     .description("CLI for AIGNE framework")
     .version(AIGNE_CLI_VERSION)
-    .addCommand(createRunCommand(options))
+    .addCommand(createRunCommand(options), { isDefault: true })
     .addCommand(createTestCommand(options))
     .addCommand(createCreateCommand())
     .addCommand(createServeMCPCommand(options))

--- a/packages/cli/test/commands/aigne.test.ts
+++ b/packages/cli/test/commands/aigne.test.ts
@@ -5,4 +5,6 @@ import { Command } from "commander";
 test("aigne command should parse --version correctly", async () => {
   const command = createAIGNECommand();
   expect(command).toBeInstanceOf(Command);
+
+  expect((command as any)["_defaultCommandName"]).toBe("run");
 });


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(cli): set run as the default command

### Checklist

- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

**Release Notes**

- New Feature: Simplified CLI usage by making `run` the default command
- Test: Added verification for default command behavior

These changes streamline the AIGNE framework CLI experience by allowing users to execute the `run` command without explicitly specifying it. Users can now use `aigne [options]` instead of `aigne run [options]`, making the CLI more intuitive and user-friendly while maintaining all existing functionality.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->