### PR TITLE
fix: add auto open document url feature

### DIFF
--- a/packages/publish-docs/src/publisher.ts
+++ b/packages/publish-docs/src/publisher.ts
@@ -12,9 +12,10 @@ export async function publisher(input: {
   };
   appUrl: string;
   accessToken: string;
+  autoOpen?: boolean;
 }): Promise<PublishResult> {
   try {
-    const { data, appUrl, accessToken } = input;
+    const { data, appUrl, accessToken, autoOpen } = input;
 
     const url = new URL(appUrl);
     const mountPoint = await getComponentMountPoint(appUrl, DISCUSS_KIT_DID);
@@ -46,13 +47,15 @@ export async function publisher(input: {
     console.log(`📖 Docs available at: ${docsUrl}`);
 
     // Auto open docs page in browser
-    try {
-      await open(docsUrl);
-      console.log(`✅ Opened docs in browser`);
-    } catch (openError) {
-      console.log(
-        `⚠️  Failed to open browser: ${openError instanceof Error ? openError.message : String(openError)}`,
-      );
+    if (autoOpen) {
+      try {
+        await open(docsUrl);
+        console.log(`✅ Opened docs in browser`);
+      } catch (openError) {
+        console.log(
+          `⚠️  Failed to open browser: ${openError instanceof Error ? openError.message : String(openError)}`,
+        );
+      }
     }
 
     return { success: true, docs: result.docs, boardId: data.boardId, docsUrl };

--- a/packages/publish-docs/src/publisher.ts
+++ b/packages/publish-docs/src/publisher.ts
@@ -1,3 +1,4 @@
+import open from "open";
 import { joinURL } from "ufo";
 import { DISCUSS_KIT_DID } from "./constants.js";
 import type { DocNode } from "./generator.js";
@@ -20,7 +21,6 @@ export async function publisher(input: {
     console.log(`Found Discuss Kit mount point: ${mountPoint}`);
 
     const publishUrl = joinURL(url.origin, mountPoint, "/api/docs/create-docs-collection");
-    console.log(`Publishing docs collection to ${publishUrl}`);
 
     const response = await fetch(publishUrl, {
       method: "POST",
@@ -39,7 +39,23 @@ export async function publisher(input: {
     }
 
     const result = await response.json();
-    return { success: true, docs: result.docs, boardId: data.boardId };
+
+    const docsUrl = joinURL(url.origin, mountPoint, "/docs", data.boardId);
+
+    console.log(`Publishing docs collection...`);
+    console.log(`📖 Docs available at: ${docsUrl}`);
+
+    // Auto open docs page in browser
+    try {
+      await open(docsUrl);
+      console.log(`✅ Opened docs in browser`);
+    } catch (openError) {
+      console.log(
+        `⚠️  Failed to open browser: ${openError instanceof Error ? openError.message : String(openError)}`,
+      );
+    }
+
+    return { success: true, docs: result.docs, boardId: data.boardId, docsUrl };
   } catch (error) {
     console.error("Error publishing docs post:", error);
     return {

--- a/packages/publish-docs/src/types.ts
+++ b/packages/publish-docs/src/types.ts
@@ -2,5 +2,6 @@ export interface PublishResult {
   success: boolean;
   docs?: unknown[];
   boardId?: string;
+  docsUrl?: string;
   error?: string;
 }


### PR DESCRIPTION
## Related Issue


### Major Changes

1. add auto open document url feature

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

### Release Notes

- New Feature: Added automatic browser opening of published documentation URLs
- Enhancement: Improved console feedback during documentation publishing process

These changes streamline the documentation workflow by automatically opening published docs in the default browser after successful publishing. Users no longer need to manually copy/paste URLs, making the documentation access more convenient and immediate.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->