### PR TITLE
fix(cli): force upgrade app while load app error

### DIFF
--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -162,14 +162,20 @@ export async function loadApplication({
   name = `@aigne/${name}`;
   dir ??= join(homedir(), ".aigne", "registry.npmjs.org", name);
 
-  const check = forceUpgrade ? undefined : await isInstallationAvailable(dir);
+  let check = forceUpgrade ? undefined : await isInstallationAvailable(dir);
   if (check?.available) {
-    return {
-      aigne: await AIGNE.load(dir),
-      dir,
-      version: check.version,
-      isCache: true,
-    };
+    const aigne = await AIGNE.load(dir).catch(() => null);
+    if (aigne) {
+      return {
+        aigne,
+        dir,
+        version: check.version,
+        isCache: true,
+      };
+    }
+
+    check = undefined;
+    forceUpgrade = true;
   }
 
   const result = await new Listr<{

--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -175,7 +175,6 @@ export async function loadApplication({
     }
 
     check = undefined;
-    forceUpgrade = true;
   }
 
   const result = await new Listr<{

--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -164,7 +164,9 @@ export async function loadApplication({
 
   let check = forceUpgrade ? undefined : await isInstallationAvailable(dir);
   if (check?.available) {
-    const aigne = await AIGNE.load(dir).catch(() => null);
+    const aigne = await AIGNE.load(dir).catch((error) => {
+      console.warn(`Failed to load ${name}, trying to reinstall:`, error.message);
+    });
     if (aigne) {
       return {
         aigne,


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(cli): force upgrade app while load app error
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

- Bug Fix: Improved error handling during application startup to prevent crashes when cache loading fails. The system will now automatically attempt to upgrade instead of failing, providing a more reliable experience for users.

The change makes the CLI more resilient by gracefully handling cache-related issues during startup, ensuring users can continue using the application even if the cache becomes corrupted or inaccessible.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->