### PR TITLE
fix(cli): reduce memory usage of AIGNE CLI

### DIFF
--- a/packages/cli/src/tracer/terminal.ts
+++ b/packages/cli/src/tracer/terminal.ts
@@ -27,7 +27,7 @@ import { AIGNEListr, AIGNEListrRenderer, type AIGNEListrTaskWrapper } from "../u
 import { highlightUrl } from "../utils/string-utils.js";
 import { parseDuration } from "../utils/time.js";
 
-const CREDITS_ERROR_HAS_BEEN_PROCESSED_FLAG = "$credits_error_has_been_processed";
+const CREDITS_ERROR_PROCESSED_FLAG = "$credits_error_processed";
 
 export interface TerminalTracerOptions {
   outputKey?: string;
@@ -196,8 +196,8 @@ export class TerminalTracer {
 
     const onError: AgentHooks["onError"] = async ({ context, agent, error, ...event }) => {
       if ("type" in error && error.type === AIGNE_HUB_CREDITS_NOT_ENOUGH_ERROR_TYPE) {
-        if (!Object.hasOwn(error, CREDITS_ERROR_HAS_BEEN_PROCESSED_FLAG)) {
-          Object.defineProperty(error, CREDITS_ERROR_HAS_BEEN_PROCESSED_FLAG, {
+        if (!Object.hasOwn(error, CREDITS_ERROR_PROCESSED_FLAG)) {
+          Object.defineProperty(error, CREDITS_ERROR_PROCESSED_FLAG, {
             value: true,
             enumerable: false,
           });

--- a/packages/cli/src/tracer/terminal.ts
+++ b/packages/cli/src/tracer/terminal.ts
@@ -27,6 +27,8 @@ import { AIGNEListr, AIGNEListrRenderer, type AIGNEListrTaskWrapper } from "../u
 import { highlightUrl } from "../utils/string-utils.js";
 import { parseDuration } from "../utils/time.js";
 
+const CREDITS_ERROR_HAS_BEEN_PROCESSED_FLAG = "$credits_error_has_been_processed";
+
 export interface TerminalTracerOptions {
   outputKey?: string;
 }
@@ -52,7 +54,7 @@ export class TerminalTracer {
           [this.formatResult(agent, context, result, options)].filter(Boolean),
       },
       [],
-      { concurrent: true },
+      { concurrent: true, exitOnError: false },
     );
     this.listr = listr;
 
@@ -194,12 +196,19 @@ export class TerminalTracer {
 
     const onError: AgentHooks["onError"] = async ({ context, agent, error, ...event }) => {
       if ("type" in error && error.type === AIGNE_HUB_CREDITS_NOT_ENOUGH_ERROR_TYPE) {
-        const retry = await this.promptBuyCredits(error);
+        if (!Object.hasOwn(error, CREDITS_ERROR_HAS_BEEN_PROCESSED_FLAG)) {
+          Object.defineProperty(error, CREDITS_ERROR_HAS_BEEN_PROCESSED_FLAG, {
+            value: true,
+            enumerable: false,
+          });
 
-        console.log("");
+          const retry = await this.promptBuyCredits(error);
 
-        if (retry === "retry") {
-          return { retry: true };
+          console.log("");
+
+          if (retry === "retry") {
+            return { retry: true };
+          }
         }
       }
 

--- a/packages/core/src/agents/agent.ts
+++ b/packages/core/src/agents/agent.ts
@@ -843,9 +843,6 @@ export abstract class Agent<I extends Message = any, O extends Message = any> {
     error: Error,
     options: AgentInvokeOptions,
   ): Promise<{ retry?: boolean; error?: Error }> {
-    if ("$error_has_been_processed" in error && error.$error_has_been_processed) return {};
-    Object.defineProperty(error, "$error_has_been_processed", { value: true, enumerable: false });
-
     logger.error("Invoke agent %s failed with error: %O", this.name, error);
     if (!this.disableEvents) options.context.emit("agentFailed", { agent: this, error });
 

--- a/packages/core/test/aigne/__snapshots__/aigne.test.ts.snap
+++ b/packages/core/test/aigne/__snapshots__/aigne.test.ts.snap
@@ -223,6 +223,15 @@ exports[`AIGNE.invoke should respond progressing chunks (with failed chunks) cor
       },
     },
   },
+  {
+    "progress": {
+      "agent": {
+        "name": "chat",
+      },
+      "error": [Error: Test error],
+      "event": "agentFailed",
+    },
+  },
   [Error: Test error],
 ]
 `;

--- a/packages/sqlite/src/index.node.ts
+++ b/packages/sqlite/src/index.node.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@libsql/client";
 import { drizzle, type LibSQLDatabase } from "drizzle-orm/libsql";
+import type { SQLiteSession } from "drizzle-orm/sqlite-core";
 import type { InitDatabaseOptions } from "./index.js";
 import { withRetry } from "./retry.js";
 
@@ -23,7 +24,13 @@ PRAGMA busy_timeout = 5000;
   }
 
   if ("session" in db && db.session && typeof db.session === "object") {
-    db.session = withRetry(db.session);
+    db.session = withRetry(db.session as SQLiteSession<any, any, any, any>, [
+      "all",
+      "get",
+      "run",
+      "values",
+      "count",
+    ]);
   }
 
   return db;

--- a/packages/sqlite/src/index.node.ts
+++ b/packages/sqlite/src/index.node.ts
@@ -1,16 +1,30 @@
 import { createClient } from "@libsql/client";
 import { drizzle, type LibSQLDatabase } from "drizzle-orm/libsql";
 import type { InitDatabaseOptions } from "./index.js";
+import { withRetry } from "./retry.js";
 
 export async function initDatabase({
   url = ":memory:",
   wal = false,
 }: InitDatabaseOptions = {}): Promise<LibSQLDatabase> {
+  let db: LibSQLDatabase;
+
   if (wal) {
     const client = createClient({ url });
-    await client.execute("PRAGMA journal_mode=WAL;");
-    return drizzle(client);
+    await client.execute(`\
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = normal;
+PRAGMA wal_autocheckpoint = 5000;
+PRAGMA busy_timeout = 5000;
+`);
+    db = drizzle(client);
+  } else {
+    db = drizzle(url);
   }
 
-  return drizzle(url);
+  if ("session" in db && db.session && typeof db.session === "object") {
+    db.session = withRetry(db.session);
+  }
+
+  return db;
 }

--- a/packages/sqlite/src/retry.ts
+++ b/packages/sqlite/src/retry.ts
@@ -1,0 +1,64 @@
+export interface WithRetryOptions {
+  max?: number;
+  backoffBase?: number;
+  backoffExponent?: number;
+  backoffJitter?: number;
+  shouldRetry?: (err: any) => boolean;
+}
+
+function isDBLockedError(error: any): boolean {
+  let err = error;
+
+  while (err) {
+    if (!(err instanceof Error)) return false;
+
+    if (typeof err.message !== "string") return false;
+
+    const isLock = err.message.includes("SQLITE_BUSY");
+    if (isLock) return true;
+
+    err = err.cause;
+  }
+
+  return false;
+}
+
+export function withRetry<T extends object>(
+  db: T,
+  {
+    max = 20,
+    backoffBase = 300,
+    backoffExponent = 1.2,
+    backoffJitter = 100,
+    shouldRetry = isDBLockedError,
+  }: WithRetryOptions = {},
+): T {
+  return new Proxy(db, {
+    get(target, prop) {
+      const val = (target as any)?.[prop];
+      if (typeof val === "function") {
+        return async (...args: any[]) => {
+          let attempt = 1;
+
+          while (true) {
+            try {
+              return await val.apply(target, args);
+            } catch (err) {
+              if (!shouldRetry(err) || ++attempt > max) {
+                throw err;
+              }
+
+              const exp = backoffExponent ** (attempt - 1);
+              const expDelay = backoffBase * exp;
+              const jitter = Math.random() * backoffJitter;
+              const waitTime = Math.floor(expDelay + jitter);
+
+              await new Promise((resolve) => setTimeout(resolve, waitTime));
+            }
+          }
+        };
+      }
+      return val;
+    },
+  });
+}

--- a/packages/sqlite/src/retry.ts
+++ b/packages/sqlite/src/retry.ts
@@ -25,6 +25,7 @@ function isDBLockedError(error: any): boolean {
 
 export function withRetry<T extends object>(
   db: T,
+  methods: (keyof T)[],
   {
     max = 20,
     backoffBase = 300,
@@ -36,7 +37,8 @@ export function withRetry<T extends object>(
   return new Proxy(db, {
     get(target, prop) {
       const val = (target as any)?.[prop];
-      if (typeof val === "function") {
+
+      if (methods.includes(prop as keyof T) && typeof val === "function") {
         return async (...args: any[]) => {
           let attempt = 1;
 

--- a/packages/sqlite/test/retry.test.ts
+++ b/packages/sqlite/test/retry.test.ts
@@ -1,0 +1,41 @@
+import { expect, spyOn, test } from "bun:test";
+import { withRetry } from "../src/retry.js";
+
+test("withRetry should retry on SQLITE_BUSY error", async () => {
+  const db = {
+    run: async (_sql: string) => {
+      return { data: [] };
+    },
+  };
+
+  const runSpy = spyOn(db, "run");
+
+  runSpy
+    .mockRejectedValueOnce(new Error("SQLITE_BUSY: database is locked"))
+    .mockResolvedValueOnce({ data: [] });
+
+  const result = await withRetry(db).run("INSERT INTO test (value) VALUES (1)");
+
+  expect(result).toEqual({ data: [] });
+  expect(runSpy).toHaveBeenCalledTimes(2);
+});
+
+test("withRetry should retry on SQLITE_BUSY error", async () => {
+  const db = {
+    run: async (_sql: string) => {
+      return { data: [] };
+    },
+  };
+
+  const runSpy = spyOn(db, "run");
+
+  runSpy
+    .mockRejectedValueOnce(new Error("SQLITE_BUSY: database is locked"))
+    .mockRejectedValueOnce(new Error("SQLITE_BUSY: database is locked"))
+    .mockResolvedValueOnce({ data: [] });
+
+  const result = withRetry(db, { max: 2 }).run("INSERT INTO test (value) VALUES (1)");
+
+  expect(result).rejects.toThrow("SQLITE_BUSY: database is locked");
+  expect(runSpy).toHaveBeenCalledTimes(2);
+});

--- a/packages/sqlite/test/retry.test.ts
+++ b/packages/sqlite/test/retry.test.ts
@@ -14,13 +14,13 @@ test("withRetry should retry on SQLITE_BUSY error", async () => {
     .mockRejectedValueOnce(new Error("SQLITE_BUSY: database is locked"))
     .mockResolvedValueOnce({ data: [] });
 
-  const result = await withRetry(db).run("INSERT INTO test (value) VALUES (1)");
+  const result = await withRetry(db, ["run"]).run("INSERT INTO test (value) VALUES (1)");
 
   expect(result).toEqual({ data: [] });
   expect(runSpy).toHaveBeenCalledTimes(2);
 });
 
-test("withRetry should retry on SQLITE_BUSY error", async () => {
+test("withRetry should fail after max retries on SQLITE_BUSY error", async () => {
   const db = {
     run: async (_sql: string) => {
       return { data: [] };
@@ -34,7 +34,7 @@ test("withRetry should retry on SQLITE_BUSY error", async () => {
     .mockRejectedValueOnce(new Error("SQLITE_BUSY: database is locked"))
     .mockResolvedValueOnce({ data: [] });
 
-  const result = withRetry(db, { max: 2 }).run("INSERT INTO test (value) VALUES (1)");
+  const result = withRetry(db, ["run"], { max: 2 }).run("INSERT INTO test (value) VALUES (1)");
 
   expect(result).rejects.toThrow("SQLITE_BUSY: database is locked");
   expect(runSpy).toHaveBeenCalledTimes(2);

--- a/packages/transport/test/http-client/__snapshots__/http-client.test.ts.snap
+++ b/packages/transport/test/http-client/__snapshots__/http-client.test.ts.snap
@@ -918,6 +918,18 @@ exports[`AIGNEClient should return error with options {
       },
     },
   },
+  {
+    "progress": {
+      "agent": {
+        "name": "chat",
+      },
+      "contextId": "TEST_CONTEXT_ID",
+      "error": [Error: test llm model error],
+      "event": "agentFailed",
+      "parentContextId": "TEST_PARENT_CONTEXT_ID",
+      "timestamp": 123456,
+    },
+  },
   [Error: test llm model error],
 ]
 `;
@@ -1018,6 +1030,18 @@ exports[`AIGNEClient should return error with options {
       "text": {
         "message": ", world",
       },
+    },
+  },
+  {
+    "progress": {
+      "agent": {
+        "name": "chat",
+      },
+      "contextId": "TEST_CONTEXT_ID",
+      "error": [Error: test llm model error],
+      "event": "agentFailed",
+      "parentContextId": "TEST_PARENT_CONTEXT_ID",
+      "timestamp": 123456,
     },
   },
   [Error: test llm model error],
@@ -1122,6 +1146,18 @@ exports[`AIGNEClient should return error with options {
       },
     },
   },
+  {
+    "progress": {
+      "agent": {
+        "name": "chat",
+      },
+      "contextId": "TEST_CONTEXT_ID",
+      "error": [Error: test llm model error],
+      "event": "agentFailed",
+      "parentContextId": "TEST_PARENT_CONTEXT_ID",
+      "timestamp": 123456,
+    },
+  },
   [Error: test llm model error],
 ]
 `;
@@ -1224,6 +1260,18 @@ exports[`AIGNEClient should return error with options {
       },
     },
   },
+  {
+    "progress": {
+      "agent": {
+        "name": "chat",
+      },
+      "contextId": "TEST_CONTEXT_ID",
+      "error": [Error: test llm model error],
+      "event": "agentFailed",
+      "parentContextId": "TEST_PARENT_CONTEXT_ID",
+      "timestamp": 123456,
+    },
+  },
   [Error: test llm model error],
 ]
 `;
@@ -1324,6 +1372,18 @@ exports[`AIGNEClient should return error with options {
       "text": {
         "message": ", world",
       },
+    },
+  },
+  {
+    "progress": {
+      "agent": {
+        "name": "chat",
+      },
+      "contextId": "TEST_CONTEXT_ID",
+      "error": [Error: test llm model error],
+      "event": "agentFailed",
+      "parentContextId": "TEST_PARENT_CONTEXT_ID",
+      "timestamp": 123456,
     },
   },
   [Error: test llm model error],


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix: improve error handling and propagation in agent execution
2. fix(sqlite): add retry mechanism with exponential backoff for sqlite

<!--
  @example:
    1. Fixed xxx
    4. Improved xxx
    5. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

Release Notes:

- Bug Fix: Enhanced error handling in CLI with improved error messages and visual feedback
- Bug Fix: Resolved SQLite database locking issues with automatic retry mechanism
- Refactor: Optimized core agent performance and reliability
- Refactor: Improved SQLite database performance with WAL optimizations

These changes improve system stability and reliability by addressing database locking issues, enhancing error reporting, and optimizing core performance. Users will experience fewer database-related interruptions and clearer error messages when issues occur.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->