### PR TITLE
fix(models): support custom clientId for aigne-hub adapter

### DIFF
--- a/models/aigne-hub/src/blocklet-aigne-hub-model.ts
+++ b/models/aigne-hub/src/blocklet-aigne-hub-model.ts
@@ -83,7 +83,10 @@ export class AIGNEHubChatModel extends ChatModel {
     options.fetchOptions = {
       headers: {
         "x-aigne-hub-client-did":
-          this.options.clientId || process.env.BLOCKLET_APP_PID || process.env.ABT_NODE_DID || "",
+          this.options?.clientOptions?.clientId ||
+          process.env.BLOCKLET_APP_PID ||
+          process.env.ABT_NODE_DID ||
+          "",
       },
       ...options.fetchOptions,
     };

--- a/models/aigne-hub/src/cli-aigne-hub-model.ts
+++ b/models/aigne-hub/src/cli-aigne-hub-model.ts
@@ -38,8 +38,7 @@ export interface AIGNEHubChatModelOptions {
   apiKey?: string;
   model?: string;
   modelOptions?: ChatModelOptions;
-  clientOptions?: OpenAIChatModelOptions["clientOptions"];
-  clientId?: string;
+  clientOptions?: OpenAIChatModelOptions["clientOptions"] & { clientId?: string };
 }
 
 export class AIGNEHubChatModel extends ChatModel {
@@ -75,7 +74,8 @@ export class AIGNEHubChatModel extends ChatModel {
   ): PromiseOrValue<AgentProcessResult<ChatModelOutput>> {
     const { BLOCKLET_APP_PID, ABT_NODE_DID } = process.env;
     const localClientId = `@aigne/aigne-hub:${nodejs.os.hostname()}`;
-    const clientId = this.options.clientId || BLOCKLET_APP_PID || ABT_NODE_DID || localClientId;
+    const clientId =
+      this.options?.clientOptions?.clientId || BLOCKLET_APP_PID || ABT_NODE_DID || localClientId;
 
     options.fetchOptions = {
       headers: { "x-aigne-hub-client-did": clientId },


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
support custom client-id for hub model requests

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [x] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [x] This change adds dependencies, and they are placed in dependencies and devDependencies
- [x] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

**Release Notes**

- New Feature: Added custom client identification support for AIGNE Hub model integration
- Enhancement: Improved client ID resolution with flexible fallback options:
  1. User-provided client ID
  2. Environment variables (BLOCKLET_APP_PID/ABT_NODE_DID)
  3. Hostname-based auto-generation

These changes give users more control over how their applications are identified when interacting with the AIGNE Hub model, while maintaining compatibility with existing environment-based configurations.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->