### PR TITLE
feat(cli): add alias support for agent

### DIFF
--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -92,6 +92,7 @@ const agentCommandModule = ({
 
   return {
     command: agent.name,
+    aliases: agent.alias || [],
     describe: agent.description || "",
     builder: (yargs) => {
       for (const [option, config] of Object.entries(inputSchema)) {

--- a/packages/cli/test/commands/app.test.ts
+++ b/packages/cli/test/commands/app.test.ts
@@ -50,6 +50,7 @@ test("app command should register doc-smith to yargs", async () => {
           agents: [
             FunctionAgent.from({
               name: "generate",
+              alias: ["gen", "g"],
               description: "Generate documents by doc-smith",
               inputSchema: z.object({
                 title: z.string().describe("Title of doc to generate"),
@@ -74,7 +75,7 @@ test("app command should register doc-smith to yargs", async () => {
 
     Commands:
       aigne doc-smith serve-mcp  Serve doc-smith a MCP server (streamable http)
-      aigne doc-smith generate   Generate documents by doc-smith
+      aigne doc-smith generate   Generate documents by doc-smith   [aliases: gen, g]
 
     Options:
       --help     Show help                                                 [boolean]

--- a/packages/cli/test/tracer/__snapshots__/terminal.test.ts.snap
+++ b/packages/cli/test/tracer/__snapshots__/terminal.test.ts.snap
@@ -1,4 +1,4 @@
-// Bun Snapshot v1, https://goo.gl/fbAQLP
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`TerminalTracer should work correctly 1`] = `
 {

--- a/packages/core/src/agents/agent.ts
+++ b/packages/core/src/agents/agent.ts
@@ -97,6 +97,11 @@ export interface AgentOptions<I extends Message = Message, O extends Message = M
   name?: string;
 
   /**
+   * Alias for the agent, can be used to refer to the agent by multiple names, especially in AIGNE CLI
+   */
+  alias?: string[];
+
+  /**
    * Description of the agent
    *
    * A human-readable description of what the agent does, useful
@@ -257,6 +262,7 @@ export abstract class Agent<I extends Message = any, O extends Message = any> {
     const { inputSchema, outputSchema } = options;
 
     this.name = options.name || this.constructor.name;
+    this.alias = options.alias;
     this.description = options.description;
 
     if (inputSchema) checkAgentInputOutputSchema(inputSchema);
@@ -331,6 +337,11 @@ export abstract class Agent<I extends Message = any, O extends Message = any> {
    * Defaults to the class constructor name if not specified in options
    */
   readonly name: string;
+
+  /**
+   * Alias for the agent, can be used to refer to the agent by multiple names, especially in AIGNE CLI
+   */
+  readonly alias?: string[];
 
   /**
    * Default topic this agent subscribes to

--- a/packages/core/src/loader/agent-yaml.ts
+++ b/packages/core/src/loader/agent-yaml.ts
@@ -108,6 +108,7 @@ export async function parseAgentFile(path: string, data: object): Promise<AgentS
 
     const baseAgentSchema = z.object({
       name: optionalize(z.string()),
+      alias: optionalize(z.array(z.string())),
       description: optionalize(z.string()),
       inputSchema: optionalize(inputOutputSchema({ path })).transform((v) =>
         v ? jsonSchemaToZod(v) : undefined,

--- a/packages/core/test-agents/chat.yaml
+++ b/packages/core/test-agents/chat.yaml
@@ -1,4 +1,7 @@
 name: chat
+alias:
+  - chat-bot
+  - bot
 description: Chat agent
 instructions: |
   You are a helpful assistant that can answer questions and provide information on a wide range of topics.

--- a/packages/core/test/loader/__snapshots__/agent-yaml.test.ts.snap
+++ b/packages/core/test/loader/__snapshots__/agent-yaml.test.ts.snap
@@ -1,5 +1,52 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
+exports[`loadAgentFromYaml should load AIAgent correctly 1`] = `
+{
+  "alias": [
+    "chat-bot",
+    "bot",
+  ],
+  "description": "Chat agent",
+  "instructions": 
+"You are a helpful assistant that can answer questions and provide information on a wide range of topics.
+Your goal is to assist users in finding the information they need and to engage in friendly conversation.
+"
+,
+  "name": "chat",
+  "skills": [
+    {
+      "default_input": undefined,
+      "description": "This agent evaluates JavaScript code.",
+      "input_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": true,
+        "properties": {
+          "code": {
+            "description": "JavaScript code to evaluate",
+            "type": "string",
+          },
+        },
+        "required": [
+          "code",
+        ],
+        "type": "object",
+      },
+      "name": "evaluateJs",
+      "output_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": true,
+        "properties": {
+          "result": {
+            "description": "Result of the evaluated code",
+          },
+        },
+        "type": "object",
+      },
+    },
+  ],
+}
+`;
+
 exports[`loadAgentFromYaml should load AIAgent with prompt file correctly 1`] = `
 "You are a helper agent to answer everything about chat prompt in AIGNE.
 


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. feat(cli): add alias support for agent

```yaml
name: chat
alias:
  - chat-bot
  - bot
description: Chat agent
```

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE Reviewer -->
### Summary by AIGNE

Release Notes:

- New Feature: Added alias support for agents, allowing multiple alternative names to be assigned to each agent
- New Feature: Introduced command aliases for CLI commands (e.g., "gen" and "g" as shortcuts for "generate")
- Documentation: Updated documentation reference links to point to new Bun documentation URL

These changes enhance usability by providing more flexible ways to reference agents and execute commands through aliases/shortcuts. Users can now define multiple names for their agents and use abbreviated command forms in the CLI.
<!-- end of auto-generated comment: release notes by AIGNE Reviewer -->