### PR TITLE
fix(cli): use corepack instead of npm install deps

### DIFF
--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -262,9 +262,10 @@ async function isInstallationAvailable(
 
 async function installDependencies(dir: string, { log }: { log?: (log: string) => void } = {}) {
   await new Promise<void>((resolve, reject) => {
-    const child = spawn("npm", ["install", "--omit", "dev", "--verbose"], {
+    const child = spawn("corepack", ["npm", "install", "--omit", "dev", "--verbose"], {
       cwd: dir,
       stdio: "pipe",
+      shell: process.platform === "win32",
     });
 
     child.stdout.on("data", (data) => {

--- a/packages/cli/test/commands/app.test.ts
+++ b/packages/cli/test/commands/app.test.ts
@@ -353,11 +353,12 @@ test("loadApplication should load doc-smith correctly", async () => {
   await app.loadApplication({ name: "doc-smith", dir: tmp });
 
   expect(spawn.mock.lastCall).toEqual([
-    "npm",
-    ["install", "--omit", "dev", "--verbose"],
+    "corepack",
+    ["npm", "install", "--omit", "dev", "--verbose"],
     {
       cwd: tmp,
       stdio: "pipe",
+      shell: process.platform === "win32",
     },
   ]);
 


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(cli): use corepack instead of npm install deps
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

**Chore**: Improved Cross-Platform Package Installation

- Chore: Enhanced dependency installation process to use `corepack` for better cross-platform compatibility
- Bug Fix: Added Windows platform support for package installation commands
- Test: Updated test suite to reflect new installation process

This change improves the reliability of package installation across different operating systems while maintaining existing functionality. Users should experience more consistent behavior when installing dependencies, particularly on Windows systems.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->