### PR TITLE
fix(core): share skills/agents from context

### DIFF
--- a/packages/core/src/aigne/context.ts
+++ b/packages/core/src/aigne/context.ts
@@ -128,6 +128,8 @@ export interface Context<U extends UserContext = UserContext>
 
   skills?: Agent[];
 
+  agents: Agent[];
+
   observer?: AIGNEObserver;
 
   span?: Span;
@@ -284,6 +286,10 @@ export class AIGNEContext implements Context {
 
   get skills() {
     return this.internal.skills;
+  }
+
+  get agents() {
+    return this.internal.agents;
   }
 
   get observer() {
@@ -570,7 +576,10 @@ class AIGNEContextShared {
   spans: Span[] = [];
 
   constructor(
-    private readonly parent?: Pick<Context, "model" | "skills" | "limits" | "observer"> & {
+    private readonly parent?: Pick<
+      Context,
+      "model" | "agents" | "skills" | "limits" | "observer"
+    > & {
       messageQueue?: MessageQueue;
       events?: Emitter<any>;
     },
@@ -589,6 +598,10 @@ class AIGNEContextShared {
 
   get skills() {
     return this.parent?.skills;
+  }
+
+  get agents() {
+    return this.parent?.agents ?? [];
   }
 
   get observer() {

--- a/packages/core/test/aigne/context.test.ts
+++ b/packages/core/test/aigne/context.test.ts
@@ -199,12 +199,24 @@ test("AIGNEContext.invoke should check output is a record type", async () => {
   );
 });
 
-test("AIGNEContext.newContext with reset should share events/messageQueue", async () => {
-  const aigne = new AIGNE({});
+test("AIGNEContext.newContext with reset should share events/messageQueue/skills/agents", async () => {
+  const agent = FunctionAgent.from(() => ({}));
+  const skill = FunctionAgent.from(() => ({}));
+
+  const aigne = new AIGNE({
+    agents: [agent],
+    skills: [skill],
+  });
 
   const context = aigne.newContext();
+
+  expect(context.agents).toEqual([agent]);
+  expect(context.skills).toEqual([skill]);
+
   const newContext = context.newContext({ reset: true });
 
+  expect(newContext.agents).toEqual([agent]);
+  expect(newContext.skills).toEqual([skill]);
   expect(context.messageQueue).toBe(newContext.messageQueue);
   expect(context["internal"].events).toBe(newContext["internal"].events);
 });


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(core): share skills/agents from context, function can access agents by options.context.agents

```ts
export default async function testAgent(
  input,
  options
) {
  const otherAgent = context.agents["OTHER_AGENT_NAME"];

  const result = await options.context.invoke(otherAgent, {
    ...
  });

  return ...
}
```

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
