### PR TITLE
feat(cli): add initAgent support for cli

### DIFF
--- a/packages/cli/src/utils/load-aigne.ts
+++ b/packages/cli/src/utils/load-aigne.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { availableModels, findModel, loadModel } from "@aigne/aigne-hub";
 import { AIGNE } from "@aigne/core";
-import { loadAIGNEFile } from "@aigne/core/loader/index.js";
+import { loadAIGNEFile } from "@aigne/core/loader/aigne-yaml.js";
 import { logger } from "@aigne/core/utils/logger.js";
 import { AesCrypter } from "@ocap/mcrypto/lib/crypter/aes-legacy.js";
 import crypto from "crypto";

--- a/packages/cli/test-agents/aigne.yaml
+++ b/packages/cli/test-agents/aigne.yaml
@@ -13,3 +13,6 @@ mcp_server:
 cli:
   agents:
     - chat.yaml
+  init_agent:
+    agent: init.js
+    output_path: init-result.yaml

--- a/packages/cli/test-agents/init.js
+++ b/packages/cli/test-agents/init.js
@@ -1,0 +1,5 @@
+export default function init() {
+  return {
+    initialized: true,
+  };
+}

--- a/packages/core/src/aigne/aigne.ts
+++ b/packages/core/src/aigne/aigne.ts
@@ -55,6 +55,8 @@ export interface AIGNEOptions {
 
   cli?: {
     agents?: Agent[];
+
+    initAgent?: AIGNE["cli"]["initAgent"];
   };
 
   /**
@@ -127,6 +129,7 @@ export class AIGNE<U extends UserContext = UserContext> {
     if (options?.agents?.length) this.addAgent(...options.agents);
     if (options?.mcpServer?.agents?.length) this.mcpServer.agents.push(...options.mcpServer.agents);
     if (options?.cli?.agents?.length) this.cli.agents.push(...options.cli.agents);
+    this.cli.initAgent = options?.cli?.initAgent;
 
     this.observer?.serve();
     this.initProcessExitHandler();
@@ -180,7 +183,28 @@ export class AIGNE<U extends UserContext = UserContext> {
     agents: createAccessorArray<Agent>([], (arr, name) => arr.find((i) => i.name === name)),
   };
 
-  readonly cli = {
+  readonly cli: {
+    agents: ReturnType<typeof createAccessorArray<Agent>>;
+
+    /**
+     * Optional initialization configuration for this AIGNE instance.
+     * When specified, the init agent will be executed before any other agents to set up the environment.
+     */
+    initAgent?: {
+      /**
+       * The agent to execute for initialization before running any other agents.
+       * This agent is responsible for setting up the environment, loading configurations,
+       * or performing any necessary preparation tasks.
+       */
+      agent: Agent;
+
+      /**
+       * The file path where the initialization agent's output will be saved.
+       * This allows other agents to access the initialization results if needed.
+       */
+      outputPath: string;
+    };
+  } = {
     agents: createAccessorArray<Agent>([], (arr, name) => arr.find((i) => i.name === name)),
   };
 

--- a/packages/core/src/loader/aigne-yaml.ts
+++ b/packages/core/src/loader/aigne-yaml.ts
@@ -1,0 +1,94 @@
+import { nodejs } from "@aigne/platform-helpers/nodejs/index.js";
+import { parse } from "yaml";
+import { z } from "zod";
+import { tryOrThrow } from "../utils/type-utils.js";
+import { camelizeSchema, optionalize } from "./schema.js";
+
+const AIGNE_FILE_NAME = ["aigne.yaml", "aigne.yml"];
+
+export const aigneFileSchema = camelizeSchema(
+  z.object({
+    name: optionalize(z.string()),
+    description: optionalize(z.string()),
+    model: optionalize(
+      z.union([
+        z.string(),
+        camelizeSchema(
+          z.object({
+            provider: z.string().nullish(),
+            name: z.string().nullish(),
+            temperature: z.number().min(0).max(2).nullish(),
+            topP: z.number().min(0).nullish(),
+            frequencyPenalty: z.number().min(-2).max(2).nullish(),
+            presencePenalty: z.number().min(-2).max(2).nullish(),
+          }),
+        ),
+      ]),
+    ).transform((v) => (typeof v === "string" ? { name: v } : v)),
+    agents: optionalize(z.array(z.string())),
+    skills: optionalize(z.array(z.string())),
+    mcpServer: optionalize(
+      z.object({
+        agents: optionalize(z.array(z.string())),
+      }),
+    ),
+    cli: optionalize(
+      camelizeSchema(
+        z.object({
+          agents: optionalize(z.array(z.string())),
+          initAgent: optionalize(
+            camelizeSchema(
+              z.object({
+                agent: z.string(),
+                outputPath: z.string(),
+              }),
+            ),
+          ),
+        }),
+      ),
+    ),
+  }),
+);
+
+export async function loadAIGNEFile(path: string): Promise<{
+  aigne: z.infer<typeof aigneFileSchema>;
+  rootDir: string;
+}> {
+  const file = await findAIGNEFile(path);
+
+  const raw = await tryOrThrow(
+    () => nodejs.fs.readFile(file, "utf8"),
+    (error) => new Error(`Failed to load aigne.yaml from ${file}: ${error.message}`),
+  );
+
+  const json = tryOrThrow(
+    () => parse(raw),
+    (error) => new Error(`Failed to parse aigne.yaml from ${file}: ${error.message}`),
+  );
+
+  const aigne = tryOrThrow(
+    () =>
+      aigneFileSchema.parse({ ...json, model: json.model ?? json.chat_model ?? json.chatModel }),
+    (error) => new Error(`Failed to validate aigne.yaml from ${file}: ${error.message}`),
+  );
+
+  return { aigne, rootDir: nodejs.path.dirname(file) };
+}
+
+async function findAIGNEFile(path: string): Promise<string> {
+  const possibleFiles = AIGNE_FILE_NAME.includes(nodejs.path.basename(path))
+    ? [path]
+    : AIGNE_FILE_NAME.map((name) => nodejs.path.join(path, name));
+
+  for (const file of possibleFiles) {
+    try {
+      const stat = await nodejs.fs.stat(file);
+
+      if (stat.isFile()) return file;
+    } catch {}
+  }
+
+  throw new Error(
+    `aigne.yaml not found in ${path}. Please ensure you are in the correct directory or provide a valid path.`,
+  );
+}

--- a/packages/core/test-agents/aigne.yaml
+++ b/packages/core/test-agents/aigne.yaml
@@ -15,3 +15,6 @@ mcp_server:
 cli:
   agents:
     - chat.yaml
+  init_agent:
+    agent: chat.yaml
+    output_path: ./output/chat.yaml

--- a/packages/core/test/loader/__snapshots__/loader.test.ts.snap
+++ b/packages/core/test/loader/__snapshots__/loader.test.ts.snap
@@ -23,6 +23,12 @@ exports[`AIGNE.load should load agents correctly 1`] = `
         "name": "chat",
       },
     ],
+    "initAgent": {
+      "agent": {
+        "name": "chat",
+      },
+      "outputPath": "./output/chat.yaml",
+    },
   },
   "mcpServer": {
     "agents": [

--- a/packages/core/test/loader/loader.test.ts
+++ b/packages/core/test/loader/loader.test.ts
@@ -57,6 +57,12 @@ test("AIGNE.load should load agents correctly", async () => {
         name: agent.name,
         description: agent.description,
       })),
+      initAgent: aigne.cli.initAgent && {
+        agent: {
+          name: aigne.cli.initAgent.agent.name,
+        },
+        outputPath: aigne.cli.initAgent.outputPath,
+      },
     },
   }).toMatchSnapshot();
 });


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. feat(cli): add initAgent support for cli

usage:

```yaml
cli:
  agents:
    - chat.yaml
  init_agent:
    agent: init.js
    output_path: init-result.yaml
```

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
