### PR TITLE
feat(core): support external files as agent input/output schema

### DIFF
--- a/packages/core/src/loader/agent-js.ts
+++ b/packages/core/src/loader/agent-js.ts
@@ -31,7 +31,7 @@ export async function loadAgentFromJsFile(path: string) {
 
   return tryOrThrow(
     () =>
-      agentJsFileSchema.parse(
+      agentJsFileSchema.parseAsync(
         camelize({
           ...agent,
           name: agent.agent_name || agent.agentName || agent.name,

--- a/packages/core/src/loader/agent-js.ts
+++ b/packages/core/src/loader/agent-js.ts
@@ -5,19 +5,19 @@ import { Agent, type FunctionAgentFn } from "../agents/agent.js";
 import { tryOrThrow } from "../utils/type-utils.js";
 import { inputOutputSchema, optionalize } from "./schema.js";
 
-const agentJsFileSchema = z.object({
-  name: z.string(),
-  description: optionalize(z.string()),
-  inputSchema: optionalize(inputOutputSchema).transform((v) =>
-    v ? jsonSchemaToZod<ZodObject<Record<string, ZodType>>>(v) : undefined,
-  ),
-  outputSchema: optionalize(inputOutputSchema).transform((v) =>
-    v ? jsonSchemaToZod<ZodObject<Record<string, ZodType>>>(v) : undefined,
-  ),
-  process: z.custom<FunctionAgentFn>(),
-});
-
 export async function loadAgentFromJsFile(path: string) {
+  const agentJsFileSchema = z.object({
+    name: z.string(),
+    description: optionalize(z.string()),
+    inputSchema: optionalize(inputOutputSchema({ path })).transform((v) =>
+      v ? jsonSchemaToZod<ZodObject<Record<string, ZodType>>>(v) : undefined,
+    ),
+    outputSchema: optionalize(inputOutputSchema({ path })).transform((v) =>
+      v ? jsonSchemaToZod<ZodObject<Record<string, ZodType>>>(v) : undefined,
+    ),
+    process: z.custom<FunctionAgentFn>(),
+  });
+
   const { default: agent } = await tryOrThrow(
     () => import(/* @vite-ignore */ path),
     (error) => new Error(`Failed to load agent definition from ${path}: ${error.message}`),

--- a/packages/core/src/loader/agent-yaml.ts
+++ b/packages/core/src/loader/agent-yaml.ts
@@ -55,10 +55,12 @@ export async function loadAgentFromYamlFile(path: string) {
     const baseAgentSchema = z.object({
       name: optionalize(z.string()),
       description: optionalize(z.string()),
-      inputSchema: optionalize(inputOutputSchema).transform<BaseAgentSchema["inputSchema"]>((v) =>
-        v ? jsonSchemaToZod(v) : undefined,
-      ) as unknown as ZodType<BaseAgentSchema["inputSchema"]>,
-      outputSchema: optionalize(inputOutputSchema).transform((v) =>
+      inputSchema: optionalize(inputOutputSchema({ path })).transform<
+        BaseAgentSchema["inputSchema"]
+      >((v) => (v ? jsonSchemaToZod(v) : undefined)) as unknown as ZodType<
+        BaseAgentSchema["inputSchema"]
+      >,
+      outputSchema: optionalize(inputOutputSchema({ path })).transform((v) =>
         v ? jsonSchemaToZod(v) : undefined,
       ) as unknown as ZodType<BaseAgentSchema["outputSchema"]>,
       skills: optionalize(z.array(z.union([z.string(), agentSchema]))),

--- a/packages/core/src/loader/agent-yaml.ts
+++ b/packages/core/src/loader/agent-yaml.ts
@@ -11,8 +11,8 @@ import { inputOutputSchema, optionalize } from "./schema.js";
 interface BaseAgentSchema {
   name?: string;
   description?: string;
-  inputSchema?: ZodType<Record<string, ZodType>>;
-  outputSchema?: ZodType<Record<string, ZodType>>;
+  inputSchema?: ZodType<Record<string, any>>;
+  outputSchema?: ZodType<Record<string, any>>;
   skills?: (string | AgentSchema)[];
   memory?:
     | boolean
@@ -55,11 +55,9 @@ export async function loadAgentFromYamlFile(path: string) {
     const baseAgentSchema = z.object({
       name: optionalize(z.string()),
       description: optionalize(z.string()),
-      inputSchema: optionalize(inputOutputSchema({ path })).transform<
-        BaseAgentSchema["inputSchema"]
-      >((v) => (v ? jsonSchemaToZod(v) : undefined)) as unknown as ZodType<
-        BaseAgentSchema["inputSchema"]
-      >,
+      inputSchema: optionalize(inputOutputSchema({ path })).transform((v) =>
+        v ? jsonSchemaToZod(v) : undefined,
+      ) as unknown as ZodType<BaseAgentSchema["inputSchema"]>,
       outputSchema: optionalize(inputOutputSchema({ path })).transform((v) =>
         v ? jsonSchemaToZod(v) : undefined,
       ) as unknown as ZodType<BaseAgentSchema["outputSchema"]>,

--- a/packages/core/src/loader/schema.ts
+++ b/packages/core/src/loader/schema.ts
@@ -2,24 +2,59 @@ import { nodejs } from "@aigne/platform-helpers/nodejs/index.js";
 import { parse } from "yaml";
 import { type ZodType, z } from "zod";
 
-const jsonSchemaSchema = z.object({
-  type: z.literal("object"),
-  properties: z.record(z.any()),
-  required: z.array(z.string()).optional(),
-  additionalProperties: z.boolean().optional(),
-});
+export const inputOutputSchema = ({ path }: { path: string }) => {
+  const jsonSchemaSchema = z
+    .object({
+      type: z.literal("object"),
+      properties: z.record(z.any()),
+      required: z.array(z.string()).optional(),
+      additionalProperties: z.boolean().optional(),
+    })
+    .transform((v) => {
+      const t = async (schema: any): Promise<typeof schema> => {
+        if (schema?.type === "object" && schema.properties) {
+          return {
+            ...schema,
+            properties: Object.fromEntries(
+              await Promise.all(
+                Object.entries(schema.properties).map(async ([key, value]) => [
+                  key,
+                  await t(value),
+                ]),
+              ),
+            ),
+          };
+        }
 
-export const inputOutputSchema = ({ path }: { path: string }) =>
-  z.union([
+        if (schema?.type === "array" && schema.items) {
+          return { ...schema, items: await t(schema.items) };
+        }
+
+        // Load nested schemas from file
+        if (typeof schema === "string") {
+          const raw = await nodejs.fs.readFile(
+            nodejs.path.join(nodejs.path.dirname(path), schema),
+            "utf8",
+          );
+          return jsonSchemaSchema.parseAsync(parse(raw));
+        }
+        return schema;
+      };
+
+      return t(v);
+    });
+
+  return z.union([
     z
       .string()
       .transform((v) =>
         nodejs.fs
           .readFile(nodejs.path.join(nodejs.path.dirname(path), v), "utf8")
-          .then((raw) => jsonSchemaSchema.parse(parse(raw))),
+          .then((raw) => jsonSchemaSchema.parseAsync(parse(raw))),
       ) as unknown as ZodType<z.infer<typeof jsonSchemaSchema>>,
     jsonSchemaSchema,
   ]);
+};
 
 export function optionalize<T>(schema: ZodType<T>): ZodType<T | undefined> {
   return schema.nullish().transform((v) => v ?? undefined) as ZodType<T | undefined>;

--- a/packages/core/src/loader/schema.ts
+++ b/packages/core/src/loader/schema.ts
@@ -1,11 +1,25 @@
+import { nodejs } from "@aigne/platform-helpers/nodejs/index.js";
+import { parse } from "yaml";
 import { type ZodType, z } from "zod";
 
-export const inputOutputSchema = z.object({
+const jsonSchemaSchema = z.object({
   type: z.literal("object"),
   properties: z.record(z.any()),
   required: z.array(z.string()).optional(),
   additionalProperties: z.boolean().optional(),
 });
+
+export const inputOutputSchema = ({ path }: { path: string }) =>
+  z.union([
+    z
+      .string()
+      .transform((v) =>
+        nodejs.fs
+          .readFile(nodejs.path.join(nodejs.path.dirname(path), v), "utf8")
+          .then((raw) => jsonSchemaSchema.parse(parse(raw))),
+      ) as unknown as ZodType<z.infer<typeof jsonSchemaSchema>>,
+    jsonSchemaSchema,
+  ]);
 
 export function optionalize<T>(schema: ZodType<T>): ZodType<T | undefined> {
   return schema.nullish().transform((v) => v ?? undefined) as ZodType<T | undefined>;

--- a/packages/core/test-agents/external-schema-agent-nested.yaml
+++ b/packages/core/test-agents/external-schema-agent-nested.yaml
@@ -1,0 +1,54 @@
+name: external-schema-agent-nested
+description: External schema in nested properties
+input_schema:
+  type: object
+  properties:
+    external: ./external-schema-first.yaml
+    nested:
+      type: object
+      properties:
+        external: ./external-schema-first.yaml
+      required:
+        - external
+    items:
+      type: array
+      items: ./external-schema-first.yaml
+    array:
+      type: array
+      items:
+        type: object
+        properties:
+          external: ./external-schema-first.yaml
+        required:
+          - external
+  required:
+    - external
+    - nested
+    - items
+    - array
+output_schema:
+  type: object
+  properties:
+    external: ./external-schema-first.yaml
+    nested:
+      type: object
+      properties:
+        external: ./external-schema-first.yaml
+      required:
+        - external
+    items:
+      type: array
+      items: ./external-schema-first.yaml
+    array:
+      type: array
+      items:
+        type: object
+        properties:
+          external: ./external-schema-first.yaml
+        required:
+          - external
+  required:
+    - external
+    - nested
+    - items
+    - array

--- a/packages/core/test-agents/external-schema-agent.yaml
+++ b/packages/core/test-agents/external-schema-agent.yaml
@@ -1,4 +1,4 @@
 name: external-schema-agent
 description: External schema agent
-input_schema: ./external-schema.yaml
-output_schema: ./external-schema.yaml
+input_schema: ./external-schema-first.yaml
+output_schema: ./external-schema-first.yaml

--- a/packages/core/test-agents/external-schema-agent.yaml
+++ b/packages/core/test-agents/external-schema-agent.yaml
@@ -1,0 +1,4 @@
+name: external-schema-agent
+description: External schema agent
+input_schema: ./external-schema.yaml
+output_schema: ./external-schema.yaml

--- a/packages/core/test-agents/external-schema-first.yaml
+++ b/packages/core/test-agents/external-schema-first.yaml
@@ -1,0 +1,9 @@
+type: object
+properties:
+  first:
+    type: string
+    description: First level property
+  second: ./external-schema-second.yaml
+required:
+  - first
+  - second

--- a/packages/core/test-agents/external-schema-second.yaml
+++ b/packages/core/test-agents/external-schema-second.yaml
@@ -1,0 +1,13 @@
+type: object
+properties:
+  second:
+    type: string
+    description: Second level property
+  third: ./external-schema-third.yaml
+  array:
+    type: array
+    items: ./external-schema-third.yaml
+required:
+  - second
+  - third
+  - array

--- a/packages/core/test-agents/external-schema-third.yaml
+++ b/packages/core/test-agents/external-schema-third.yaml
@@ -1,0 +1,7 @@
+type: object
+properties:
+  third:
+    type: string
+    description: Third level property
+required:
+  - third

--- a/packages/core/test-agents/external-schema.yaml
+++ b/packages/core/test-agents/external-schema.yaml
@@ -1,0 +1,7 @@
+type: object
+properties:
+  message:
+    type: string
+    description: Message to process
+required:
+  - message

--- a/packages/core/test-agents/external-schema.yaml
+++ b/packages/core/test-agents/external-schema.yaml
@@ -1,7 +1,0 @@
-type: object
-properties:
-  message:
-    type: string
-    description: Message to process
-required:
-  - message

--- a/packages/core/test/loader/__snapshots__/agent-yaml.test.ts.snap
+++ b/packages/core/test/loader/__snapshots__/agent-yaml.test.ts.snap
@@ -11,7 +11,7 @@ exports[`loadAgentFromYaml should load AIAgent with prompt file correctly 2`] = 
 {
   "messages": [
     {
-      "content": 
+      "content":
 "You are a helper agent to answer everything about chat prompt in AIGNE.
 
 Output in English
@@ -34,7 +34,7 @@ exports[`loadAgentFromYaml should load nested agent correctly 3`] = `
   "skills": [
     {
       "inputSchema": undefined,
-      "instructions": 
+      "instructions":
 "You are a helpful assistant that can answer questions and provide information on a wide range of topics.
 Your goal is to assist users in finding the information they need and to engage in friendly conversation.
 "
@@ -75,7 +75,7 @@ Your goal is to assist users in finding the information they need and to engage 
     },
     {
       "inputSchema": undefined,
-      "instructions": 
+      "instructions":
 "You are a helper agent to answer everything about chat prompt in AIGNE.
 
 {% include "language_instruction.txt" %}
@@ -93,7 +93,7 @@ Your goal is to assist users in finding the information they need and to engage 
       "skills": [
         {
           "inputSchema": undefined,
-          "instructions": 
+          "instructions":
 "You are a helpful assistant that can answer questions and provide information on a wide range of topics.
 Your goal is to assist users in finding the information they need and to engage in friendly conversation.
 "
@@ -147,7 +147,7 @@ Your goal is to assist users in finding the information they need and to engage 
             ],
             "type": "object",
           },
-          "instructions": 
+          "instructions":
 "You are a helper agent to answer everything about chat prompt in AIGNE.
 
 {% include "language_instruction.txt" %}
@@ -173,5 +173,673 @@ Your goal is to assist users in finding the information they need and to engage 
       ],
     },
   ],
+}
+`;
+
+exports[`loadAgentFromYaml should load external schema agent correctly 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": true,
+  "properties": {
+    "first": {
+      "description": "First level property",
+      "type": "string",
+    },
+    "second": {
+      "additionalProperties": false,
+      "properties": {
+        "array": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "third": {
+                "description": "Third level property",
+                "type": "string",
+              },
+            },
+            "required": [
+              "third",
+            ],
+            "type": "object",
+          },
+          "type": "array",
+        },
+        "second": {
+          "description": "Second level property",
+          "type": "string",
+        },
+        "third": {
+          "additionalProperties": false,
+          "properties": {
+            "third": {
+              "description": "Third level property",
+              "type": "string",
+            },
+          },
+          "required": [
+            "third",
+          ],
+          "type": "object",
+        },
+      },
+      "required": [
+        "second",
+        "third",
+        "array",
+      ],
+      "type": "object",
+    },
+  },
+  "required": [
+    "first",
+    "second",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`loadAgentFromYaml should load external schema agent correctly 2`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": true,
+  "properties": {
+    "first": {
+      "description": "First level property",
+      "type": "string",
+    },
+    "second": {
+      "additionalProperties": false,
+      "properties": {
+        "array": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "third": {
+                "description": "Third level property",
+                "type": "string",
+              },
+            },
+            "required": [
+              "third",
+            ],
+            "type": "object",
+          },
+          "type": "array",
+        },
+        "second": {
+          "description": "Second level property",
+          "type": "string",
+        },
+        "third": {
+          "additionalProperties": false,
+          "properties": {
+            "third": {
+              "description": "Third level property",
+              "type": "string",
+            },
+          },
+          "required": [
+            "third",
+          ],
+          "type": "object",
+        },
+      },
+      "required": [
+        "second",
+        "third",
+        "array",
+      ],
+      "type": "object",
+    },
+  },
+  "required": [
+    "first",
+    "second",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`loadAgentFromYaml should load nested external schema agent correctly 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": true,
+  "properties": {
+    "array": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "external": {
+            "additionalProperties": false,
+            "properties": {
+              "first": {
+                "description": "First level property",
+                "type": "string",
+              },
+              "second": {
+                "additionalProperties": false,
+                "properties": {
+                  "array": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "third": {
+                          "description": "Third level property",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "third",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "second": {
+                    "description": "Second level property",
+                    "type": "string",
+                  },
+                  "third": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "third": {
+                        "description": "Third level property",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "third",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "second",
+                  "third",
+                  "array",
+                ],
+                "type": "object",
+              },
+            },
+            "required": [
+              "first",
+              "second",
+            ],
+            "type": "object",
+          },
+        },
+        "required": [
+          "external",
+        ],
+        "type": "object",
+      },
+      "type": "array",
+    },
+    "external": {
+      "additionalProperties": false,
+      "properties": {
+        "first": {
+          "description": "First level property",
+          "type": "string",
+        },
+        "second": {
+          "additionalProperties": false,
+          "properties": {
+            "array": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "third": {
+                    "description": "Third level property",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "third",
+                ],
+                "type": "object",
+              },
+              "type": "array",
+            },
+            "second": {
+              "description": "Second level property",
+              "type": "string",
+            },
+            "third": {
+              "additionalProperties": false,
+              "properties": {
+                "third": {
+                  "description": "Third level property",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "third",
+              ],
+              "type": "object",
+            },
+          },
+          "required": [
+            "second",
+            "third",
+            "array",
+          ],
+          "type": "object",
+        },
+      },
+      "required": [
+        "first",
+        "second",
+      ],
+      "type": "object",
+    },
+    "items": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "first": {
+            "description": "First level property",
+            "type": "string",
+          },
+          "second": {
+            "additionalProperties": false,
+            "properties": {
+              "array": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "third": {
+                      "description": "Third level property",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "third",
+                  ],
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              "second": {
+                "description": "Second level property",
+                "type": "string",
+              },
+              "third": {
+                "additionalProperties": false,
+                "properties": {
+                  "third": {
+                    "description": "Third level property",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "third",
+                ],
+                "type": "object",
+              },
+            },
+            "required": [
+              "second",
+              "third",
+              "array",
+            ],
+            "type": "object",
+          },
+        },
+        "required": [
+          "first",
+          "second",
+        ],
+        "type": "object",
+      },
+      "type": "array",
+    },
+    "nested": {
+      "additionalProperties": false,
+      "properties": {
+        "external": {
+          "additionalProperties": false,
+          "properties": {
+            "first": {
+              "description": "First level property",
+              "type": "string",
+            },
+            "second": {
+              "additionalProperties": false,
+              "properties": {
+                "array": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "third": {
+                        "description": "Third level property",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "third",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "second": {
+                  "description": "Second level property",
+                  "type": "string",
+                },
+                "third": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "third": {
+                      "description": "Third level property",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "third",
+                  ],
+                  "type": "object",
+                },
+              },
+              "required": [
+                "second",
+                "third",
+                "array",
+              ],
+              "type": "object",
+            },
+          },
+          "required": [
+            "first",
+            "second",
+          ],
+          "type": "object",
+        },
+      },
+      "required": [
+        "external",
+      ],
+      "type": "object",
+    },
+  },
+  "required": [
+    "external",
+    "nested",
+    "items",
+    "array",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`loadAgentFromYaml should load nested external schema agent correctly 2`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": true,
+  "properties": {
+    "array": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "external": {
+            "additionalProperties": false,
+            "properties": {
+              "first": {
+                "description": "First level property",
+                "type": "string",
+              },
+              "second": {
+                "additionalProperties": false,
+                "properties": {
+                  "array": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "third": {
+                          "description": "Third level property",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "third",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "second": {
+                    "description": "Second level property",
+                    "type": "string",
+                  },
+                  "third": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "third": {
+                        "description": "Third level property",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "third",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "second",
+                  "third",
+                  "array",
+                ],
+                "type": "object",
+              },
+            },
+            "required": [
+              "first",
+              "second",
+            ],
+            "type": "object",
+          },
+        },
+        "required": [
+          "external",
+        ],
+        "type": "object",
+      },
+      "type": "array",
+    },
+    "external": {
+      "additionalProperties": false,
+      "properties": {
+        "first": {
+          "description": "First level property",
+          "type": "string",
+        },
+        "second": {
+          "additionalProperties": false,
+          "properties": {
+            "array": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "third": {
+                    "description": "Third level property",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "third",
+                ],
+                "type": "object",
+              },
+              "type": "array",
+            },
+            "second": {
+              "description": "Second level property",
+              "type": "string",
+            },
+            "third": {
+              "additionalProperties": false,
+              "properties": {
+                "third": {
+                  "description": "Third level property",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "third",
+              ],
+              "type": "object",
+            },
+          },
+          "required": [
+            "second",
+            "third",
+            "array",
+          ],
+          "type": "object",
+        },
+      },
+      "required": [
+        "first",
+        "second",
+      ],
+      "type": "object",
+    },
+    "items": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "first": {
+            "description": "First level property",
+            "type": "string",
+          },
+          "second": {
+            "additionalProperties": false,
+            "properties": {
+              "array": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "third": {
+                      "description": "Third level property",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "third",
+                  ],
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              "second": {
+                "description": "Second level property",
+                "type": "string",
+              },
+              "third": {
+                "additionalProperties": false,
+                "properties": {
+                  "third": {
+                    "description": "Third level property",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "third",
+                ],
+                "type": "object",
+              },
+            },
+            "required": [
+              "second",
+              "third",
+              "array",
+            ],
+            "type": "object",
+          },
+        },
+        "required": [
+          "first",
+          "second",
+        ],
+        "type": "object",
+      },
+      "type": "array",
+    },
+    "nested": {
+      "additionalProperties": false,
+      "properties": {
+        "external": {
+          "additionalProperties": false,
+          "properties": {
+            "first": {
+              "description": "First level property",
+              "type": "string",
+            },
+            "second": {
+              "additionalProperties": false,
+              "properties": {
+                "array": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "third": {
+                        "description": "Third level property",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "third",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "second": {
+                  "description": "Second level property",
+                  "type": "string",
+                },
+                "third": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "third": {
+                      "description": "Third level property",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "third",
+                  ],
+                  "type": "object",
+                },
+              },
+              "required": [
+                "second",
+                "third",
+                "array",
+              ],
+              "type": "object",
+            },
+          },
+          "required": [
+            "first",
+            "second",
+          ],
+          "type": "object",
+        },
+      },
+      "required": [
+        "external",
+      ],
+      "type": "object",
+    },
+  },
+  "required": [
+    "external",
+    "nested",
+    "items",
+    "array",
+  ],
+  "type": "object",
 }
 `;

--- a/packages/core/test/loader/__snapshots__/agent-yaml.test.ts.snap
+++ b/packages/core/test/loader/__snapshots__/agent-yaml.test.ts.snap
@@ -11,7 +11,7 @@ exports[`loadAgentFromYaml should load AIAgent with prompt file correctly 2`] = 
 {
   "messages": [
     {
-      "content":
+      "content": 
 "You are a helper agent to answer everything about chat prompt in AIGNE.
 
 Output in English
@@ -34,7 +34,7 @@ exports[`loadAgentFromYaml should load nested agent correctly 3`] = `
   "skills": [
     {
       "inputSchema": undefined,
-      "instructions":
+      "instructions": 
 "You are a helpful assistant that can answer questions and provide information on a wide range of topics.
 Your goal is to assist users in finding the information they need and to engage in friendly conversation.
 "
@@ -75,7 +75,7 @@ Your goal is to assist users in finding the information they need and to engage 
     },
     {
       "inputSchema": undefined,
-      "instructions":
+      "instructions": 
 "You are a helper agent to answer everything about chat prompt in AIGNE.
 
 {% include "language_instruction.txt" %}
@@ -93,7 +93,7 @@ Your goal is to assist users in finding the information they need and to engage 
       "skills": [
         {
           "inputSchema": undefined,
-          "instructions":
+          "instructions": 
 "You are a helpful assistant that can answer questions and provide information on a wide range of topics.
 Your goal is to assist users in finding the information they need and to engage in friendly conversation.
 "
@@ -147,7 +147,7 @@ Your goal is to assist users in finding the information they need and to engage 
             ],
             "type": "object",
           },
-          "instructions":
+          "instructions": 
 "You are a helper agent to answer everything about chat prompt in AIGNE.
 
 {% include "language_instruction.txt" %}

--- a/packages/core/test/loader/agent-yaml.test.ts
+++ b/packages/core/test/loader/agent-yaml.test.ts
@@ -204,3 +204,42 @@ test("loadAgentFromYaml should load transform agent correctly", async () => {
     "
   `);
 });
+
+test("loadAgentFromYaml should load external schema agent correctly", async () => {
+  const agent = await loadAgent(
+    join(import.meta.dirname, "../../test-agents/external-schema-agent.yaml"),
+  );
+
+  expect(zodToJsonSchema(agent.inputSchema)).toMatchInlineSnapshot(`
+    {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": true,
+      "properties": {
+        "message": {
+          "description": "Message to process",
+          "type": "string",
+        },
+      },
+      "required": [
+        "message",
+      ],
+      "type": "object",
+    }
+  `);
+  expect(zodToJsonSchema(agent.outputSchema)).toMatchInlineSnapshot(`
+    {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": true,
+      "properties": {
+        "message": {
+          "description": "Message to process",
+          "type": "string",
+        },
+      },
+      "required": [
+        "message",
+      ],
+      "type": "object",
+    }
+  `);
+});

--- a/packages/core/test/loader/agent-yaml.test.ts
+++ b/packages/core/test/loader/agent-yaml.test.ts
@@ -210,36 +210,15 @@ test("loadAgentFromYaml should load external schema agent correctly", async () =
     join(import.meta.dirname, "../../test-agents/external-schema-agent.yaml"),
   );
 
-  expect(zodToJsonSchema(agent.inputSchema)).toMatchInlineSnapshot(`
-    {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "properties": {
-        "message": {
-          "description": "Message to process",
-          "type": "string",
-        },
-      },
-      "required": [
-        "message",
-      ],
-      "type": "object",
-    }
-  `);
-  expect(zodToJsonSchema(agent.outputSchema)).toMatchInlineSnapshot(`
-    {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "additionalProperties": true,
-      "properties": {
-        "message": {
-          "description": "Message to process",
-          "type": "string",
-        },
-      },
-      "required": [
-        "message",
-      ],
-      "type": "object",
-    }
-  `);
+  expect(zodToJsonSchema(agent.inputSchema)).toMatchSnapshot();
+  expect(zodToJsonSchema(agent.outputSchema)).toMatchSnapshot();
+});
+
+test("loadAgentFromYaml should load nested external schema agent correctly", async () => {
+  const agent = await loadAgent(
+    join(import.meta.dirname, "../../test-agents/external-schema-agent-nested.yaml"),
+  );
+
+  expect(zodToJsonSchema(agent.inputSchema)).toMatchSnapshot();
+  expect(zodToJsonSchema(agent.outputSchema)).toMatchSnapshot();
 });


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. feat(core): support include external schema for input/output schema

file: agent.yaml
```yaml
name: external-schema-agent
description: External schema agent
input_schema: schema.yaml
output_schema: schema.yaml
```

file: schema.yaml
```yaml
type: object
properties:
  message:
    type: string
    description: Message to process
  other: ./other-schema.yaml
required:
  - message

```

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
- [ ] I have updated ArcBlock dependencies to the latest version: `pnpm update:deps`
