### PR TITLE
fix(docs): should parse inline code inside markdown links

### DIFF
--- a/packages/publish-docs/src/converter/index.ts
+++ b/packages/publish-docs/src/converter/index.ts
@@ -73,7 +73,7 @@ export class Converter {
         const [relPathWithoutAnchor, anchor] = normalizedRelPath.split("#");
         const slug = slugify(relPathWithoutAnchor as string);
         usedSlugs[slug] = [...(usedSlugs[slug] ?? []), filePath];
-        return `<a href="${slugPrefix ? `${slugPrefix}-${slug}${anchor ? `#${anchor}` : ""}` : slug}${anchor ? `#${anchor}` : ""}">${text}</a>`;
+        return `<a href="${slugPrefix ? `${slugPrefix}-${slug}${anchor ? `#${anchor}` : ""}` : slug}${anchor ? `#${anchor}` : ""}">${marked.parseInline(text)}</a>`;
       },
     };
 

--- a/packages/publish-docs/test/index.test.ts
+++ b/packages/publish-docs/test/index.test.ts
@@ -1,3 +1,21 @@
-import { test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { Converter } from "../src/converter/index.js";
 
-test("no tests", () => {});
+describe("Converter", () => {
+  describe("markdownToLexical", () => {
+    test("should correctly convert inline code inside a markdown link", async () => {
+      const markdown = `[\`inline code\` in a link](./test.md)`;
+      const converter = new Converter();
+      const { content } = await converter.markdownToLexical(markdown, "");
+
+      expect(content).toBeTruthy();
+
+      // @ts-expect-error: lexical structure is not fully typed
+      const textNode = content?.root?.children?.[0]?.children?.[0]?.children?.[0];
+
+      expect(textNode?.format).toBe(16); // 16 indicates inline code
+      expect(textNode?.text).toBe("inline code");
+      expect(textNode?.type).toBe("text");
+    });
+  });
+});


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

Fixes how inline code is parsed inside markdown links. Right now, links with inline code render incorrectly (see screenshot below).

<img width="2218" height="1398" alt="image" src="https://github.com/user-attachments/assets/901a9d1b-14a2-4e9f-85ef-fc600b829a13" />


### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [x] The newly added code logic is also covered by tests

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

- Bug Fix: Improved rendering of markdown links containing inline code blocks (e.g. [`example`](link))
- Test: Added test coverage for markdown link parsing with inline code blocks

These changes ensure that documentation links containing code snippets are displayed correctly, providing a better reading experience for users viewing the generated documentation.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->