### PR TITLE
fix(core): function agent should use common schema from yaml definition

### DIFF
--- a/packages/core/src/loader/agent-js.ts
+++ b/packages/core/src/loader/agent-js.ts
@@ -1,24 +1,8 @@
-import { jsonSchemaToZod } from "@aigne/json-schema-to-zod";
-import { type ZodObject, type ZodType, z } from "zod";
-import { Agent, type FunctionAgentFn } from "../agents/agent.js";
+import { Agent } from "../agents/agent.js";
 import { tryOrThrow } from "../utils/type-utils.js";
-import { camelizeSchema, inputOutputSchema, optionalize } from "./schema.js";
+import { parseAgentFile } from "./agent-yaml.js";
 
 export async function loadAgentFromJsFile(path: string) {
-  const agentJsFileSchema = camelizeSchema(
-    z.object({
-      name: z.string(),
-      description: optionalize(z.string()),
-      inputSchema: optionalize(inputOutputSchema({ path })).transform((v) =>
-        v ? jsonSchemaToZod<ZodObject<Record<string, ZodType>>>(v) : undefined,
-      ),
-      outputSchema: optionalize(inputOutputSchema({ path })).transform((v) =>
-        v ? jsonSchemaToZod<ZodObject<Record<string, ZodType>>>(v) : undefined,
-      ),
-      process: z.custom<FunctionAgentFn>(),
-    }),
-  );
-
   const { default: agent } = await tryOrThrow(
     () => import(/* @vite-ignore */ path),
     (error) => new Error(`Failed to load agent definition from ${path}: ${error.message}`),
@@ -32,8 +16,9 @@ export async function loadAgentFromJsFile(path: string) {
 
   return tryOrThrow(
     () =>
-      agentJsFileSchema.parseAsync({
+      parseAgentFile(path, {
         ...agent,
+        type: "function",
         name: agent.agent_name || agent.agentName || agent.name,
         process: agent,
       }),

--- a/packages/core/src/loader/index.ts
+++ b/packages/core/src/loader/index.ts
@@ -71,7 +71,7 @@ export async function loadAgent(
   if ([".js", ".mjs", ".ts", ".mts"].includes(nodejs.path.extname(path))) {
     const agent = await loadAgentFromJsFile(path);
     if (agent instanceof Agent) return agent;
-    return FunctionAgent.from(agent);
+    return parseAgent(path, agent, options, agentOptions);
   }
 
   if ([".yml", ".yaml"].includes(nodejs.path.extname(path))) {
@@ -193,6 +193,12 @@ async function parseAgent(
       return TransformAgent.from({
         ...baseOptions,
         jsonata: agent.jsonata,
+      });
+    }
+    case "function": {
+      return FunctionAgent.from({
+        ...baseOptions,
+        process: agent.process,
       });
     }
   }

--- a/packages/core/test-agents/test-agent-with-default-input-skill-js.js
+++ b/packages/core/test-agents/test-agent-with-default-input-skill-js.js
@@ -1,0 +1,16 @@
+export default function testAgentWithDefaultInputSkillJS() {
+  return {};
+}
+
+testAgentWithDefaultInputSkillJS.input_schema = {
+  type: "object",
+  properties: {
+    title: {
+      type: "string",
+    },
+    description: {
+      type: "string",
+    },
+  },
+  required: ["title", "description"],
+};

--- a/packages/core/test-agents/test-agent-with-default-input.yaml
+++ b/packages/core/test-agents/test-agent-with-default-input.yaml
@@ -6,6 +6,11 @@ skills:
       title: Default Title
       description:
         $get: title
+  - url: ./test-agent-with-default-input-skill-js.js
+    default_input:
+      title: Default Title JS
+      description:
+        $get: title
   - type: ai
     name: test_agent_with_default_input_skill2.yaml
     input_schema:

--- a/packages/core/test/loader/__snapshots__/agent-yaml.test.ts.snap
+++ b/packages/core/test/loader/__snapshots__/agent-yaml.test.ts.snap
@@ -965,6 +965,32 @@ exports[`loadAgentFromYaml should support default input 1`] = `
         "description": {
           "$get": "title",
         },
+        "title": "Default Title JS",
+      },
+      "input_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": true,
+        "properties": {
+          "description": {
+            "type": "string",
+          },
+          "title": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "title",
+          "description",
+        ],
+        "type": "object",
+      },
+      "name": "testAgentWithDefaultInputSkillJS",
+    },
+    {
+      "default_input": {
+        "description": {
+          "$get": "title",
+        },
         "title": "Another Default Title",
       },
       "input_schema": {


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(core): function agent should use common schema from yaml definition

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

Release Notes:

- New Feature: Added support for function-based agents, allowing developers to define agents using JavaScript functions with input schema validation
- Refactor: Streamlined agent loading system to handle multiple agent formats (YAML and JS) more consistently
- Test: Enhanced test coverage for function agents and input validation scenarios

These changes make it easier to create agents using JavaScript functions while maintaining the same validation and configuration capabilities available in YAML-based agents. The unified loading system provides a more reliable and maintainable foundation for agent development.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->