### PR TITLE
fix(core): auto trim trailing whitespace for AIAgent with structuredStreamMode enabled

### DIFF
--- a/packages/core/src/utils/structured-stream-extractor.ts
+++ b/packages/core/src/utils/structured-stream-extractor.ts
@@ -27,9 +27,19 @@ export class ExtractMetadataTransform extends TransformStream<
             if (this.state === "none") {
               const found = findMatchIndex(this.buffer, this.cursor, start);
               if (found.start > this.cursor) {
-                const text = this.buffer.slice(this.cursor, found.start);
+                let text = this.buffer.slice(this.cursor, found.start);
                 this.cursor = found.start;
-                controller.enqueue({ delta: { text: { text } } });
+
+                // Trim trailing whitespace from the text
+                const whitespace = text.match(/(?<whitespace>\s+)$/)?.groups?.whitespace;
+                if (whitespace) {
+                  text = text.slice(0, -whitespace.length);
+                  this.cursor -= whitespace.length;
+                }
+
+                if (text) {
+                  controller.enqueue({ delta: { text: { text } } });
+                }
               }
 
               if (found.end) {

--- a/packages/core/test/agents/ai-agent.test.ts
+++ b/packages/core/test/agents/ai-agent.test.ts
@@ -624,11 +624,7 @@ needMoreContext: false
   expect(response).toMatchInlineSnapshot(`
     {
       "confidence": 9,
-      "message": 
-    "Hello, How can I help you today?
-
-    "
-    ,
+      "message": "Hello, How can I help you today?",
       "needMoreContext": false,
     }
   `);
@@ -674,11 +670,7 @@ ${"```"}
   expect(response).toMatchInlineSnapshot(`
     {
       "confidence": 9,
-      "message": 
-    "Hello, How can I help you today?
-
-    "
-    ,
+      "message": "Hello, How can I help you today?",
       "needMoreContext": false,
     }
   `);

--- a/packages/core/test/utils/__snapshots__/structured-stream-extractor.test.ts.snap
+++ b/packages/core/test/utils/__snapshots__/structured-stream-extractor.test.ts.snap
@@ -19,84 +19,120 @@ exports[`ExtractMetadataTransform should extract metadata from structured stream
   {
     "delta": {
       "text": {
-        "text": " ",
+        "text": " How",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "text": "How",
+        "text": " can",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "text": " ",
+        "text": " I",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "text": "can",
+        "text": " help",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "text": " ",
+        "text": " you",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "text": "I",
+        "text": " today",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "text": " ",
+        "text": "?",
+      },
+    },
+  },
+  {
+    "delta": {
+      "json": {
+        "json": {
+          "baz": 123,
+          "foo": "bar",
+        },
+      },
+    },
+  },
+]
+`;
+
+exports[`ExtractMetadataTransform should trim trailing whitespace 1`] = `
+[
+  {
+    "delta": {
+      "text": {
+        "text": "Hello",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "text": "help",
+        "text": ",",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "text": " ",
+        "text": " How",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "text": "you",
+        "text": " can",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "text": " ",
+        "text": " I",
       },
     },
   },
   {
     "delta": {
       "text": {
-        "text": "today",
+        "text": " help",
+      },
+    },
+  },
+  {
+    "delta": {
+      "text": {
+        "text": " you",
+      },
+    },
+  },
+  {
+    "delta": {
+      "text": {
+        "text": " today",
       },
     },
   },

--- a/packages/core/test/utils/structured-stream-extractor.test.ts
+++ b/packages/core/test/utils/structured-stream-extractor.test.ts
@@ -19,3 +19,23 @@ Hello, How can I help you today?<metadata>
 
   expect(readableStreamToArray(stream)).resolves.toMatchSnapshot();
 });
+
+test("ExtractMetadataTransform should trim trailing whitespace", async () => {
+  const stream = stringToAgentResponseStream(`\
+Hello, How can I help you today?
+
+<metadata>
+{
+  "foo": "bar",
+  "baz": 123
+}
+</metadata>`).pipeThrough(
+    new ExtractMetadataTransform({
+      start: "<metadata>",
+      end: "</metadata>",
+      parse: JSON.parse,
+    }),
+  );
+
+  expect(readableStreamToArray(stream)).resolves.toMatchSnapshot();
+});


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(core): auto trim trailing whitespace for AIAgent with structuredStreamMode enabled

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

**Bug Fix**: 
- Improved text processing in structured streams by properly handling trailing whitespace
- Fixed inconsistencies in text segment output when using structured stream mode

**Test**:
- Enhanced test coverage for whitespace handling in structured streams

These changes improve the quality and consistency of text output when using structured streams, ensuring cleaner text segments without unwanted whitespace artifacts. Users will experience more predictable and polished text processing results, particularly in applications that rely on structured stream processing.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->