### PR TITLE
fix(core): ensure output is a record type for FunctionAgent

### DIFF
--- a/packages/core/src/agents/agent.ts
+++ b/packages/core/src/agents/agent.ts
@@ -19,6 +19,7 @@ import {
   createAccessorArray,
   flat,
   isEmpty,
+  isRecord,
   type Nullish,
   type PromiseOrValue,
   type XOr,
@@ -649,6 +650,12 @@ export abstract class Agent<I extends Message = any, O extends Message = any> {
     options: AgentInvokeOptions,
   ): Promise<O> {
     const { context } = options;
+
+    if (!isRecord(output)) {
+      throw new Error(
+        `expect to return a record type such as {result: ...}, but got (${typeof output}): ${output}`,
+      );
+    }
 
     const parsedOutput = checkArguments(
       `Agent ${this.name} output`,

--- a/packages/core/src/utils/stream-utils.ts
+++ b/packages/core/src/utils/stream-utils.ts
@@ -7,11 +7,17 @@ import {
   isEmptyChunk,
   type Message,
 } from "../agents/agent.js";
-import { omitBy, type PromiseOrValue } from "./type-utils.js";
+import { isRecord, omitBy, type PromiseOrValue } from "./type-utils.js";
 import "./stream-polyfill.js";
 import type { ReadableStreamDefaultReadResult } from "bun";
 
 export function objectToAgentResponseStream<T extends Message>(json: T): AgentResponseStream<T> {
+  if (!isRecord(json)) {
+    throw new Error(
+      `expect to return a record type such as {result: ...}, but got (${typeof json}): ${json}`,
+    );
+  }
+
   return new ReadableStream({
     pull(controller) {
       controller.enqueue({ delta: { json } });

--- a/packages/core/test/agents/agent.test.ts
+++ b/packages/core/test/agents/agent.test.ts
@@ -726,3 +726,16 @@ test("AgentInput/AgentOutput should infer correct types", async () => {
   expectType<AgentInput<typeof agent>>().is<{ name: string; age: number }>();
   expectType<AgentOutput<typeof agent>>().is<{ greeting: string; ageInMonths: number }>();
 });
+
+test("Agent must return a record type", async () => {
+  // biome-ignore lint/security/noGlobalEval: just for testing
+  const agent = FunctionAgent.from(() => eval("4 * 4"));
+
+  expect(agent.invoke({}, { streaming: false })).rejects.toThrow(
+    "expect to return a record type such as {result: ...}, but got (number): 16",
+  );
+
+  expect(agent.invoke({}, { streaming: true })).rejects.toThrow(
+    "expect to return a record type such as {result: ...}, but got (number): 16",
+  );
+});

--- a/packages/core/test/aigne/context.test.ts
+++ b/packages/core/test/aigne/context.test.ts
@@ -6,7 +6,10 @@ import {
   FunctionAgent,
   type MessageQueueListener,
 } from "@aigne/core";
-import { arrayToAgentProcessAsyncGenerator } from "@aigne/core/utils/stream-utils.js";
+import {
+  arrayToAgentProcessAsyncGenerator,
+  readableStreamToArray,
+} from "@aigne/core/utils/stream-utils.js";
 import type { Listener } from "@aigne/core/utils/typed-event-emitter.js";
 
 test("AIGNEContext should subscribe/unsubscribe correctly", async () => {
@@ -172,5 +175,26 @@ test("AIGNEContext.invoke should update userContext/memories correctly", async (
         memories: [{ content: "test memory content" }],
       }),
     }),
+  );
+});
+
+test("AIGNEContext.invoke should check output is a record type", async () => {
+  const aigne = new AIGNE({});
+
+  // biome-ignore lint/security/noGlobalEval: just for testing
+  const agent = FunctionAgent.from(() => eval("4 * 4"));
+
+  expect(
+    await readableStreamToArray(await aigne.invoke(agent, {}, { streaming: true }), {
+      catchError: true,
+    }),
+  ).toMatchInlineSnapshot(`
+    [
+      [Error: expect to return a record type such as {result: ...}, but got (number): 16],
+    ]
+  `);
+
+  expect(aigne.invoke(agent, {})).rejects.toThrow(
+    "expect to return a record type such as {result: ...}, but got (number): 16",
   );
 });


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(core): ensure output is a record type

```shell
$ bun run test.ts        
  aigne:core:error Invoke agent calculate failed with error: Error: expect to return a record type such as {result: ...}, but got (number): 110
  aigne:core:error     at objectToAgentResponseStream (/Users/chao/Projects/blocklet/aigne-framework/packages/core/lib/esm/utils/stream-utils.js:7:19)
  aigne:core:error     at invoke (/Users/chao/Projects/blocklet/aigne-framework/packages/core/lib/esm/agents/agent.js:311:27)
  aigne:core:error     at processTicksAndRejections (native:7:39) +0ms
  aigne:core:error Invoke agent calculate failed with error: Error: expect to return a record type such as {result: ...}, but got (number): 110
  aigne:core:error     at objectToAgentResponseStream (/Users/chao/Projects/blocklet/aigne-framework/packages/core/lib/esm/utils/stream-utils.js:7:19)
  aigne:core:error     at invoke (/Users/chao/Projects/blocklet/aigne-framework/packages/core/lib/esm/agents/agent.js:311:27)
  aigne:core:error     at processTicksAndRejections (native:7:39) +1s
```


### Checklist

- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

**Release Notes**

- New Feature: Added type validation for agent outputs to ensure consistent record-type responses
- Bug Fix: Improved error handling when agents return invalid output formats
- Test: Enhanced test coverage for agent output validation

These changes improve reliability by ensuring agents always return properly structured data, preventing potential runtime errors. Users will receive clearer error messages if their agent implementations return incorrect output formats.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->