### PR TITLE
feat(cli): add support for array inputs in CLI arguments

### DIFF
--- a/docs/how-to-guides/complete-cli-workflow.md
+++ b/docs/how-to-guides/complete-cli-workflow.md
@@ -176,14 +176,14 @@ aigne run --input "Hello, please introduce yourself"
 aigne run --model openai:gpt-4.1 --input "Explain the basic concepts of machine learning"
 
 # Use specific Agent and input
-aigne run --entry-agent poem --input-topic "Spring" --input-style "Modern"
+aigne run --entry-agent poem --topic "Spring" --style "Modern"
 ```
 
 ### Adjust Model Parameters
 
 ```bash
 # Set lower temperature for more deterministic output
-aigne run --temperature 0.2 --entry-agent poem --input-topic "Autumn" --input-style "Classical"
+aigne run --temperature 0.2 --entry-agent poem --topic "Autumn" --style "Classical"
 ```
 
 ### Enable Debug Mode

--- a/packages/cli/test/utils/run-with-aigne.test.ts
+++ b/packages/cli/test/utils/run-with-aigne.test.ts
@@ -141,6 +141,7 @@ test("parseAgentInputByCommander should parse input correctly", async () => {
       name: z.string(),
       age: z.number().int(),
     }),
+    inputKey: "message",
   });
 
   const testInputFile = join(import.meta.dirname, "run-with-aigne-test-input.txt");
@@ -161,7 +162,7 @@ test("parseAgentInputByCommander should parse input correctly", async () => {
     parseAgentInputByCommander(agent, {
       input: ["Hello!"],
       inputKey: "message",
-      argv: ["", "", "--input-name", `@${testInputFile}`, "--input-age", "30"],
+      argv: ["", "", "--name", `@${testInputFile}`, "--age", "30"],
     }),
   ).resolves.toEqual({
     name: testInputContent,
@@ -175,9 +176,9 @@ test("parseAgentInputByCommander should parse input correctly", async () => {
       argv: [
         "",
         "",
-        "--input-name",
+        "--name",
         `@${join(import.meta.dirname, "run-with-aigne-test-input-not-exists.txt")}`,
-        "--input-age",
+        "--age",
         "30",
       ],
     }),

--- a/packages/cli/test/utils/yargs.test.ts
+++ b/packages/cli/test/utils/yargs.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+import { inferZodType } from "@aigne/cli/utils/yargs.js";
+import { z } from "zod";
+
+test("inferZodType should infer type correctly", async () => {
+  expect(inferZodType(z.string())).toEqual({ type: "string" });
+  expect(inferZodType(z.number())).toEqual({ type: "number" });
+  expect(inferZodType(z.boolean())).toEqual({ type: "boolean" });
+});
+
+test("inferZodType should handle array types", async () => {
+  expect(inferZodType(z.array(z.string()))).toEqual({ type: "string", array: true });
+  expect(inferZodType(z.array(z.number()))).toEqual({ type: "number", array: true });
+  expect(inferZodType(z.array(z.boolean()))).toEqual({ type: "boolean", array: true });
+});
+
+test("inferZodType should handle optional types", async () => {
+  expect(inferZodType(z.string().optional())).toEqual({ type: "string", optional: true });
+  expect(inferZodType(z.number().optional())).toEqual({ type: "number", optional: true });
+  expect(inferZodType(z.boolean().optional())).toEqual({ type: "boolean", optional: true });
+});
+
+test("inferZodType should handle optional types", async () => {
+  expect(inferZodType(z.string().nullable())).toEqual({ type: "string", optional: true });
+  expect(inferZodType(z.number().nullable())).toEqual({ type: "number", optional: true });
+  expect(inferZodType(z.boolean().nullable())).toEqual({ type: "boolean", optional: true });
+});
+
+test("inferZodType should handle nullish types", async () => {
+  expect(inferZodType(z.string().nullish())).toEqual({ type: "string", optional: true });
+  expect(inferZodType(z.number().nullish())).toEqual({ type: "number", optional: true });
+  expect(inferZodType(z.boolean().nullish())).toEqual({ type: "boolean", optional: true });
+});
+
+test("inferZodType should handle unknown type as string", async () => {
+  expect(inferZodType(z.unknown())).toEqual({ type: "string", optional: true });
+  expect(inferZodType(z.any())).toEqual({ type: "string", optional: true });
+});


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. feat(cli): add support for array inputs in CLI arguments

usage:

```yaml
input_schema:
  type: object
  properties:
    langs:
      type: array
      item:
        type: string
```

```bash
agine CMD --langs en --langs zh
```

<!--
  @example:
    1. Fixed xxx
    3. Improved xxx
    4. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
