### PR TITLE
feat(core): support define hooks for agent in yaml

### DIFF
--- a/packages/cli/src/tracer/terminal.ts
+++ b/packages/cli/src/tracer/terminal.ts
@@ -9,6 +9,7 @@ import {
   type ContextEventMap,
   type ContextUsage,
   DEFAULT_OUTPUT_KEY,
+  type InvokeOptions,
   type Message,
 } from "@aigne/core";
 import { LogLevel, logger } from "@aigne/core/utils/logger.js";
@@ -35,7 +36,7 @@ export class TerminalTracer {
 
   private tasks: { [callId: string]: Task } = {};
 
-  async run(agent: Agent, input: Message) {
+  async run(agent: Agent, input: Message, options?: InvokeOptions) {
     await this.context.observer?.serve();
 
     const context = this.context.newContext({ reset: true });
@@ -143,7 +144,7 @@ export class TerminalTracer {
 
     try {
       const result = await listr.run(() =>
-        context.invoke(agent, input, { streaming: true, newContext: false }),
+        context.invoke(agent, input, { ...options, streaming: true, newContext: false }),
       );
 
       return { result, context };

--- a/packages/cli/src/utils/run-with-aigne.ts
+++ b/packages/cli/src/utils/run-with-aigne.ts
@@ -1,4 +1,3 @@
-import assert from "node:assert";
 import { fstat } from "node:fs";
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join } from "node:path";
@@ -325,8 +324,7 @@ export async function runAgentWithAIGNE(
     outputKey,
   });
 
-  assert(options.input);
-  const { result } = await tracer.run(agent, options.input);
+  const { result } = await tracer.run(agent, options.input ?? {});
 
   if (options.output) {
     const message = result[outputKey || DEFAULT_OUTPUT_KEY];

--- a/packages/core/src/agents/ai-agent.ts
+++ b/packages/core/src/agents/ai-agent.ts
@@ -421,7 +421,7 @@ export class AIAgent<I extends Message = any, O extends Message = any> extends A
       let stream = await options.context.invoke(
         model,
         { ...modelInput, messages: modelInput.messages.concat(toolCallMessages) },
-        { streaming: true },
+        { ...options, streaming: true },
       );
 
       if (this.structuredStreamMode) {
@@ -542,7 +542,10 @@ export class AIAgent<I extends Message = any, O extends Message = any> extends A
     options: AgentInvokeOptions,
     toolsMap: Map<string, Agent>,
   ): AgentProcessAsyncGenerator<O> {
-    const { toolCalls: [call] = [] } = await options.context.invoke(model, modelInput);
+    const { toolCalls: [call] = [] } = await options.context.invoke(model, modelInput, {
+      ...options,
+      streaming: false,
+    });
 
     if (!call) {
       throw new Error("Router toolChoice requires exactly one tool to be executed");
@@ -554,7 +557,7 @@ export class AIAgent<I extends Message = any, O extends Message = any> extends A
     const stream = await options.context.invoke(
       tool,
       { ...call.function.arguments, ...input },
-      { streaming: true, sourceAgent: this },
+      { ...options, streaming: true, sourceAgent: this },
     );
 
     return yield* stream as AgentResponseStream<O>;

--- a/packages/core/src/utils/type-utils.ts
+++ b/packages/core/src/utils/type-utils.ts
@@ -129,9 +129,8 @@ export function omitBy<T extends Record<string, unknown>, K extends keyof T>(
   ) as Partial<T>;
 }
 
-export function flat<T>(value?: T | T[]): T[] {
-  if (isNil(value)) return [];
-  return Array.isArray(value) ? value : [value];
+export function flat<T>(...value: (T | T[])[]): NonNullable<T>[] {
+  return value.flat().filter(isNonNullable) as NonNullable<T>[];
 }
 
 export function createAccessorArray<T>(

--- a/packages/core/test-agents/test-agent-with-hooks.yaml
+++ b/packages/core/test-agents/test-agent-with-hooks.yaml
@@ -1,0 +1,20 @@
+type: team
+name: test_agent_with_default_input
+hooks:
+  on_start:
+    type: ai
+    name: test_hooks_inline
+  on_success: test-hooks.yaml
+  on_error: test-hooks.yaml
+  on_end: test-hooks.yaml
+  on_skill_start: test-hooks.yaml
+  on_skill_end: test-hooks.yaml
+  on_handoff: test-hooks.yaml
+skills:
+  - url: ./test-agent-with-default-input-skill.yaml
+    hooks:
+      on_start: test-hooks.yaml
+  - type: ai
+    name: test_agent_with_default_input_skill2.yaml
+    hooks:
+      on_start: test-hooks.yaml

--- a/packages/core/test-agents/test-hooks.yaml
+++ b/packages/core/test-agents/test-hooks.yaml
@@ -1,0 +1,2 @@
+type: ai
+name: test_hooks

--- a/packages/core/test/agents/agent.test.ts
+++ b/packages/core/test/agents/agent.test.ts
@@ -1,4 +1,5 @@
 import { expect, spyOn, test } from "bun:test";
+import assert from "node:assert";
 import { inspect } from "node:util";
 import {
   Agent,
@@ -625,10 +626,13 @@ test("Agent hooks simple example", async () => {
     inputKey: "message",
   });
 
-  const onStart = spyOn(agent.hooks, "onStart");
-  const onEnd = spyOn(agent.hooks, "onEnd");
-  const onSkillStart = spyOn(agent.hooks, "onSkillStart");
-  const onSkillEnd = spyOn(agent.hooks, "onSkillEnd");
+  const hooks = agent.hooks.at(0);
+  assert(hooks);
+
+  const onStart = spyOn(hooks, "onStart");
+  const onEnd = spyOn(hooks, "onEnd");
+  const onSkillStart = spyOn(hooks, "onSkillStart");
+  const onSkillEnd = spyOn(hooks, "onSkillEnd");
 
   spyOn(model, "process")
     .mockReturnValueOnce({ toolCalls: [createToolCallResponse("weather", { city: "Paris" })] })
@@ -686,7 +690,10 @@ test("Agent hook onHandoff should work correctly", async () => {
     inputKey: "message",
   });
 
-  const onHandoff = spyOn(triage.hooks, "onHandoff");
+  const hooks = triage.hooks.at(0);
+  assert(hooks);
+
+  const onHandoff = spyOn(hooks, "onHandoff");
 
   const feedback = AIAgent.from({
     inputKey: "message",
@@ -697,8 +704,6 @@ test("Agent hook onHandoff should work correctly", async () => {
     .mockReturnValueOnce({ text: "Hello, I am feedback agent." });
 
   const result = await aigne.invoke(triage, { message: "I want to give feedback" });
-
-  console.log(result);
 
   expect(onHandoff).toHaveBeenLastCalledWith(
     expect.objectContaining({

--- a/packages/core/test/aigne/context.test.ts
+++ b/packages/core/test/aigne/context.test.ts
@@ -198,3 +198,13 @@ test("AIGNEContext.invoke should check output is a record type", async () => {
     "expect to return a record type such as {result: ...}, but got (number): 16",
   );
 });
+
+test("AIGNEContext.newContext with reset should share events/messageQueue", async () => {
+  const aigne = new AIGNE({});
+
+  const context = aigne.newContext();
+  const newContext = context.newContext({ reset: true });
+
+  expect(context.messageQueue).toBe(newContext.messageQueue);
+  expect(context["internal"].events).toBe(newContext["internal"].events);
+});

--- a/packages/core/test/loader/__snapshots__/agent-yaml.test.ts.snap
+++ b/packages/core/test/loader/__snapshots__/agent-yaml.test.ts.snap
@@ -991,3 +991,50 @@ exports[`loadAgentFromYaml should support default input 1`] = `
   ],
 }
 `;
+
+exports[`loadAgentFromYaml should support hooks 1`] = `
+{
+  "hooks": [
+    {
+      "onEnd": "test_hooks",
+      "onError": "test_hooks",
+      "onHandoff": "test_hooks",
+      "onSkillEnd": "test_hooks",
+      "onSkillStart": "test_hooks",
+      "onStart": "test_hooks_inline",
+      "onSuccess": "test_hooks",
+    },
+  ],
+  "name": "test_agent_with_default_input",
+  "skills": [
+    {
+      "hooks": [
+        {
+          "onEnd": "test_hooks",
+          "onError": "test_hooks",
+          "onHandoff": "test_hooks",
+          "onSkillEnd": "test_hooks",
+          "onSkillStart": "test_hooks",
+          "onStart": "test_hooks_inline",
+          "onSuccess": "test_hooks",
+        },
+      ],
+      "name": "test_agent_input_naming_skill",
+    },
+    {
+      "hooks": [
+        {
+          "onEnd": "test_hooks",
+          "onError": "test_hooks",
+          "onHandoff": "test_hooks",
+          "onSkillEnd": "test_hooks",
+          "onSkillStart": "test_hooks",
+          "onStart": "test_hooks_inline",
+          "onSuccess": "test_hooks",
+        },
+      ],
+      "name": "test_agent_with_default_input_skill2.yaml",
+    },
+  ],
+}
+`;

--- a/packages/core/test/loader/agent-yaml.test.ts
+++ b/packages/core/test/loader/agent-yaml.test.ts
@@ -246,3 +246,22 @@ test("loadAgentFromYaml should support default input", async () => {
     })),
   }).toMatchSnapshot();
 });
+
+test("loadAgentFromYaml should support hooks", async () => {
+  const agent = await loadAgent(
+    join(import.meta.dirname, "../../test-agents/test-agent-with-hooks.yaml"),
+  );
+
+  expect({
+    name: agent.name,
+    hooks: agent.hooks.map((i) =>
+      Object.fromEntries(Object.entries(i).map(([k, v]) => [k, v?.name])),
+    ),
+    skills: agent.skills.map((i) => ({
+      name: i.name,
+      hooks: agent.hooks.map((i) =>
+        Object.fromEntries(Object.entries(i).map(([k, v]) => [k, v?.name])),
+      ),
+    })),
+  }).toMatchSnapshot();
+});

--- a/packages/core/test/loader/loader.test.ts
+++ b/packages/core/test/loader/loader.test.ts
@@ -231,9 +231,11 @@ url: http://localhost:3000/sse
   );
 
   expect(await loadAgent("./remote-mcp.yaml")).toBe(testMcp);
-  expect(from).toHaveBeenLastCalledWith({
-    url: "http://localhost:3000/sse",
-  });
+  expect(from).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      url: "http://localhost:3000/sse",
+    }),
+  );
 
   readFile.mockRestore();
 });
@@ -254,10 +256,12 @@ args: ["-y", "@modelcontextprotocol/server-filesystem", "."]
   );
 
   expect(await loadAgent("./local-mcp.yaml")).toBe(fsMcp);
-  expect(from).toHaveBeenLastCalledWith({
-    command: "npx",
-    args: ["-y", "@modelcontextprotocol/server-filesystem", "."],
-  });
+  expect(from).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "."],
+    }),
+  );
 
   readFile.mockRestore();
 });


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. feat(core): support define hooks for agent in yaml

usage:

```yaml
type: team
name: test_agent_with_default_input
hooks:
  on_start:
    type: ai
    name: test_hooks_inline
  on_success: test-hooks.yaml
  on_error: test-hooks.yaml
  on_end: test-hooks.yaml
  on_skill_start: test-hooks.yaml
  on_skill_end: test-hooks.yaml
  on_handoff: test-hooks.yaml
skills:
  - url: ./test-agent-with-default-input-skill.yaml
    hooks:
      on_start: test-hooks.yaml
  - type: ai
    name: test_agent_with_default_input_skill2.yaml
    hooks:
      on_start: test-hooks.yaml
```

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
