### PR TITLE
fix(core): update blocklet key name

### DIFF
--- a/models/aigne-hub/src/hub-model.ts
+++ b/models/aigne-hub/src/hub-model.ts
@@ -104,7 +104,7 @@ export class HubChatModel extends ChatModel {
       ...options,
       model: options.model ?? process.env.BLOCKLET_AIGNE_API_MODEL,
       modelOptions: options.modelOptions,
-      baseURL: options.baseURL ?? options.url ?? process.env.BLOCKLET_AIGNE_API_BASE_URL,
+      baseURL: options.baseURL ?? options.url ?? process.env.BLOCKLET_AIGNE_API_URL,
       apiKey: options.apiKey ?? apiKey,
       ...rest,
     });


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [x] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [x] This change adds dependencies, and they are placed in dependencies and devDependencies
- [x] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

## Release Notes

### Chore
- Updated environment variable configuration for the AigneHub chat model to use `BLOCKLET_AIGNE_API_URL` instead of `BLOCKLET_AIGNE_API_BASE_URL`

This is a minor configuration update that ensures consistent environment variable naming across the system. No functional changes or user-facing impacts are expected from this change.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->