### PR TITLE
fix(core): hide internal prop toolsMap from trace logs

### DIFF
--- a/packages/core/src/agents/chat-model.ts
+++ b/packages/core/src/agents/chat-model.ts
@@ -119,7 +119,11 @@ export abstract class ChatModel extends Agent<ChatModelInput, ChatModelOutput> {
 
       this.validateToolNames(tools);
 
-      Object.assign(input, { _toolsMap: toolsMap, tools });
+      Object.assign(input, { tools });
+      Object.defineProperty(input, "_toolsMap", {
+        value: toolsMap,
+        enumerable: false,
+      });
     }
   }
 


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(core): hide internal prop toolsMap from trace logs
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

- **Refactor**: Modified how internal tool mappings are handled to prevent unnecessary logging, improving trace output clarity without affecting functionality.

This is a minor internal change that helps keep logs cleaner and more focused on relevant information. End users will see more concise trace logs without any changes to the actual behavior or capabilities of the system.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->