### PR TITLE
fix(cli): only show ascii logo on help and errors

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -27,6 +27,7 @@ export default createAIGNECommand({ aigneFilePath })
       yargs.showHelp();
 
       console.error(`\n${message}`);
+      process.exit(1);
     }
   })
   .parseAsync(hideBin([...process.argv.slice(0, 2), ...process.argv.slice(aigneFilePath ? 3 : 2)]))

--- a/packages/cli/src/commands/aigne.ts
+++ b/packages/cli/src/commands/aigne.ts
@@ -11,11 +11,9 @@ import { createServeMCPCommand } from "./serve-mcp.js";
 import { createTestCommand } from "./test.js";
 
 export function createAIGNECommand(options?: { aigneFilePath?: string }) {
-  console.log(asciiLogo);
-
   return yargs()
     .scriptName("aigne")
-    .usage("CLI for AIGNE framework")
+    .usage(`${asciiLogo}\n$0 <command> [options]`)
     .version(AIGNE_CLI_VERSION)
     .command(createRunCommand(options))
     .command(createTestCommand(options))
@@ -28,5 +26,6 @@ export function createAIGNECommand(options?: { aigneFilePath?: string }) {
     .demandCommand()
     .alias("help", "h")
     .alias("version", "v")
+    .wrap(null)
     .strict();
 }

--- a/packages/cli/test/commands/__snapshots__/aigne.test.ts.snap
+++ b/packages/cli/test/commands/__snapshots__/aigne.test.ts.snap
@@ -1,26 +1,34 @@
-// Bun Snapshot v1, https://goo.gl/fbAQLP
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`aigne command should print help if no any subcommand 1`] = `
 [
   [
     
-"CLI for AIGNE framework
+"
+     \x1B[38;2;79;172;254m_\x1B[39m    \x1B[38;2;80;170;254m_\x1B[39m\x1B[38;2;81;169;253m_\x1B[39m\x1B[38;2;81;167;253m_\x1B[39m \x1B[38;2;82;166;253m_\x1B[39m\x1B[38;2;83;164;252m_\x1B[39m\x1B[38;2;84;163;252m_\x1B[39m\x1B[38;2;85;161;252m_\x1B[39m \x1B[38;2;86;159;251m_\x1B[39m   \x1B[38;2;86;158;251m_\x1B[39m \x1B[38;2;87;156;251m_\x1B[39m\x1B[38;2;88;155;251m_\x1B[39m\x1B[38;2;89;153;250m_\x1B[39m\x1B[38;2;90;152;250m_\x1B[39m\x1B[38;2;90;150;250m_\x1B[39m
+    \x1B[38;2;91;148;249m/\x1B[39m \x1B[38;2;92;147;249m\\\x1B[39m  \x1B[38;2;93;145;249m|\x1B[39m\x1B[38;2;94;144;248m_\x1B[39m \x1B[38;2;95;142;248m_\x1B[39m\x1B[38;2;95;141;248m/\x1B[39m \x1B[38;2;96;139;247m_\x1B[39m\x1B[38;2;97;138;247m_\x1B[39m\x1B[38;2;98;136;247m_\x1B[39m\x1B[38;2;99;134;246m|\x1B[39m \x1B[38;2;99;133;246m\\\x1B[39m \x1B[38;2;100;131;246m|\x1B[39m \x1B[38;2;101;130;245m|\x1B[39m \x1B[38;2;102;128;245m_\x1B[39m\x1B[38;2;103;127;245m_\x1B[39m\x1B[38;2;104;125;244m_\x1B[39m\x1B[38;2;104;123;244m_\x1B[39m\x1B[38;2;105;122;244m|\x1B[39m
+   \x1B[38;2;106;120;244m/\x1B[39m \x1B[38;2;107;119;243m_\x1B[39m \x1B[38;2;108;117;243m\\\x1B[39m  \x1B[38;2;108;116;243m|\x1B[39m \x1B[38;2;109;114;242m|\x1B[39m \x1B[38;2;110;112;242m|\x1B[39m  \x1B[38;2;111;111;242m_\x1B[39m\x1B[38;2;112;109;241m|\x1B[39m  \x1B[38;2;113;108;241m\\\x1B[39m\x1B[38;2;113;106;241m|\x1B[39m \x1B[38;2;114;105;240m|\x1B[39m  \x1B[38;2;115;103;240m_\x1B[39m\x1B[38;2;118;103;239m|\x1B[39m
+  \x1B[38;2;121;103;237m/\x1B[39m \x1B[38;2;124;103;236m_\x1B[39m\x1B[38;2;127;103;234m_\x1B[39m\x1B[38;2;130;103;233m_\x1B[39m \x1B[38;2;133;103;231m\\\x1B[39m \x1B[38;2;136;103;230m|\x1B[39m \x1B[38;2;139;104;228m|\x1B[39m \x1B[38;2;142;104;227m|\x1B[39m\x1B[38;2;145;104;225m_\x1B[39m\x1B[38;2;148;104;224m|\x1B[39m \x1B[38;2;150;104;222m|\x1B[39m \x1B[38;2;153;104;221m|\x1B[39m\x1B[38;2;156;104;219m\\\x1B[39m  \x1B[38;2;159;104;218m|\x1B[39m \x1B[38;2;162;104;216m|\x1B[39m\x1B[38;2;165;104;215m_\x1B[39m\x1B[38;2;168;104;213m_\x1B[39m\x1B[38;2;171;104;212m_\x1B[39m
+ \x1B[38;2;174;104;210m/\x1B[39m\x1B[38;2;177;104;209m_\x1B[39m\x1B[38;2;180;104;207m/\x1B[39m   \x1B[38;2;183;105;206m\\\x1B[39m\x1B[38;2;186;105;204m_\x1B[39m\x1B[38;2;189;105;203m\\\x1B[39m\x1B[38;2;192;105;201m_\x1B[39m\x1B[38;2;195;105;200m_\x1B[39m\x1B[38;2;198;105;198m_\x1B[39m\x1B[38;2;201;105;197m\\\x1B[39m\x1B[38;2;204;105;195m_\x1B[39m\x1B[38;2;207;105;194m_\x1B[39m\x1B[38;2;210;105;192m_\x1B[39m\x1B[38;2;213;105;191m_\x1B[39m\x1B[38;2;215;105;189m|\x1B[39m\x1B[38;2;218;105;188m_\x1B[39m\x1B[38;2;221;105;186m|\x1B[39m \x1B[38;2;224;105;185m\\\x1B[39m\x1B[38;2;227;106;183m_\x1B[39m\x1B[38;2;230;106;182m|\x1B[39m\x1B[38;2;233;106;180m_\x1B[39m\x1B[38;2;236;106;179m_\x1B[39m\x1B[38;2;239;106;177m_\x1B[39m\x1B[38;2;242;106;176m_\x1B[39m\x1B[38;2;245;106;174m_\x1B[39m\x1B[38;2;248;106;173m|\x1B[39m
+
+\x1B[36m            vxx.xx.xx\x1B[39m
+
+
+aigne <command> [options]
 
 Commands:
   aigne run [path]     Run AIGNE from the specified agent
   aigne test           Run tests in the specified agents directory
   aigne create [path]  Create a new aigne project with agent config files
-  aigne serve-mcp      Serve the agents in the specified directory as a MCP
-                       server (streamable http)
+  aigne serve-mcp      Serve the agents in the specified directory as a MCP server (streamable http)
   aigne observe        Start the observability server
-  aigne doc-smith      Generate and maintain project docs — powered by agents.
-                                                        [aliases: docsmith, doc]
+  aigne doc-smith      Generate and maintain project docs — powered by agents.  [aliases: docsmith, doc]
   aigne hub <command>  Manage AIGNE Hub connections
   aigne deploy         Deploy an aigne application
 
 Options:
-  -h, --help     Show help                                             [boolean]
-  -v, --version  Show version number                                   [boolean]"
+  -h, --help     Show help  [boolean]
+  -v, --version  Show version number  [boolean]"
 ,
   ],
   [],

--- a/packages/cli/test/commands/aigne.test.ts
+++ b/packages/cli/test/commands/aigne.test.ts
@@ -1,5 +1,6 @@
 import { expect, spyOn, test } from "bun:test";
 import { createAIGNECommand } from "@aigne/cli/commands/aigne.js";
+import { AIGNE_CLI_VERSION } from "@aigne/cli/constants";
 
 test("aigne command should parse --version correctly", async () => {
   const command = createAIGNECommand();
@@ -26,7 +27,11 @@ test("aigne command should print help if no any subcommand", async () => {
 
   await command.parseAsync([]);
 
-  expect(log.mock.calls).toMatchSnapshot();
+  expect(
+    log.mock.calls.map((i) =>
+      i.map((j) => (typeof j === "string" ? j.replaceAll(AIGNE_CLI_VERSION, "xx.xx.xx") : j)),
+    ),
+  ).toMatchSnapshot();
 
   exit.mockRestore();
   log.mockRestore();


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(cli): only show ascii logo on help and errors
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

Release Notes:

- Refactor: Enhanced CLI error handling with clearer error messages and proper exit codes
- Style: Improved help command display with better formatting and visual organization
- Style: Relocated ASCII logo to usage text for better visual hierarchy
- Test: Updated version testing infrastructure to handle dynamic version numbers

These changes improve the overall user experience when interacting with the CLI, making error messages more informative and help documentation easier to read. The updates maintain backward compatibility while providing a more polished interface.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->