### PR TITLE
feat(cli): support config custom AIGNE Hub service URL

### DIFF
--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -177,16 +177,9 @@ function innerZodType(type: ZodType): ZodType {
 export async function invokeCLIAgentFromDir(options: {
   dir: string;
   agent: string;
-  input: Message & {
-    input?: string[];
-    format?: "yaml" | "json";
-    model?: string;
-    aigneHubUrl?: string;
-  };
+  input: Message & { input?: string[]; format?: "yaml" | "json"; model?: string };
 }) {
-  const aigne = await loadAIGNE(options.dir, {
-    model: options.input.model,
-  });
+  const aigne = await loadAIGNE(options.dir, { model: options.input.model });
 
   try {
     const agent = aigne.cli.agents[options.agent];

--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -151,6 +151,11 @@ const agentCommandModule = ({
           type: "string",
           description: 'Input format, can be "json" or "yaml"',
           choices: ["json", "yaml"],
+        })
+        .option("aigne-hub-url", {
+          describe:
+            "Custom AIGNE Hub service URL. Used to fetch remote agent definitions or models.",
+          type: "string",
         }) as any;
     },
     handler: async (input) => {
@@ -162,9 +167,17 @@ const agentCommandModule = ({
 export async function invokeCLIAgentFromDir(options: {
   dir: string;
   agent: string;
-  input: Message & { input?: string[]; format?: "yaml" | "json"; model?: string };
+  input: Message & {
+    input?: string[];
+    format?: "yaml" | "json";
+    model?: string;
+    aigneHubUrl?: string;
+  };
 }) {
-  const aigne = await loadAIGNE(options.dir, { model: options.input.model });
+  const aigne = await loadAIGNE(options.dir, {
+    model: options.input.model,
+    aigneHubUrl: options.input.aigneHubUrl,
+  });
 
   try {
     const agent = aigne.cli.agents[options.agent];

--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -158,11 +158,6 @@ const agentCommandModule = ({
           type: "string",
           description: 'Input format, can be "json" or "yaml"',
           choices: ["json", "yaml"],
-        })
-        .option("aigne-hub-url", {
-          describe:
-            "Custom AIGNE Hub service URL. Used to fetch remote agent definitions or models.",
-          type: "string",
         }) as any;
     },
     handler: async (input) => {
@@ -191,7 +186,6 @@ export async function invokeCLIAgentFromDir(options: {
 }) {
   const aigne = await loadAIGNE(options.dir, {
     model: options.input.model,
-    aigneHubUrl: options.input.aigneHubUrl,
   });
 
   try {

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -65,13 +65,12 @@ export async function displayStatus(statusList: StatusInfo[]) {
     statusList.find((status) => status.host === "default")?.apiUrl || DEFAULT_URL;
 
   for (const status of statusList.filter((status) => status.host !== "default")) {
-    const userInfo = await getUserInfo({
-      baseUrl: status.apiUrl,
-      accessKey: status.apiKey,
-    }).catch((e) => {
-      console.error(e);
-      return null;
-    });
+    const userInfo = await getUserInfo({ baseUrl: status.apiUrl, apiKey: status.apiKey }).catch(
+      (e) => {
+        console.error(e);
+        return null;
+      },
+    );
 
     const isConnected = new URL(status.apiUrl).origin === new URL(defaultStatus).origin;
     const statusIcon = isConnected ? chalk.green("✓") : chalk.red("✗");

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -4,7 +4,7 @@ import chalk from "chalk";
 import { parse } from "yaml";
 import type { CommandModule } from "yargs";
 import { getUserInfo } from "../utils/aigne-hub-user.js";
-import { AIGNE_ENV_FILE, connectToAIGNEHub } from "../utils/load-aigne.js";
+import { AIGNE_ENV_FILE, connectToAIGNEHub, DEFAULT_URL } from "../utils/load-aigne.js";
 
 interface ConnectOptions {
   url?: string;
@@ -61,8 +61,10 @@ export async function displayStatus(statusList: StatusInfo[]) {
   }
 
   console.log(chalk.blue("AIGNE Hub Connection Status:\n"));
+  const defaultStatus =
+    statusList.find((status) => status.host === "default")?.apiUrl || DEFAULT_URL;
 
-  for (const status of statusList) {
+  for (const status of statusList.filter((status) => status.host !== "default")) {
     const userInfo = await getUserInfo({
       baseUrl: status.apiUrl,
       accessKey: status.apiKey,
@@ -71,8 +73,9 @@ export async function displayStatus(statusList: StatusInfo[]) {
       return null;
     });
 
-    const statusIcon = userInfo ? chalk.green("✓") : chalk.red("✗");
-    const statusText = userInfo ? "Connected" : "Disconnected";
+    const isConnected = new URL(status.apiUrl).origin === new URL(defaultStatus).origin;
+    const statusIcon = isConnected ? chalk.green("✓") : chalk.red("✗");
+    const statusText = isConnected ? "Connected" : "Disconnected";
 
     console.log(`${statusIcon} ${chalk.bold(status.host)}`);
     console.log(`   Status: ${statusText}`);

--- a/packages/cli/src/commands/serve-mcp.ts
+++ b/packages/cli/src/commands/serve-mcp.ts
@@ -52,6 +52,11 @@ export function createServeMCPCommand({
           describe: "Pathname to the service",
           type: "string",
           default: "/mcp",
+        })
+        .option("aigne-hub-url", {
+          describe:
+            "Custom AIGNE Hub service URL. Used to fetch remote agent definitions or models. ",
+          type: "string",
         });
     },
     handler: async (options) => {
@@ -68,10 +73,11 @@ export async function serveMCPServerFromDir(options: {
   host: string;
   port?: number;
   pathname: string;
+  aigneHubUrl?: string;
 }) {
   const port = options.port || DEFAULT_PORT();
 
-  const aigne = await loadAIGNE(options.dir);
+  const aigne = await loadAIGNE(options.dir, { aigneHubUrl: options.aigneHubUrl });
 
   await serveMCPServer({
     aigne,

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -6,6 +6,7 @@ import { loadAIGNE } from "../utils/load-aigne.js";
 
 interface TestOptions {
   path: string;
+  aigneHubUrl?: string;
 }
 
 export function createTestCommand({
@@ -17,18 +18,24 @@ export function createTestCommand({
     command: "test",
     describe: "Run tests in the specified agents directory",
     builder: (yargs) => {
-      return yargs.option("path", {
-        describe: "Path to the agents directory or URL to aigne project",
-        type: "string",
-        default: ".",
-        alias: ["url"],
-      });
+      return yargs
+        .option("path", {
+          describe: "Path to the agents directory or URL to aigne project",
+          type: "string",
+          default: ".",
+          alias: ["url"],
+        })
+        .option("aigne-hub-url", {
+          describe:
+            "Custom AIGNE Hub service URL. Used to fetch remote agent definitions or models. ",
+          type: "string",
+        });
     },
     handler: async (options) => {
       const path = aigneFilePath || options.path;
       const absolutePath = isAbsolute(path) ? path : resolve(process.cwd(), path);
 
-      const aigne = await loadAIGNE(absolutePath);
+      const aigne = await loadAIGNE(absolutePath, { aigneHubUrl: options?.aigneHubUrl });
       assert(aigne.rootDir);
 
       spawnSync("node", ["--test"], { cwd: aigne.rootDir, stdio: "inherit" });

--- a/packages/cli/src/utils/aigne-hub-user.ts
+++ b/packages/cli/src/utils/aigne-hub-user.ts
@@ -15,14 +15,14 @@ export interface UserInfoResult {
 
 export async function getUserInfo({
   baseUrl,
-  accessKey,
+  apiKey,
 }: {
   baseUrl: string;
-  accessKey: string;
+  apiKey: string;
 }): Promise<UserInfoResult> {
   const response = await fetch(joinURL(baseUrl, "/api/user/info"), {
     headers: {
-      Authorization: `Bearer ${accessKey}`,
+      Authorization: `Bearer ${apiKey}`,
     },
   });
 

--- a/packages/cli/src/utils/load-aigne.ts
+++ b/packages/cli/src/utils/load-aigne.ts
@@ -51,6 +51,7 @@ export interface RunOptions extends RunAIGNECommandOptions {
   path: string;
   entryAgent?: string;
   cacheDir?: string;
+  aigneHubUrl?: string;
 }
 
 const WELLKNOWN_SERVICE_PATH_PREFIX = "/.well-known/service";
@@ -164,7 +165,7 @@ export async function createConnect({
 const AGENT_HUB_PROVIDER = "aignehub";
 const DEFAULT_AIGNE_HUB_MODEL = "openai/gpt-4o";
 const DEFAULT_AIGNE_HUB_PROVIDER_MODEL = `${AGENT_HUB_PROVIDER}:${DEFAULT_AIGNE_HUB_MODEL}`;
-const DEFAULT_URL = "https://hub.aigne.io/";
+export const DEFAULT_URL = "https://hub.aigne.io/";
 
 export const formatModelName = async (
   models: ReturnType<typeof availableModels>,
@@ -239,7 +240,7 @@ export async function connectToAIGNEHub(url: string) {
     });
 
     const accessKeyOptions = {
-      accessKey: result.accessKeySecret,
+      apiKey: result.accessKeySecret,
       url: joinURL(origin, aigneHubMount?.mountPoint || ""),
     };
 
@@ -256,7 +257,10 @@ export async function connectToAIGNEHub(url: string) {
       stringify({
         ...envs,
         [host]: {
-          AIGNE_HUB_API_KEY: accessKeyOptions.accessKey,
+          AIGNE_HUB_API_KEY: accessKeyOptions.apiKey,
+          AIGNE_HUB_API_URL: accessKeyOptions.url,
+        },
+        default: {
           AIGNE_HUB_API_URL: accessKeyOptions.url,
         },
       }),
@@ -306,7 +310,7 @@ const mockInquirerPrompt = (() => Promise.resolve({ useAigneHub: true })) as any
 
 export async function loadAIGNE(
   path: string,
-  options?: Pick<RunOptions, "model">,
+  options?: Pick<RunOptions, "model" | "aigneHubUrl">,
   actionOptions?: {
     inquirerPromptFn?: (prompt: {
       type: string;
@@ -318,11 +322,20 @@ export async function loadAIGNE(
     runTest?: boolean;
   },
 ) {
-  const models = availableModels();
-  const AIGNE_HUB_URL = process.env.AIGNE_HUB_API_URL || DEFAULT_URL;
-  const connectUrl = joinURL(new URL(AIGNE_HUB_URL).origin, WELLKNOWN_SERVICE_PATH_PREFIX);
+  const aigneDir = join(homedir(), ".aigne");
+  if (!existsSync(aigneDir)) {
+    mkdirSync(aigneDir, { recursive: true });
+  }
+
+  const envs = parse(await readFile(AIGNE_ENV_FILE, "utf8").catch(() => stringify({})));
   const inquirerPrompt = (actionOptions?.inquirerPromptFn ??
     inquirer.prompt) as typeof inquirer.prompt;
+
+  const models = availableModels();
+  const configUrl = options?.aigneHubUrl || process.env.AIGNE_HUB_API_URL;
+  const AIGNE_HUB_URL = configUrl || envs?.default?.AIGNE_HUB_API_URL || DEFAULT_URL;
+
+  const connectUrl = joinURL(new URL(AIGNE_HUB_URL).origin, WELLKNOWN_SERVICE_PATH_PREFIX);
 
   const { host } = new URL(AIGNE_HUB_URL);
   const { aigne } = await loadAIGNEFile(path).catch(() => ({ aigne: null }));
@@ -347,28 +360,57 @@ export async function loadAIGNE(
       credential = await checkConnectionStatus(host);
     } catch (error) {
       if (error instanceof Error && error.message.includes("login first")) {
-        // If none or invalid, prompt the user to proceed
-        const subscribePrompt = await inquirerPrompt({
-          type: "list",
-          name: "subscribe",
-          message:
-            "No LLM API Keys or AIGNE Hub connections found, select your preferred way to continue:",
-          choices: [
-            {
-              name: "Connect to AIGNE Hub with just a few clicks, free credits eligible for new users (Recommended)",
-              value: true,
-            },
-            { name: "Exit and configure my own LLM API Keys", value: false },
-          ],
-          default: true,
-        });
+        let aigneHubUrl = connectUrl;
 
-        if (!subscribePrompt.subscribe) {
-          console.warn("The AIGNE Hub connection has been cancelled");
-          process.exit(0);
+        if (!configUrl) {
+          const { subscribe } = await inquirerPrompt({
+            type: "list",
+            name: "subscribe",
+            message:
+              "No LLM API Keys or AIGNE Hub connections found. How would you like to proceed?",
+            choices: [
+              {
+                name: "Connect to the Arcblock official AIGNE Hub (recommended, free credits for new users)",
+                value: "official",
+              },
+              connectUrl.includes(DEFAULT_URL)
+                ? {
+                    name: "Connect to your own AIGNE Hub instance (self-hosted)",
+                    value: "custom",
+                  }
+                : null,
+              {
+                name: "Exit and configure my own LLM API Keys",
+                value: "manual",
+              },
+            ].filter(Boolean) as { name: string; value: string }[],
+            default: "official",
+          });
+
+          if (subscribe === "custom") {
+            const { customUrl } = await inquirerPrompt({
+              type: "input",
+              name: "customUrl",
+              message: "Enter the URL of your AIGNE Hub:",
+              validate(input) {
+                try {
+                  const url = new URL(input);
+                  return url.protocol.startsWith("http")
+                    ? true
+                    : "Must be a valid URL with http or https";
+                } catch {
+                  return "Invalid URL";
+                }
+              },
+            });
+            aigneHubUrl = customUrl;
+          } else if (subscribe === "manual") {
+            console.log("You chose to configure your own LLM API Keys. Exiting...");
+            process.exit(0);
+          }
         }
 
-        credential = await connectToAIGNEHub(connectUrl);
+        credential = await connectToAIGNEHub(aigneHubUrl);
       }
     }
   }

--- a/packages/cli/src/utils/load-aigne.ts
+++ b/packages/cli/src/utils/load-aigne.ts
@@ -275,7 +275,7 @@ export async function connectToAIGNEHub(url: string) {
     return accessKeyOptions;
   } catch (error) {
     logger.error("Failed to connect to AIGNE Hub", error.message);
-    return { accessKey: undefined, url: undefined };
+    return { apiKey: undefined, url: undefined };
   }
 }
 

--- a/packages/cli/test/utils/load-aigne.test.ts
+++ b/packages/cli/test/utils/load-aigne.test.ts
@@ -80,6 +80,41 @@ describe("load aigne", () => {
     default: mockOpen,
   }));
 
+  describe("loadAIGNE with process.env.AIGNE_HUB_API_URL", () => {
+    test("should load aigne successfully with default env file", async () => {
+      const { url, close } = await createHonoServer();
+      const mockInquirerPrompt: any = mock(async () => ({ subscribe: "official" }));
+
+      await writeFile(
+        AIGNE_ENV_FILE,
+        stringify({
+          [new URL(url).host]: {
+            AIGNE_HUB_API_KEY: "123",
+            AIGNE_HUB_API_URL: url,
+          },
+          default: {
+            AIGNE_HUB_API_URL: url,
+          },
+        }),
+      );
+
+      const path = join(import.meta.dirname, "../_mocks_");
+      await loadAIGNE(
+        path,
+        { model: "aignehub:openai/gpt-4o" },
+        { inquirerPromptFn: mockInquirerPrompt, runTest: true },
+      );
+
+      const envs = parse(await readFile(AIGNE_ENV_FILE, "utf8").catch(() => stringify({})));
+      const env = envs[new URL(url).host];
+      await rm(AIGNE_ENV_FILE, { force: true });
+
+      expect(env).toBeDefined();
+      expect(env.AIGNE_HUB_API_KEY).toBe("123");
+      close();
+    });
+  });
+
   describe("Encryption Functions", () => {
     describe("encodeEncryptionKey", () => {
       test("should encode encryption key correctly", () => {
@@ -524,7 +559,7 @@ describe("load aigne", () => {
   describe("loadAIGNE", () => {
     test("should load aigne successfully with no env file", async () => {
       const { url, close } = await createHonoServer();
-      const mockInquirerPrompt: any = mock(async () => ({ subscribe: true }));
+      const mockInquirerPrompt: any = mock(async () => ({ subscribe: "official" }));
 
       process.env.AIGNE_HUB_API_URL = url;
       const path = join(import.meta.dirname, "../_mocks_");
@@ -545,7 +580,7 @@ describe("load aigne", () => {
 
     test("should load aigne successfully with empty env file", async () => {
       const { url, close } = await createHonoServer();
-      const mockInquirerPrompt: any = mock(async () => ({ subscribe: true }));
+      const mockInquirerPrompt: any = mock(async () => ({ subscribe: "official" }));
 
       process.env.AIGNE_HUB_API_URL = url;
       await writeFile(AIGNE_ENV_FILE, stringify({}));
@@ -568,7 +603,7 @@ describe("load aigne", () => {
 
     test("should load aigne successfully with no host env file", async () => {
       const { url, close } = await createHonoServer();
-      const mockInquirerPrompt: any = mock(async () => ({ subscribe: true }));
+      const mockInquirerPrompt: any = mock(async () => ({ subscribe: "official" }));
 
       process.env.AIGNE_HUB_API_URL = url;
       await writeFile(
@@ -598,7 +633,7 @@ describe("load aigne", () => {
 
     test("should load aigne successfully with no host key env file", async () => {
       const { url, close } = await createHonoServer();
-      const mockInquirerPrompt: any = mock(async () => ({ subscribe: true }));
+      const mockInquirerPrompt: any = mock(async () => ({ subscribe: "official" }));
 
       process.env.AIGNE_HUB_API_URL = url;
       await writeFile(
@@ -627,7 +662,7 @@ describe("load aigne", () => {
 
     test("should load aigne successfully with no host key env file", async () => {
       const { url, close } = await createHonoServer();
-      const mockInquirerPrompt: any = mock(async () => ({ subscribe: true }));
+      const mockInquirerPrompt: any = mock(async () => ({ subscribe: "official" }));
 
       process.env.AIGNE_HUB_API_URL = url;
       await writeFile(
@@ -644,35 +679,6 @@ describe("load aigne", () => {
       await loadAIGNE(
         path,
         { model: "aignehub:openai/gpt-4o" },
-        { inquirerPromptFn: mockInquirerPrompt, runTest: true },
-      );
-
-      const envs = parse(await readFile(AIGNE_ENV_FILE, "utf8").catch(() => stringify({})));
-      const env = envs[new URL(url).host];
-
-      expect(env).toBeDefined();
-      expect(env.AIGNE_HUB_API_KEY).toBe("123");
-      close();
-    });
-
-    test("should load aigne successfully with aigneHubUrl", async () => {
-      const { url, close } = await createHonoServer();
-      const mockInquirerPrompt: any = mock(async () => ({ subscribe: true }));
-
-      await writeFile(
-        AIGNE_ENV_FILE,
-        stringify({
-          [new URL(url).host]: {
-            AIGNE_HUB_API_KEY: "123",
-            AIGNE_HUB_API_URL: url,
-          },
-        }),
-      );
-
-      const path = join(import.meta.dirname, "../_mocks_");
-      await loadAIGNE(
-        path,
-        { model: "aignehub:openai/gpt-4o", aigneHubUrl: url },
         { inquirerPromptFn: mockInquirerPrompt, runTest: true },
       );
 

--- a/packages/cli/test/utils/load-aigne.test.ts
+++ b/packages/cli/test/utils/load-aigne.test.ts
@@ -435,93 +435,29 @@ describe("load aigne", () => {
     });
   });
 
-  describe("checkConnectionStatus", () => {
-    test("should throw error with no env file", async () => {
-      const { url, close } = await createHonoServer();
-      await rm(AIGNE_ENV_FILE, { force: true });
-      await expect(checkConnectionStatus(new URL(url).host)).rejects.toThrow(
-        /need to login first/i,
-      );
-      close();
-    });
-
-    test("should throw error with empty env file", async () => {
-      const { url, close } = await createHonoServer();
-
-      process.env.AIGNE_HUB_API_URL = url;
-      await writeFile(AIGNE_ENV_FILE, stringify({}));
-      await expect(checkConnectionStatus(new URL(url).host)).rejects.toThrow(
-        /need to login first/i,
-      );
-
-      close();
-    });
-
-    test("should load aigne successfully with no host env file", async () => {
-      const { url, close } = await createHonoServer();
-
-      process.env.AIGNE_HUB_API_URL = url;
-      await writeFile(
-        AIGNE_ENV_FILE,
-        stringify({
-          test: {
-            AIGNE_HUB_API_KEY: "123",
-          },
-        }),
-      );
-
-      await expect(checkConnectionStatus(new URL(url).host)).rejects.toThrow(
-        /need to login first/i,
-      );
-
-      close();
-    });
-
-    test("should load aigne successfully with no host key env file", async () => {
-      const { url, close } = await createHonoServer();
-
-      process.env.AIGNE_HUB_API_URL = url;
-      await writeFile(
-        AIGNE_ENV_FILE,
-        stringify({
-          [new URL(url).host]: {
-            AIGNE_HUB_API_KEY1: "123",
-          },
-        }),
-      );
-
-      await expect(checkConnectionStatus(new URL(url).host)).rejects.toThrow(
-        /need to login first/i,
-      );
-
-      close();
-    });
-
-    test("should load aigne successfully with no host key env file", async () => {
-      const { url, close } = await createHonoServer();
-
-      process.env.AIGNE_HUB_API_URL = url;
-      await writeFile(
-        AIGNE_ENV_FILE,
-        stringify({
-          [new URL(url).host]: {
-            AIGNE_HUB_API_KEY: "123",
-            AIGNE_HUB_API_URL: url,
-          },
-        }),
-      );
-
-      await expect(await checkConnectionStatus(new URL(url).host));
-
-      close();
-    });
-
-    afterEach(async () => {
-      await rm(AIGNE_ENV_FILE, { force: true });
-    });
-  });
-
   describe("loadAIGNE", () => {
+    test("should load aigne successfully with default env file", async () => {
+      const { url, close } = await createHonoServer();
+      const mockInquirerPrompt: any = mock(async () => ({ subscribe: "official" }));
+
+      await writeFile(AIGNE_ENV_FILE, stringify({ default: { AIGNE_HUB_API_URL: url } }));
+
+      const path = join(import.meta.dirname, "../_mocks_");
+      await loadAIGNE(
+        path,
+        { model: "aignehub:openai/gpt-4o" },
+        { inquirerPromptFn: mockInquirerPrompt, runTest: true },
+      );
+
+      const envs = parse(await readFile(AIGNE_ENV_FILE, "utf8").catch(() => stringify({})));
+      const env = envs[new URL(url).host];
+
+      expect(env).toBeDefined();
+      expect(env.AIGNE_HUB_API_KEY).toBe("test");
+      expect(env.AIGNE_HUB_API_URL).toBe(joinURL(url, "ai-kit"));
+      close();
+    });
+
     test("should load aigne successfully with no env file", async () => {
       const { url, close } = await createHonoServer();
       const mockInquirerPrompt: any = mock(async () => ({ subscribe: "official" }));
@@ -549,28 +485,6 @@ describe("load aigne", () => {
 
       process.env.AIGNE_HUB_API_URL = url;
       await writeFile(AIGNE_ENV_FILE, stringify({}));
-
-      const path = join(import.meta.dirname, "../_mocks_");
-      await loadAIGNE(
-        path,
-        { model: "aignehub:openai/gpt-4o" },
-        { inquirerPromptFn: mockInquirerPrompt, runTest: true },
-      );
-
-      const envs = parse(await readFile(AIGNE_ENV_FILE, "utf8").catch(() => stringify({})));
-      const env = envs[new URL(url).host];
-
-      expect(env).toBeDefined();
-      expect(env.AIGNE_HUB_API_KEY).toBe("test");
-      expect(env.AIGNE_HUB_API_URL).toBe(joinURL(url, "ai-kit"));
-      close();
-    });
-
-    test("should load aigne successfully with default env file", async () => {
-      const { url, close } = await createHonoServer();
-      const mockInquirerPrompt: any = mock(async () => ({ subscribe: "official" }));
-
-      await writeFile(AIGNE_ENV_FILE, stringify({ default: { AIGNE_HUB_API_URL: url } }));
 
       const path = join(import.meta.dirname, "../_mocks_");
       await loadAIGNE(

--- a/packages/cli/test/utils/load-aigne.test.ts
+++ b/packages/cli/test/utils/load-aigne.test.ts
@@ -420,7 +420,7 @@ describe("load aigne", () => {
       const result = await connectToAIGNEHub(url);
 
       expect(result).toBeDefined();
-      expect(result.accessKey).toBe("test");
+      expect(result.apiKey).toBe("test");
       expect(result.url).toBe(joinURL(url, "ai-kit"));
 
       const envs = parse(await readFile(AIGNE_ENV_FILE, "utf8").catch(() => stringify({})));

--- a/packages/cli/test/utils/load-aigne.test.ts
+++ b/packages/cli/test/utils/load-aigne.test.ts
@@ -655,6 +655,35 @@ describe("load aigne", () => {
       close();
     });
 
+    test("should load aigne successfully with aigneHubUrl", async () => {
+      const { url, close } = await createHonoServer();
+      const mockInquirerPrompt: any = mock(async () => ({ subscribe: true }));
+
+      await writeFile(
+        AIGNE_ENV_FILE,
+        stringify({
+          [new URL(url).host]: {
+            AIGNE_HUB_API_KEY: "123",
+            AIGNE_HUB_API_URL: url,
+          },
+        }),
+      );
+
+      const path = join(import.meta.dirname, "../_mocks_");
+      await loadAIGNE(
+        path,
+        { model: "aignehub:openai/gpt-4o", aigneHubUrl: url },
+        { inquirerPromptFn: mockInquirerPrompt, runTest: true },
+      );
+
+      const envs = parse(await readFile(AIGNE_ENV_FILE, "utf8").catch(() => stringify({})));
+      const env = envs[new URL(url).host];
+
+      expect(env).toBeDefined();
+      expect(env.AIGNE_HUB_API_KEY).toBe("123");
+      close();
+    });
+
     afterEach(async () => {
       await rm(AIGNE_ENV_FILE, { force: true });
     });

--- a/packages/cli/test/utils/load-aigne.test.ts
+++ b/packages/cli/test/utils/load-aigne.test.ts
@@ -80,41 +80,6 @@ describe("load aigne", () => {
     default: mockOpen,
   }));
 
-  describe("loadAIGNE with process.env.AIGNE_HUB_API_URL", () => {
-    test("should load aigne successfully with default env file", async () => {
-      const { url, close } = await createHonoServer();
-      const mockInquirerPrompt: any = mock(async () => ({ subscribe: "official" }));
-
-      await writeFile(
-        AIGNE_ENV_FILE,
-        stringify({
-          [new URL(url).host]: {
-            AIGNE_HUB_API_KEY: "123",
-            AIGNE_HUB_API_URL: url,
-          },
-          default: {
-            AIGNE_HUB_API_URL: url,
-          },
-        }),
-      );
-
-      const path = join(import.meta.dirname, "../_mocks_");
-      await loadAIGNE(
-        path,
-        { model: "aignehub:openai/gpt-4o" },
-        { inquirerPromptFn: mockInquirerPrompt, runTest: true },
-      );
-
-      const envs = parse(await readFile(AIGNE_ENV_FILE, "utf8").catch(() => stringify({})));
-      const env = envs[new URL(url).host];
-      await rm(AIGNE_ENV_FILE, { force: true });
-
-      expect(env).toBeDefined();
-      expect(env.AIGNE_HUB_API_KEY).toBe("123");
-      close();
-    });
-  });
-
   describe("Encryption Functions", () => {
     describe("encodeEncryptionKey", () => {
       test("should encode encryption key correctly", () => {
@@ -584,6 +549,29 @@ describe("load aigne", () => {
 
       process.env.AIGNE_HUB_API_URL = url;
       await writeFile(AIGNE_ENV_FILE, stringify({}));
+
+      const path = join(import.meta.dirname, "../_mocks_");
+      await loadAIGNE(
+        path,
+        { model: "aignehub:openai/gpt-4o" },
+        { inquirerPromptFn: mockInquirerPrompt, runTest: true },
+      );
+
+      const envs = parse(await readFile(AIGNE_ENV_FILE, "utf8").catch(() => stringify({})));
+      const env = envs[new URL(url).host];
+
+      expect(env).toBeDefined();
+      expect(env.AIGNE_HUB_API_KEY).toBe("test");
+      expect(env.AIGNE_HUB_API_URL).toBe(joinURL(url, "ai-kit"));
+      close();
+    });
+
+    test("should load aigne successfully with default env file", async () => {
+      const { url, close } = await createHonoServer();
+      const mockInquirerPrompt: any = mock(async () => ({ subscribe: "official" }));
+
+      process.env.AIGNE_HUB_API_URL = url;
+      await writeFile(AIGNE_ENV_FILE, stringify({ default: { AIGNE_HUB_API_URL: url } }));
 
       const path = join(import.meta.dirname, "../_mocks_");
       await loadAIGNE(

--- a/packages/cli/test/utils/load-aigne.test.ts
+++ b/packages/cli/test/utils/load-aigne.test.ts
@@ -457,6 +457,33 @@ describe("load aigne", () => {
       close();
     });
 
+    test("should load aigne successfully with default env file with custom url", async () => {
+      const { url, close } = await createHonoServer();
+      const mockInquirerPrompt: any = mock(async (data) => {
+        if (data.type === "input") {
+          return { customUrl: url };
+        }
+        return { subscribe: "custom" };
+      });
+
+      await writeFile(AIGNE_ENV_FILE, stringify({ default: { AIGNE_HUB_API_URL: url } }));
+
+      const path = join(import.meta.dirname, "../_mocks_");
+      await loadAIGNE(
+        path,
+        { model: "aignehub:openai/gpt-4o" },
+        { inquirerPromptFn: mockInquirerPrompt, runTest: true },
+      );
+
+      const envs = parse(await readFile(AIGNE_ENV_FILE, "utf8").catch(() => stringify({})));
+      const env = envs[new URL(url).host];
+
+      expect(env).toBeDefined();
+      expect(env.AIGNE_HUB_API_KEY).toBe("test");
+      expect(env.AIGNE_HUB_API_URL).toBe(joinURL(url, "ai-kit"));
+      close();
+    });
+
     test("should load aigne successfully with no env file", async () => {
       const { url, close } = await createHonoServer();
       const mockInquirerPrompt: any = mock(async () => ({ subscribe: "official" }));

--- a/packages/cli/test/utils/load-aigne.test.ts
+++ b/packages/cli/test/utils/load-aigne.test.ts
@@ -8,7 +8,6 @@ import { joinURL } from "ufo";
 import { parse, stringify } from "yaml";
 import {
   AIGNE_ENV_FILE,
-  checkConnectionStatus,
   connectToAIGNEHub,
   createConnect,
   decodeEncryptionKey,

--- a/packages/cli/test/utils/load-aigne.test.ts
+++ b/packages/cli/test/utils/load-aigne.test.ts
@@ -570,7 +570,6 @@ describe("load aigne", () => {
       const { url, close } = await createHonoServer();
       const mockInquirerPrompt: any = mock(async () => ({ subscribe: "official" }));
 
-      process.env.AIGNE_HUB_API_URL = url;
       await writeFile(AIGNE_ENV_FILE, stringify({ default: { AIGNE_HUB_API_URL: url } }));
 
       const path = join(import.meta.dirname, "../_mocks_");


### PR DESCRIPTION
## Related Issue
https://team.arcblock.io/task/task/607863992588697600
<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. Support setting `aigne-hub-url` via CLI options.
2. Skip AIGNE Hub selection prompt if a custom URL is provided.
3. Add first-time setup prompt to choose AIGNE Hub connection type.
4. Update AIGNE Connect to check and display connection status.

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots
![bug bash](https://github.com/user-attachments/assets/21b4edd2-242a-4258-8811-e220a93fd1be)
<img width="897" height="1189" alt="image" src="https://github.com/user-attachments/assets/1c698b00-5cd0-46d9-9842-27828268ac3c" />

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan
- [x] Verified CLI correctly accepts and overrides `--aigne-hub-url`.
- [x] Tested first-time run behavior: confirmed prompt appears when no existing configuration is found.
- [x] Confirmed that providing a custom AIGNE Hub URL skips the connection prompt.
- [x] Validated that connection status check in `aigne connect` reflects accurate status for both official and custom URLs.

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [x] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [x] This change adds dependencies, and they are placed in dependencies and devDependencies
- [x] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

**Release Notes**

New Feature:
- Added support for custom AIGNE Hub service URLs via `--aigne-hub-url` option across CLI commands
- Enhanced connection management with support for both official and self-hosted AIGNE Hub instances
- Improved prompt handling system to support input-type prompts alongside select prompts

These changes give users more flexibility in connecting to different AIGNE Hub environments and provide better control over their agent interactions through expanded prompt capabilities.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->