### PR TITLE
feat(core): add concurrency support for team agent

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -87,6 +87,7 @@
     "debug": "^4.4.1",
     "eventsource-parser": "^3.0.3",
     "fast-deep-equal": "^3.1.3",
+    "fastq": "^1.19.1",
     "immer": "^10.1.1",
     "jaison": "^2.0.2",
     "jsonata": "^2.0.6",

--- a/packages/core/src/agents/team-agent.ts
+++ b/packages/core/src/agents/team-agent.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import fastq from "fastq";
 import { produce } from "immer";
 import { mergeAgentResponseChunk } from "../utils/stream-utils.js";
 import { isEmpty, isNil, isRecord, omit, type PromiseOrValue } from "../utils/type-utils.js";
@@ -161,6 +162,23 @@ export interface TeamAgentOptions<I extends Message, O extends Message> extends 
   iterateOn?: keyof I;
 
   /**
+   * The maximum number of concurrent operations when processing array items with `iterateOn`.
+   *
+   * This property controls how many array elements are processed simultaneously when
+   * iterating over an array field. A higher concurrency value allows for faster
+   * parallel processing but may consume more resources.
+   *
+   * @remarks
+   * - Only applies when `iterateOn` is specified
+   * - Cannot be used together with `iterateWithPreviousOutput` (concurrency > 1)
+   * - Uses a queue-based approach to limit concurrent operations
+   * - Each concurrent operation processes one array element through the entire agent workflow
+   *
+   * @default 1
+   */
+  concurrency?: number;
+
+  /**
    * Controls whether to merge the output from each iteration back into the array items
    * for subsequent iterations when using `iterateOn`.
    *
@@ -240,8 +258,15 @@ export class TeamAgent<I extends Message, O extends Message> extends Agent<I, O>
       maxIterations: options.reflection.maxIterations ?? DEFAULT_REFLECTION_MAX_ITERATIONS,
     };
     this.iterateOn = options.iterateOn;
+    this.concurrency = options.concurrency ?? 1;
     this.iterateWithPreviousOutput = options.iterateWithPreviousOutput;
     this.includeAllStepsOutput = options.includeAllStepsOutput;
+
+    if (this.concurrency !== 1 && this.iterateWithPreviousOutput) {
+      throw new Error(
+        `iterateWithPreviousOutput cannot be used with concurrency > 1, concurrency: ${this.concurrency}`,
+      );
+    }
   }
 
   /**
@@ -270,6 +295,17 @@ export class TeamAgent<I extends Message, O extends Message> extends Agent<I, O>
    * @see TeamAgentOptions.iterateOn for detailed documentation
    */
   iterateOn?: keyof I;
+
+  /**
+   * The maximum number of concurrent operations when processing array items.
+   *
+   * This property controls the concurrency level for iterative processing when `iterateOn`
+   * is used. It determines how many array elements are processed simultaneously.
+   *
+   * @see TeamAgentOptions.concurrency for detailed documentation
+   * @default 1
+   */
+  concurrency: number;
 
   /**
    * Controls whether to merge the output from each iteration back into the array items
@@ -368,34 +404,44 @@ export class TeamAgent<I extends Message, O extends Message> extends Agent<I, O>
     let arr = input[this.iterateOn] as unknown[];
     arr = Array.isArray(arr) ? [...arr] : isNil(arr) ? [arr] : [];
 
-    const result: Message[] = [];
+    const results: Message[] = [];
 
-    for (let i = 0; i < arr.length; i++) {
-      const item = arr[i];
+    const queue = fastq.promise<unknown, { item: unknown; index: number }>(
+      async ({ item, index }) => {
+        if (!isRecord(item))
+          throw new TypeError(`Expected ${String(key)} to be an object, got ${typeof item}`);
 
-      if (!isRecord(item))
-        throw new TypeError(`Expected ${String(key)} to be an object, got ${typeof item}`);
+        const o = await agentProcessResultToObject(
+          await this._processNonIterator(
+            { ...input, [key]: arr, ...item },
+            { ...options, streaming: false },
+          ),
+        );
 
-      const res = await agentProcessResultToObject(
-        await this._processNonIterator(
-          { ...input, [key]: arr, ...item },
-          { ...options, streaming: false },
-        ),
-      );
+        const res = omit(o, key as any);
 
-      // Merge the item result with the original item used for next iteration
-      if (this.iterateWithPreviousOutput) {
-        arr = produce(arr, (draft) => {
-          const item = draft[i];
-          assert(item);
-          Object.assign(item, res);
-        });
-      }
+        // Merge the item result with the original item used for next iteration
+        if (this.iterateWithPreviousOutput) {
+          arr = produce(arr, (draft) => {
+            const item = draft[index];
+            assert(item);
+            Object.assign(item, res);
+          });
+        }
 
-      result.push(omit(res, key as any) as Message);
+        results[index] = res;
+      },
+      this.concurrency,
+    );
 
-      yield { delta: { json: { [key]: result } } } as AgentResponseChunk<O>;
+    for (let index = 0; index < arr.length; index++) {
+      queue.push({ index, item: arr[index] });
     }
+
+    // result.push(omit(res, key as any) as Message);
+    await queue.drained();
+
+    yield { delta: { json: { [key]: results } } } as AgentResponseChunk<O>;
   }
 
   private _processNonIterator(

--- a/packages/core/src/agents/team-agent.ts
+++ b/packages/core/src/agents/team-agent.ts
@@ -404,7 +404,7 @@ export class TeamAgent<I extends Message, O extends Message> extends Agent<I, O>
     let arr = input[this.iterateOn] as unknown[];
     arr = Array.isArray(arr) ? [...arr] : isNil(arr) ? [arr] : [];
 
-    const results: Message[] = [];
+    const results: Message[] = new Array(arr.length);
 
     const queue = fastq.promise<unknown, { item: unknown; index: number }>(
       async ({ item, index }) => {
@@ -438,7 +438,6 @@ export class TeamAgent<I extends Message, O extends Message> extends Agent<I, O>
       queue.push({ index, item: arr[index] });
     }
 
-    // result.push(omit(res, key as any) as Message);
     await queue.drained();
 
     yield { delta: { json: { [key]: results } } } as AgentResponseChunk<O>;

--- a/packages/core/src/loader/agent-yaml.ts
+++ b/packages/core/src/loader/agent-yaml.ts
@@ -58,6 +58,9 @@ export interface TeamAgentSchema extends BaseAgentSchema {
   type: "team";
   mode?: ProcessMode;
   iterateOn?: string;
+  concurrency?: number;
+  iterateWithPreviousOutput?: boolean;
+  includeAllStepsOutput?: boolean;
   reflection?: Omit<ReflectionMode, "reviewer"> & { reviewer: NestAgentSchema };
 }
 
@@ -168,6 +171,9 @@ export async function parseAgentFile(path: string, data: object): Promise<AgentS
             type: z.literal("team"),
             mode: optionalize(z.nativeEnum(ProcessMode)),
             iterateOn: optionalize(z.string()),
+            concurrency: optionalize(z.number().int().min(1)),
+            iterateWithPreviousOutput: optionalize(z.boolean()),
+            includeAllStepsOutput: optionalize(z.boolean()),
             reflection: camelizeSchema(
               optionalize(
                 z.object({

--- a/packages/core/test-agents/team.yaml
+++ b/packages/core/test-agents/team.yaml
@@ -32,3 +32,6 @@ output_schema:
           description:
             type: string
 iterate_on: sections
+concurrency: 2
+iterate-with-previous-output: false
+include-all-steps-output: true

--- a/packages/core/test/agents/__snapshots__/team-agent.test.ts.snap
+++ b/packages/core/test/agents/__snapshots__/team-agent.test.ts.snap
@@ -228,7 +228,9 @@ exports[`TeamAgent with sequential mode should yield output chunks correctly 1`]
 ]
 `;
 
-exports[`TeamAgent with iterateOn should process array input correctly 1`] = `
+exports[`TeamAgent with iterateOn should process array input correctly {
+  concurrency: 1,
+} 1`] = `
 {
   "sections": [
     {
@@ -244,7 +246,76 @@ exports[`TeamAgent with iterateOn should process array input correctly 1`] = `
 }
 `;
 
-exports[`TeamAgent with iterateOn should process array input correctly 2`] = `
+exports[`TeamAgent with iterateOn should process array input correctly {
+  concurrency: 1,
+} 2`] = `
+[
+  {
+    "sections": [
+      {
+        "title": "Test title 0",
+      },
+      {
+        "title": "Test title 1",
+      },
+      {
+        "title": "Test title 2",
+      },
+    ],
+    "title": "Test title 0",
+  },
+  {
+    "sections": [
+      {
+        "title": "Test title 0",
+      },
+      {
+        "title": "Test title 1",
+      },
+      {
+        "title": "Test title 2",
+      },
+    ],
+    "title": "Test title 1",
+  },
+  {
+    "sections": [
+      {
+        "title": "Test title 0",
+      },
+      {
+        "title": "Test title 1",
+      },
+      {
+        "title": "Test title 2",
+      },
+    ],
+    "title": "Test title 2",
+  },
+]
+`;
+
+exports[`TeamAgent with iterateOn should process array input correctly {
+  concurrency: 2,
+} 1`] = `
+{
+  "sections": [
+    {
+      "description": "Description for Test title 0",
+    },
+    {
+      "description": "Description for Test title 1",
+    },
+    {
+      "description": "Description for Test title 2",
+    },
+  ],
+}
+`;
+
+exports[`TeamAgent with iterateOn should process array input correctly {
+  concurrency: 2,
+} 2`] = `
 [
   {
     "sections": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1127,7 +1127,7 @@ importers:
         version: link:../../packages/sqlite
       '@arcblock/did-connect':
         specifier: ^3.0.24
-        version: 3.0.24(@arcblock/ux@3.0.24(3229887ebef85d204beb14a892529cec))(@blocklet/js-sdk@1.16.46)(@blocklet/theme@3.0.33(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 3.0.24(19890d47c2aed4eb3216fbb9904c4a12)
       '@arcblock/ux':
         specifier: ^3.0.24
         version: 3.0.24(3229887ebef85d204beb14a892529cec)
@@ -1245,7 +1245,7 @@ importers:
         version: 1.16.46
       '@arcblock/did-connect':
         specifier: ^3.0.24
-        version: 3.0.24(@arcblock/ux@3.0.24(3229887ebef85d204beb14a892529cec))(@blocklet/js-sdk@1.16.46)(@blocklet/theme@3.0.33(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 3.0.24(19890d47c2aed4eb3216fbb9904c4a12)
       '@arcblock/ux':
         specifier: ^3.0.24
         version: 3.0.24(3229887ebef85d204beb14a892529cec)
@@ -1605,13 +1605,16 @@ importers:
         version: 1.0.5
       debug:
         specifier: ^4.4.1
-        version: 4.4.1(supports-color@5.5.0)
+        version: 4.4.1
       eventsource-parser:
         specifier: ^3.0.3
         version: 3.0.3
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
+      fastq:
+        specifier: ^1.19.1
+        version: 1.19.1
       immer:
         specifier: ^10.1.1
         version: 10.1.1
@@ -10648,7 +10651,7 @@ snapshots:
       '@ocap/wallet': 1.20.15
       archiver: 7.0.1
       axios: 1.10.0(debug@4.4.1)
-      axios-mock-adapter: 2.1.0(axios@1.10.0(debug@4.4.1))
+      axios-mock-adapter: 2.1.0(axios@1.10.0)
       axon: 2.0.3
       chalk: 4.1.2
       cookie: 1.0.2
@@ -10755,7 +10758,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@arcblock/did-connect@3.0.24(@arcblock/ux@3.0.24(3229887ebef85d204beb14a892529cec))(@blocklet/js-sdk@1.16.46)(@blocklet/theme@3.0.33(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@arcblock/did-connect@3.0.24(19890d47c2aed4eb3216fbb9904c4a12)':
     dependencies:
       '@arcblock/bridge': 3.0.24
       '@arcblock/did': 1.20.15
@@ -11696,7 +11699,7 @@ snapshots:
   '@blocklet/did-space-react@1.1.5(6f3afd0eb9fa40329e5c30679b84b222)':
     dependencies:
       '@arcblock/did': 1.20.15
-      '@arcblock/did-connect': 3.0.24(@arcblock/ux@3.0.24(3229887ebef85d204beb14a892529cec))(@blocklet/js-sdk@1.16.46)(@blocklet/theme@3.0.33(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@arcblock/did-connect': 3.0.24(19890d47c2aed4eb3216fbb9904c4a12)
       '@arcblock/ux': 3.0.24(3229887ebef85d204beb14a892529cec)
       '@blocklet/js-sdk': 1.16.46
       '@blocklet/sdk': 1.16.46(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
@@ -11867,7 +11870,7 @@ snapshots:
       '@abtnode/constant': 1.16.46
       '@abtnode/util': 1.16.46
       '@arcblock/bridge': 3.0.24
-      '@arcblock/did-connect': 3.0.24(@arcblock/ux@3.0.24(3229887ebef85d204beb14a892529cec))(@blocklet/js-sdk@1.16.46)(@blocklet/theme@3.0.33(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@arcblock/did-connect': 3.0.24(19890d47c2aed4eb3216fbb9904c4a12)
       '@arcblock/icons': 3.0.24(react@19.1.0)
       '@arcblock/react-hooks': 3.0.24
       '@arcblock/ux': 3.0.24(3229887ebef85d204beb14a892529cec)
@@ -14798,9 +14801,9 @@ snapshots:
 
   awesome-phonenumber@7.5.0: {}
 
-  axios-mock-adapter@2.1.0(axios@1.10.0(debug@4.4.1)):
+  axios-mock-adapter@2.1.0(axios@1.10.0):
     dependencies:
-      axios: 1.10.0(debug@4.4.1)
+      axios: 1.10.0
       fast-deep-equal: 3.1.3
       is-buffer: 2.0.5
 
@@ -14912,7 +14915,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       on-finished: 2.4.1
@@ -15661,6 +15664,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.1(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -16261,7 +16268,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -16426,7 +16433,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -19904,7 +19911,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -20000,7 +20007,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.1
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. feat(core): add concurrency support for team agent

usage

```yaml
type: team
name: test-team-agent
iterate_on: sections
concurrency: 2
```

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [x] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

Release Notes:

- New Feature: Added concurrent processing support to TeamAgent, allowing parallel execution of agent tasks for improved performance
- New Feature: Introduced `concurrency` configuration option to control parallel processing behavior
- Test: Added comprehensive test coverage for concurrent execution scenarios

These changes enable users to significantly improve processing speed by running multiple agent tasks simultaneously while maintaining control over resource utilization through the concurrency setting.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->