### PR TITLE
feat(cli): add multilingual support for document publishing

### DIFF
--- a/packages/publish-docs/src/generator.ts
+++ b/packages/publish-docs/src/generator.ts
@@ -68,7 +68,7 @@ export class Generator {
     filePath: string,
   ): Promise<Record<string, { h1?: string; content?: string }>> {
     const i18n: Record<string, { h1?: string; content?: string }> = {};
-    const langs = ["zh"];
+    const langs = ["zh", "zh-TW", "ja", "ko", "es", "fr", "de", "pt", "ru", "it", "ar"];
     for (const lang of langs) {
       const i18nPath = filePath.replace(/\.md$/, `.${lang}.md`);
       try {


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

1. 发布文档添加处理更多语言

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

**Release Notes**

- New Feature: Expanded multilingual documentation support to include 10 additional languages:
  - Chinese (Traditional)
  - Japanese
  - Korean
  - Spanish
  - French
  - German
  - Portuguese
  - Russian
  - Italian
  - Arabic

This enhancement enables users to access documentation in their preferred language, making the platform more accessible to a global audience.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->