### PR TITLE
feat(docs): support optional extension suffix for doc slug

### DIFF
--- a/packages/publish-docs/src/converter/index.ts
+++ b/packages/publish-docs/src/converter/index.ts
@@ -24,9 +24,11 @@ export class Converter {
   private slugPrefix?: string;
   public usedSlugs: Record<string, string[]>;
   public blankFilePaths: string[];
+  private slugWithoutExt: boolean;
 
-  constructor(options: { slugPrefix?: string } = {}) {
+  constructor(options: { slugPrefix?: string; slugWithoutExt?: boolean } = {}) {
     this.slugPrefix = options.slugPrefix;
+    this.slugWithoutExt = options.slugWithoutExt ?? true;
     this.usedSlugs = {};
     this.blankFilePaths = [];
   }
@@ -58,6 +60,8 @@ export class Converter {
 
     const slugPrefix = this.slugPrefix;
     const usedSlugs = this.usedSlugs;
+    const slugWithoutExt = this.slugWithoutExt;
+
     const renderer: RendererObject = {
       code({ text, lang }) {
         if (lang === "mermaid") return `<pre class="mermaid">${text}</pre>`;
@@ -67,11 +71,11 @@ export class Converter {
         if (/^(http|https|\/|#)/.test(href)) return false;
 
         const absPath = path.resolve(path.dirname(filePath), href);
-        const docsRoot = path.resolve(process.cwd(), "docs");
+        const docsRoot = path.resolve(process.cwd(), process.env.DOC_ROOT_DIR ?? "docs");
         const relPath = path.relative(docsRoot, absPath);
         const normalizedRelPath = relPath.replace(/\.([a-zA-Z-]+)\.md$/, ".md");
         const [relPathWithoutAnchor, anchor] = normalizedRelPath.split("#");
-        const slug = slugify(relPathWithoutAnchor as string);
+        const slug = slugify(relPathWithoutAnchor as string, slugWithoutExt);
         usedSlugs[slug] = [...(usedSlugs[slug] ?? []), filePath];
         return `<a href="${slugPrefix ? `${slugPrefix}-${slug}${anchor ? `#${anchor}` : ""}` : slug}${anchor ? `#${anchor}` : ""}">${marked.parseInline(text)}</a>`;
       },

--- a/packages/publish-docs/src/generator.ts
+++ b/packages/publish-docs/src/generator.ts
@@ -21,6 +21,7 @@ export interface DocNode {
 export interface GeneratorOptions {
   sidebarPath: string;
   slugPrefix?: string;
+  slugWithoutExt?: boolean;
 }
 
 export class Generator {
@@ -28,17 +29,22 @@ export class Generator {
   private slugPrefix?: string;
   private sidebarPath: string;
   private converter: Converter;
+  private slugWithoutExt: boolean;
 
   constructor(options: GeneratorOptions) {
     this.sidebarPath = options.sidebarPath;
     this.slugs = new Set<string>();
     this.slugPrefix = options.slugPrefix;
-    this.converter = new Converter({ slugPrefix: options.slugPrefix });
+    this.converter = new Converter({
+      slugPrefix: options.slugPrefix,
+      slugWithoutExt: options.slugWithoutExt,
+    });
+    this.slugWithoutExt = options.slugWithoutExt ?? true;
   }
 
   private resolveLinkFilePath(link: string): string {
     const rel = link.replace(/^\//, "");
-    return path.join(process.cwd(), "docs", rel);
+    return path.join(process.cwd(), process.env.DOC_ROOT_DIR || "docs", rel);
   }
 
   private async getInfoFromFile(filePath: string) {
@@ -79,7 +85,7 @@ export class Generator {
   }
 
   private uniqueSlugify(str: string): string {
-    const slug = slugify(str);
+    const slug = slugify(str, this.slugWithoutExt);
     if (this.slugs.has(slug)) {
       throw new Error(`Duplicate slug: ${slug}`);
     }

--- a/packages/publish-docs/src/index.ts
+++ b/packages/publish-docs/src/index.ts
@@ -9,6 +9,7 @@ const withTokenSchema = z.object({
   boardId: z.string(),
   appUrl: z.string().url(),
   accessToken: z.string(),
+  slugWithoutExt: z.boolean().optional(),
 });
 
 const withAuthSchema = z.object({
@@ -20,6 +21,7 @@ const withAuthSchema = z.object({
   clientId: z.string(),
   clientSecret: z.string(),
   redirectUri: z.string().url(),
+  slugWithoutExt: z.boolean().optional(),
 });
 
 const optionsSchema = z.union([withTokenSchema, withAuthSchema]);
@@ -47,6 +49,7 @@ export async function publishDocs(options: PublishDocsOptions): Promise<PublishR
   const docs = await new Generator({
     sidebarPath: parsed.sidebarPath,
     slugPrefix: parsed.boardId,
+    slugWithoutExt: parsed.slugWithoutExt ?? true,
   }).generate();
 
   const published = await publisher({

--- a/packages/publish-docs/src/utils/slugify.ts
+++ b/packages/publish-docs/src/utils/slugify.ts
@@ -1,5 +1,10 @@
-export function slugify(str: string): string {
-  return str
+export function slugify(str: string, slugWithoutExt: boolean): string {
+  let cleanStr = str;
+  if (slugWithoutExt) {
+    cleanStr = cleanStr.replace(/\.md$/i, "");
+  }
+
+  return cleanStr
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");

--- a/scripts/publish-docs.ts
+++ b/scripts/publish-docs.ts
@@ -12,10 +12,11 @@ if (!process.env.DOC_DISCUSS_KIT_BOARD_ID) {
 }
 
 const { success, error } = await publishDocs({
-  sidebarPath: path.join(process.cwd(), "docs/_sidebar.md"),
+  sidebarPath: path.join(process.cwd(), `${process.env.DOC_ROOT_DIR || "docs"}/_sidebar.md`),
   accessToken: process.env.DOC_DISCUSS_KIT_ACCESS_TOKEN,
   appUrl: process.env.DOC_DISCUSS_KIT_URL,
   boardId: process.env.DOC_DISCUSS_KIT_BOARD_ID,
+  slugWithoutExt: false,
 });
 
 if (!success) {


### PR DESCRIPTION
## Related Issue



### Major Changes

1. publish docs option add slug without ext parameter, default value is true

### Screenshots


### Test Plan



### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

**Release Notes**

- New Feature: Added `slugWithoutExt` option to control whether .md extensions are removed from generated slugs in documentation paths
- Enhancement: Introduced `DOC_ROOT_DIR` environment variable support for flexible documentation root directory configuration
- Refactor: Improved slug generation consistency across documentation processing pipeline

These changes provide more flexibility in documentation path handling and organization, allowing users to maintain their preferred URL structure while supporting custom root directory configurations.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->