### PR TITLE
fix(cli): highlight URLs in error messages

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -29,8 +29,10 @@ export default createAIGNECommand({ aigneFilePath })
     }
   })
   .parseAsync(hideBin([...process.argv.slice(0, 2), ...process.argv.slice(aigneFilePath ? 3 : 2)]))
-  .catch((error) => {
+  .catch((error: Error) => {
     console.log(""); // Add an empty line for better readability
-    console.error(`${chalk.red("Error:")} ${error.message}`);
+    console.error(
+      `${chalk.red("Error:")} ${error.message.replace(/https?:\/\/[^\s]+/g, (url) => chalk.blue(url))}`,
+    );
     process.exit(1);
   });


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(cli): highlight URLs in error messages
<img width="2770" height="710" alt="Screenshot 2025-08-11 at 10 16 44" src="https://github.com/user-attachments/assets/8b326e76-b999-49d7-a2ba-605161933d5f" />

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
