### PR TITLE
fix(core): check if skills is empty before TeamAgent processes

### DIFF
--- a/packages/core/src/agents/team-agent.ts
+++ b/packages/core/src/agents/team-agent.ts
@@ -179,6 +179,8 @@ export class TeamAgent<I extends Message, O extends Message> extends Agent<I, O>
    * @returns A stream of message chunks that collectively form the response
    */
   process(input: I, options: AgentInvokeOptions): PromiseOrValue<AgentProcessResult<O>> {
+    if (!this.skills.length) throw new Error("TeamAgent must have at least one skill defined.");
+
     if (this.iterateOn) {
       return this._processIterator(this.iterateOn, input, options);
     }

--- a/packages/core/test/agents/team-agent.test.ts
+++ b/packages/core/test/agents/team-agent.test.ts
@@ -240,3 +240,15 @@ test("TeamAgent with iterateOn should iterate with previous step's output", asyn
   expect(response).toMatchSnapshot();
   expect(skillProcess.mock.calls.map((i) => i[0])).toMatchSnapshot();
 });
+
+test("TeamAgent should throw an error if skills is empty", async () => {
+  const teamAgent = TeamAgent.from({
+    mode: ProcessMode.sequential,
+  });
+
+  const aigne = new AIGNE({});
+
+  expect(aigne.invoke(teamAgent, {})).rejects.toThrow(
+    "TeamAgent must have at least one skill defined.",
+  );
+});


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(core): check if skills is empty before TeamAgent processes

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

**Release Notes**

- New Feature: Added validation to TeamAgent requiring at least one skill to be defined
- Test: Added unit tests to verify TeamAgent skill validation

This change prevents invalid TeamAgent configurations by ensuring at least one skill is specified during initialization. This improves reliability by failing fast with clear error messages rather than allowing misconfigured agents to run.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->