### PR TITLE
fix(cli): improve help display and command handling

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -20,7 +20,14 @@ function getAIGNEFilePath() {
 const aigneFilePath = getAIGNEFilePath();
 
 export default createAIGNECommand({ aigneFilePath })
-  .fail(() => {})
+  .fail((message, error, yargs) => {
+    // We catch all errors below, here just print the help message non-error case like demandCommand
+    if (!error) {
+      yargs.showHelp();
+
+      console.error(`\n${message}`);
+    }
+  })
   .parseAsync(hideBin([...process.argv.slice(0, 2), ...process.argv.slice(aigneFilePath ? 3 : 2)]))
   .catch((error) => {
     console.log(""); // Add an empty line for better readability

--- a/packages/cli/src/commands/aigne.ts
+++ b/packages/cli/src/commands/aigne.ts
@@ -14,7 +14,7 @@ export function createAIGNECommand(options?: { aigneFilePath?: string }) {
   console.log(asciiLogo);
 
   console.log(
-    `${chalk.grey("TIPS:")} use ${chalk.greenBright("aigne observe")} to start the observability server.\n`,
+    `${chalk.grey("TIPS:")} run ${chalk.blue("aigne observe")} to start the observability server.\n`,
   );
 
   return yargs()
@@ -28,6 +28,7 @@ export function createAIGNECommand(options?: { aigneFilePath?: string }) {
     .command(createObservabilityCommand())
     .command(createConnectCommand())
     .command(createAppCommands())
+    .demandCommand()
     .alias("help", "h")
     .alias("version", "v")
     .strict();

--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -48,7 +48,7 @@ export function createAppCommands(): CommandModule[] {
         yargs.command(agentCommandModule({ dir, agent }));
       }
 
-      yargs.version(`${app.name} v${version}`);
+      yargs.version(`${app.name} v${version}`).alias("version", "v");
 
       return yargs.demandCommand();
     },
@@ -105,7 +105,7 @@ const upgradeCommandModule = ({
       const result = await loadApplication({ name, dir, forceUpgrade: true });
 
       if (version !== result.version) {
-        console.log(`\n✅ Upgraded ${name} to version ${version}`);
+        console.log(`\n✅ Upgraded ${name} to version ${result.version}`);
         return;
       }
     }

--- a/packages/cli/test/commands/__snapshots__/aigne.test.ts.snap
+++ b/packages/cli/test/commands/__snapshots__/aigne.test.ts.snap
@@ -1,0 +1,30 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`aigne command should print help if no any subcommand 1`] = `
+[
+  [
+    
+"CLI for AIGNE framework
+
+Commands:
+  aigne run [path]     Run AIGNE from the specified agent
+  aigne test           Run tests in the specified agents directory
+  aigne create [path]  Create a new aigne project with agent config files
+  aigne serve-mcp      Serve the agents in the specified directory as a MCP
+                       server (streamable http)
+  aigne observe        Start the observability server
+  aigne connect [url]  Manage AIGNE Hub connections
+  aigne doc-smith      Generate professional documents by doc-smith
+                                                        [aliases: docsmith, doc]
+
+Options:
+  -h, --help     Show help                                             [boolean]
+  -v, --version  Show version number                                   [boolean]"
+,
+  ],
+  [],
+  [
+    "Not enough non-option arguments: got 0, need at least 1",
+  ],
+]
+`;

--- a/packages/cli/test/commands/aigne.test.ts
+++ b/packages/cli/test/commands/aigne.test.ts
@@ -23,34 +23,7 @@ test("aigne command should print help if no any subcommand", async () => {
 
   await command.parseAsync([]);
 
-  expect(log.mock.calls).toMatchInlineSnapshot(`
-    [
-      [
-
-    "CLI for AIGNE framework
-
-    Commands:
-      aigne run [path]     Run AIGNE from the specified agent
-      aigne test           Run tests in the specified agents directory
-      aigne create [path]  Create a new aigne project with agent config files
-      aigne serve-mcp      Serve the agents in the specified directory as a MCP
-                           server (streamable http)
-      aigne observe        Start the observability server
-      aigne connect [url]  Manage AIGNE Hub connections
-      aigne doc-smith      Generate professional documents by doc-smith
-                                                            [aliases: docsmith, doc]
-
-    Options:
-      -h, --help     Show help                                             [boolean]
-      -v, --version  Show version number                                   [boolean]"
-    ,
-      ],
-      [],
-      [
-        "Not enough non-option arguments: got 0, need at least 1",
-      ],
-    ]
-  `);
+  expect(log.mock.calls).toMatchSnapshot();
 
   exit.mockRestore();
   log.mockRestore();

--- a/packages/cli/test/commands/aigne.test.ts
+++ b/packages/cli/test/commands/aigne.test.ts
@@ -14,3 +14,44 @@ test("aigne command should parse --version correctly", async () => {
     }),
   );
 });
+
+test("aigne command should print help if no any subcommand", async () => {
+  const command = createAIGNECommand();
+
+  const exit = spyOn(process, "exit").mockReturnValue(undefined as never);
+  const log = spyOn(console, "error").mockReturnValue(undefined as never);
+
+  await command.parseAsync([]);
+
+  expect(log.mock.calls).toMatchInlineSnapshot(`
+    [
+      [
+
+    "CLI for AIGNE framework
+
+    Commands:
+      aigne run [path]     Run AIGNE from the specified agent
+      aigne test           Run tests in the specified agents directory
+      aigne create [path]  Create a new aigne project with agent config files
+      aigne serve-mcp      Serve the agents in the specified directory as a MCP
+                           server (streamable http)
+      aigne observe        Start the observability server
+      aigne connect [url]  Manage AIGNE Hub connections
+      aigne doc-smith      Generate professional documents by doc-smith
+                                                            [aliases: docsmith, doc]
+
+    Options:
+      -h, --help     Show help                                             [boolean]
+      -v, --version  Show version number                                   [boolean]"
+    ,
+      ],
+      [],
+      [
+        "Not enough non-option arguments: got 0, need at least 1",
+      ],
+    ]
+  `);
+
+  exit.mockRestore();
+  log.mockRestore();
+});

--- a/packages/cli/test/commands/app.test.ts
+++ b/packages/cli/test/commands/app.test.ts
@@ -80,10 +80,10 @@ test("app command should register doc-smith to yargs", async () => {
       aigne doc-smith generate   Generate documents by doc-smith   [aliases: gen, g]
 
     Options:
-      --help     Show help                                                 [boolean]
-      --model    Model to use for the application, example: openai:gpt-4.1 or
-                 google:gemini-2.5-flash                                    [string]
-      --version  Show version number                                       [boolean]"
+          --help     Show help                                             [boolean]
+          --model    Model to use for the application, example: openai:gpt-4.1 or
+                     google:gemini-2.5-flash                                [string]
+      -v, --version  Show version number                                   [boolean]"
   `);
 
   await command.parseAsync(["doc-smith", "generate", "--help"]);
@@ -97,7 +97,7 @@ test("app command should register doc-smith to yargs", async () => {
           --help     Show help                                             [boolean]
           --model    Model to use for the application, example: openai:gpt-4.1 or
                      google:gemini-2.5-flash                                [string]
-          --version  Show version number                                   [boolean]
+      -v, --version  Show version number                                   [boolean]
           --title    Title of doc to generate                    [string] [required]
           --topic    Topic of doc to generate                               [string]
       -i, --input    Input to the agent, use @<file> to read from a file     [array]


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

1. show help message if no any subcommand
2. polish tips for `aigne observe` command
3. correctly show the app's last version after upgraded

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

CLI Improvements:

- Enhancement: Improved error handling with clearer help messages when commands are missing or incorrect
- Enhancement: Added "-v" shorthand alias for version command for easier access
- Bug Fix: Version numbers now display correctly in upgrade notifications and success messages
- Enhancement: Updated command help text styling and instructions for better readability
- Enhancement: Added requirement for subcommands to prevent invalid command usage

These changes focus on making the CLI more user-friendly with better error messages, consistent version reporting, and clearer command guidance.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->