### PR TITLE
feat(core): add reflection mode support to TeamAgent

### DIFF
--- a/packages/core/src/agents/team-agent.ts
+++ b/packages/core/src/agents/team-agent.ts
@@ -37,6 +37,57 @@ export enum ProcessMode {
   parallel = "parallel",
 }
 
+export const DEFAULT_REFLECTION_MAX_ITERATIONS = 3;
+
+/**
+ * Configuration for reflection mode processing in TeamAgent.
+ *
+ * Reflection mode enables iterative refinement of agent outputs through a review process.
+ * The team agent will repeatedly process the input and have a reviewer agent evaluate
+ * the output until it meets approval criteria or reaches the maximum iteration limit.
+ *
+ * This is particularly useful for:
+ * - Quality assurance workflows where outputs need validation
+ * - Iterative improvement processes where initial results can be refined
+ * - Self-correcting agent systems that learn from feedback
+ */
+export interface ReflectionMode {
+  /**
+   * The agent responsible for reviewing and providing feedback on the team's output.
+   *
+   * The reviewer agent receives the combined output from the team's processing
+   * and should provide feedback or evaluation that can be used to determine
+   * whether the output meets the required standards.
+   */
+  reviewer: Agent;
+
+  /**
+   * Function that determines whether the reviewer's output indicates approval.
+   *
+   * This function receives the reviewer agent's output message and should return:
+   * - `true` or truthy value: The output is approved and processing should stop
+   * - `false` or falsy value: The output needs improvement and another iteration should run
+   *
+   * The function can be synchronous or asynchronous, allowing for complex approval logic
+   * including external validation, scoring systems, or human-in-the-loop approval.
+   *
+   * @param output - The message output from the reviewer agent
+   * @returns A boolean or truthy/falsy value indicating approval status
+   */
+  isApproved: (output: Message) => PromiseOrValue<boolean | unknown>;
+
+  /**
+   * Maximum number of reflection iterations before giving up.
+   *
+   * This prevents infinite loops when the approval criteria cannot be met.
+   * If the maximum iterations are reached without approval, the process will
+   * throw an error indicating the reflection failed to converge.
+   *
+   * @default 3
+   */
+  maxIterations?: number;
+}
+
 /**
  * Configuration options for creating a TeamAgent.
  *
@@ -48,6 +99,22 @@ export interface TeamAgentOptions<I extends Message, O extends Message> extends 
    * @default {ProcessMode.sequential}
    */
   mode?: ProcessMode;
+
+  /**
+   * Configuration for reflection mode processing.
+   *
+   * When enabled, the TeamAgent will use an iterative refinement process where:
+   * 1. The team processes the input normally
+   * 2. A reviewer agent evaluates the output
+   * 3. If not approved, the process repeats with the previous output as context
+   * 4. This continues until approval or maximum iterations are reached
+   *
+   * This enables self-improving agent workflows that can iteratively refine
+   * their outputs based on feedback from a specialized reviewer agent.
+   *
+   * @see ReflectionMode for detailed configuration options
+   */
+  reflection?: ReflectionMode;
 
   /**
    * Specifies which input field should be treated as an array for iterative processing.
@@ -134,6 +201,10 @@ export class TeamAgent<I extends Message, O extends Message> extends Agent<I, O>
   constructor(options: TeamAgentOptions<I, O>) {
     super(options);
     this.mode = options.mode ?? ProcessMode.sequential;
+    this.reflection = options.reflection && {
+      ...options.reflection,
+      maxIterations: options.reflection.maxIterations ?? DEFAULT_REFLECTION_MAX_ITERATIONS,
+    };
     this.iterateOn = options.iterateOn;
     this.iterateWithPreviousOutput = options.iterateWithPreviousOutput;
   }
@@ -144,6 +215,15 @@ export class TeamAgent<I extends Message, O extends Message> extends Agent<I, O>
    * This can be either sequential (one after another) or parallel (all at once).
    */
   mode: ProcessMode;
+
+  /**
+   * The reflection mode configuration with guaranteed maxIterations value.
+   *
+   * This is the internal representation after processing the user-provided
+   * reflection configuration, ensuring that maxIterations always has a value
+   * (defaulting to DEFAULT_REFLECTION_MAX_ITERATIONS if not specified).
+   */
+  reflection?: ReflectionMode & Required<Pick<ReflectionMode, "maxIterations">>;
 
   /**
    * The input field key to iterate over when processing array inputs.
@@ -181,11 +261,45 @@ export class TeamAgent<I extends Message, O extends Message> extends Agent<I, O>
   process(input: I, options: AgentInvokeOptions): PromiseOrValue<AgentProcessResult<O>> {
     if (!this.skills.length) throw new Error("TeamAgent must have at least one skill defined.");
 
+    if (this.reflection) return this._processReflection(input, options);
+
+    return this._processNonReflection(input, options);
+  }
+
+  private _processNonReflection(
+    input: I,
+    options: AgentInvokeOptions,
+  ): PromiseOrValue<AgentProcessResult<O>> {
     if (this.iterateOn) {
       return this._processIterator(this.iterateOn, input, options);
     }
 
-    return this._process(input, options);
+    return this._processNonIterator(input, options);
+  }
+
+  private async _processReflection(input: I, options: AgentInvokeOptions): Promise<O> {
+    assert(this.reflection, "Reflection mode must be defined for reflection processing");
+
+    let iterations = 0;
+    const previousOutput = { ...input };
+
+    do {
+      const output = await agentProcessResultToObject(
+        await this._processNonReflection(previousOutput, options),
+      );
+      Object.assign(previousOutput, output);
+
+      const reviewOutput = await options.context.invoke(this.reflection.reviewer, previousOutput);
+      Object.assign(previousOutput, reviewOutput);
+
+      const approved = await this.reflection.isApproved(reviewOutput);
+
+      if (approved) return output;
+    } while (++iterations < this.reflection.maxIterations);
+
+    throw new Error(
+      `Reflection mode exceeded max iterations ${this.reflection.maxIterations}. Please review the feedback and try again.`,
+    );
   }
 
   private async *_processIterator(
@@ -206,7 +320,10 @@ export class TeamAgent<I extends Message, O extends Message> extends Agent<I, O>
         throw new TypeError(`Expected ${String(key)} to be an object, got ${typeof item}`);
 
       const res = await agentProcessResultToObject(
-        await this._process({ ...input, [key]: arr, ...item }, { ...options, streaming: false }),
+        await this._processNonIterator(
+          { ...input, [key]: arr, ...item },
+          { ...options, streaming: false },
+        ),
       );
 
       // Merge the item result with the original item used for next iteration
@@ -224,7 +341,7 @@ export class TeamAgent<I extends Message, O extends Message> extends Agent<I, O>
     }
   }
 
-  private _process(
+  private _processNonIterator(
     input: Message,
     options: AgentInvokeOptions,
   ): PromiseOrValue<AgentProcessResult<O>> {

--- a/packages/core/test/agents/__snapshots__/team-agent.test.ts.snap
+++ b/packages/core/test/agents/__snapshots__/team-agent.test.ts.snap
@@ -415,3 +415,142 @@ exports[`TeamAgent with iterateOn should iterate with previous step's output 2`]
   },
 ]
 `;
+
+exports[`TeamAgent should process reflection mode correctly 1`] = `
+[
+  {
+    "messages": [
+      {
+        "content": 
+"Write a article about AIGNE in 2025
+
+<previous-content>
+
+</previous-content>
+
+<feedback>
+
+</feedback>
+"
+,
+        "name": undefined,
+        "role": "system",
+      },
+    ],
+    "modelOptions": undefined,
+    "responseFormat": undefined,
+    "toolChoice": undefined,
+    "tools": undefined,
+  },
+  {
+    "messages": [
+      {
+        "content": 
+"You are a reviewer. Please review the following article and provide feedback.
+
+topic: AIGNE in 2025
+
+generated content:
+AIGNE in 2025 is a framework for building AI agents.
+"
+,
+        "name": undefined,
+        "role": "system",
+      },
+    ],
+    "modelOptions": undefined,
+    "responseFormat": {
+      "jsonSchema": {
+        "name": "output",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "approved": {
+              "type": "boolean",
+            },
+            "feedback": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "approved",
+          ],
+          "type": "object",
+        },
+        "strict": true,
+      },
+      "type": "json_schema",
+    },
+    "toolChoice": undefined,
+    "tools": undefined,
+  },
+  {
+    "messages": [
+      {
+        "content": 
+"Write a article about AIGNE in 2025
+
+<previous-content>
+AIGNE in 2025 is a framework for building AI agents.
+</previous-content>
+
+<feedback>
+The article is well-written and informative. However, it could use more examples.
+</feedback>
+"
+,
+        "name": undefined,
+        "role": "system",
+      },
+    ],
+    "modelOptions": undefined,
+    "responseFormat": undefined,
+    "toolChoice": undefined,
+    "tools": undefined,
+  },
+  {
+    "messages": [
+      {
+        "content": 
+"You are a reviewer. Please review the following article and provide feedback.
+
+topic: AIGNE in 2025
+
+generated content:
+AIGNE in 2025 is a framework for building AI agents. For example, it allows developers to create agents that can interact with users in a natural way, using natural language processing and machine learning techniques.
+"
+,
+        "name": undefined,
+        "role": "system",
+      },
+    ],
+    "modelOptions": undefined,
+    "responseFormat": {
+      "jsonSchema": {
+        "name": "output",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "approved": {
+              "type": "boolean",
+            },
+            "feedback": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "approved",
+          ],
+          "type": "object",
+        },
+        "strict": true,
+      },
+      "type": "json_schema",
+    },
+    "toolChoice": undefined,
+    "tools": undefined,
+  },
+]
+`;

--- a/packages/core/test/agents/team-agent.test.ts
+++ b/packages/core/test/agents/team-agent.test.ts
@@ -1,7 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
 import assert from "node:assert";
 import { AIAgent, AIGNE, FunctionAgent, type Message } from "@aigne/core";
-import { ProcessMode, TeamAgent } from "@aigne/core/agents/team-agent.js";
+import { ProcessMode, type ReflectionMode, TeamAgent } from "@aigne/core/agents/team-agent.js";
 import {
   readableStreamToArray,
   stringToAgentResponseStream,
@@ -253,13 +253,14 @@ test("TeamAgent should throw an error if skills is empty", async () => {
   );
 });
 
-const teamAgentWithReflection = TeamAgent.from({
-  inputSchema: z.object({
-    topic: z.string(),
-  }),
-  skills: [
-    AIAgent.from({
-      instructions: `\
+const teamAgentWithReflection = (options?: Partial<ReflectionMode>) =>
+  TeamAgent.from({
+    inputSchema: z.object({
+      topic: z.string(),
+    }),
+    skills: [
+      AIAgent.from({
+        instructions: `\
 Write a article about {{topic}}
 
 <previous-content>
@@ -270,12 +271,12 @@ Write a article about {{topic}}
 {{feedback}}
 </feedback>
 `,
-      outputKey: "content",
-    }),
-  ],
-  reflection: {
-    reviewer: AIAgent.from({
-      instructions: `\
+        outputKey: "content",
+      }),
+    ],
+    reflection: {
+      reviewer: AIAgent.from({
+        instructions: `\
 You are a reviewer. Please review the following article and provide feedback.
 
 topic: {{topic}}
@@ -283,15 +284,16 @@ topic: {{topic}}
 generated content:
 {{content}}
 `,
-      outputSchema: z.object({
-        approved: z.boolean(),
-        feedback: z.string().optional(),
+        outputSchema: z.object({
+          approved: z.boolean(),
+          feedback: z.string().optional(),
+        }),
       }),
-    }),
-    isApproved: (o) => o.approved,
-    maxIterations: 3,
-  },
-});
+      isApproved: (o) => o.approved,
+      maxIterations: 3,
+      ...options,
+    },
+  });
 
 test("TeamAgent should process reflection mode correctly", async () => {
   const model = new OpenAIChatModel();
@@ -320,7 +322,7 @@ test("TeamAgent should process reflection mode correctly", async () => {
       },
     });
 
-  const result = await aigne.invoke(teamAgentWithReflection, { topic: "AIGNE in 2025" });
+  const result = await aigne.invoke(teamAgentWithReflection(), { topic: "AIGNE in 2025" });
 
   expect(result).toEqual({
     content:
@@ -369,7 +371,56 @@ test("TeamAgent should raise error if max iterations exceeded", async () => {
       },
     });
 
-  expect(aigne.invoke(teamAgentWithReflection, { topic: "AIGNE in 2025" })).rejects.toThrow(
+  expect(aigne.invoke(teamAgentWithReflection(), { topic: "AIGNE in 2025" })).rejects.toThrow(
     "Reflection mode exceeded max iterations 3. Please review the feedback and try again.",
   );
+});
+
+test("TeamAgent should use last output if max iterations exceeded", async () => {
+  const model = new OpenAIChatModel();
+
+  const aigne = new AIGNE({ model });
+
+  spyOn(model, "process")
+    .mockReturnValueOnce(
+      stringToAgentResponseStream("AIGNE in 2025 is a framework for building AI agents."),
+    )
+    .mockReturnValueOnce({
+      json: {
+        approved: false,
+        feedback:
+          "The article is well-written and informative. However, it could use more examples.",
+      },
+    })
+    .mockReturnValueOnce(
+      stringToAgentResponseStream(
+        "AIGNE in 2025 is a framework for building AI agents. For example, it allows developers to create agents that can interact with users in a natural way, using natural language processing and machine learning techniques.",
+      ),
+    )
+    .mockReturnValueOnce({
+      json: {
+        approved: false,
+        feedback: "The article is good, but it could be improved with more details.",
+      },
+    })
+    .mockReturnValueOnce(
+      stringToAgentResponseStream(
+        "AIGNE in 2025 is a framework for building AI agents. For example, it allows developers to create agents that can interact with users in a natural way, using natural language processing and machine learning techniques. This framework enables developers to build agents that can understand and respond to user queries effectively.",
+      ),
+    )
+    .mockReturnValueOnce({
+      json: {
+        approved: false,
+        feedback: "The article is good, but it could be improved with more examples.",
+      },
+    });
+
+  const result = await aigne.invoke(teamAgentWithReflection({ returnLastOnMaxIterations: true }), {
+    topic: "AIGNE in 2025",
+  });
+
+  expect(result).toEqual({
+    content:
+      "AIGNE in 2025 is a framework for building AI agents. For example, it allows developers to create agents that can interact with users in a natural way, using natural language processing and machine learning techniques. This framework enables developers to build agents that can understand and respond to user queries effectively.",
+  });
 });

--- a/packages/core/test/agents/team-agent.test.ts
+++ b/packages/core/test/agents/team-agent.test.ts
@@ -252,3 +252,124 @@ test("TeamAgent should throw an error if skills is empty", async () => {
     "TeamAgent must have at least one skill defined.",
   );
 });
+
+const teamAgentWithReflection = TeamAgent.from({
+  inputSchema: z.object({
+    topic: z.string(),
+  }),
+  skills: [
+    AIAgent.from({
+      instructions: `\
+Write a article about {{topic}}
+
+<previous-content>
+{{content}}
+</previous-content>
+
+<feedback>
+{{feedback}}
+</feedback>
+`,
+      outputKey: "content",
+    }),
+  ],
+  reflection: {
+    reviewer: AIAgent.from({
+      instructions: `\
+You are a reviewer. Please review the following article and provide feedback.
+
+topic: {{topic}}
+
+generated content:
+{{content}}
+`,
+      outputSchema: z.object({
+        approved: z.boolean(),
+        feedback: z.string().optional(),
+      }),
+    }),
+    isApproved: (o) => o.approved,
+    maxIterations: 3,
+  },
+});
+
+test("TeamAgent should process reflection mode correctly", async () => {
+  const model = new OpenAIChatModel();
+
+  const aigne = new AIGNE({ model });
+
+  const modelProcess = spyOn(model, "process")
+    .mockReturnValueOnce(
+      stringToAgentResponseStream("AIGNE in 2025 is a framework for building AI agents."),
+    )
+    .mockReturnValueOnce({
+      json: {
+        approved: false,
+        feedback:
+          "The article is well-written and informative. However, it could use more examples.",
+      },
+    })
+    .mockReturnValueOnce(
+      stringToAgentResponseStream(
+        "AIGNE in 2025 is a framework for building AI agents. For example, it allows developers to create agents that can interact with users in a natural way, using natural language processing and machine learning techniques.",
+      ),
+    )
+    .mockReturnValueOnce({
+      json: {
+        approved: true,
+      },
+    });
+
+  const result = await aigne.invoke(teamAgentWithReflection, { topic: "AIGNE in 2025" });
+
+  expect(result).toEqual({
+    content:
+      "AIGNE in 2025 is a framework for building AI agents. For example, it allows developers to create agents that can interact with users in a natural way, using natural language processing and machine learning techniques.",
+  });
+
+  expect(modelProcess.mock.calls.map((i) => i.at(0))).toMatchSnapshot();
+});
+
+test("TeamAgent should raise error if max iterations exceeded", async () => {
+  const model = new OpenAIChatModel();
+
+  const aigne = new AIGNE({ model });
+
+  spyOn(model, "process")
+    .mockReturnValueOnce(
+      stringToAgentResponseStream("AIGNE in 2025 is a framework for building AI agents."),
+    )
+    .mockReturnValueOnce({
+      json: {
+        approved: false,
+        feedback:
+          "The article is well-written and informative. However, it could use more examples.",
+      },
+    })
+    .mockReturnValueOnce(
+      stringToAgentResponseStream(
+        "AIGNE in 2025 is a framework for building AI agents. For example, it allows developers to create agents that can interact with users in a natural way, using natural language processing and machine learning techniques.",
+      ),
+    )
+    .mockReturnValueOnce({
+      json: {
+        approved: false,
+        feedback: "The article is good, but it could be improved with more details.",
+      },
+    })
+    .mockReturnValueOnce(
+      stringToAgentResponseStream(
+        "AIGNE in 2025 is a framework for building AI agents. For example, it allows developers to create agents that can interact with users in a natural way, using natural language processing and machine learning techniques.",
+      ),
+    )
+    .mockReturnValueOnce({
+      json: {
+        approved: false,
+        feedback: "The article is good, but it could be improved with more examples.",
+      },
+    });
+
+  expect(aigne.invoke(teamAgentWithReflection, { topic: "AIGNE in 2025" })).rejects.toThrow(
+    "Reflection mode exceeded max iterations 3. Please review the feedback and try again.",
+  );
+});


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. feat(core): add reflection mode support to TeamAgent

usage:
```ts
const teamAgentWithReflection = TeamAgent.from({
  inputSchema: z.object({
    topic: z.string(),
  }),
  skills: [
    AIAgent.from({
      instructions: `\
Write a article about {{topic}}

<previous-content>
{{content}}
</previous-content>

<feedback>
{{feedback}}
</feedback>
`,
      outputKey: "content",
    }),
  ],
  reflection: {
    reviewer: AIAgent.from({
      instructions: `\
You are a reviewer. Please review the following article and provide feedback.

topic: {{topic}}

generated content:
{{content}}
`,
      outputSchema: z.object({
        approved: z.boolean(),
        feedback: z.string().optional(),
      }),
    }),
    isApproved: (o) => o.approved,
    maxIterations: 3,
  },
});
```

### Checklist

- [x] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
