### PR TITLE
fix(core): improve nested prompt file resolution

### DIFF
--- a/packages/core/src/loader/index.ts
+++ b/packages/core/src/loader/index.ts
@@ -196,7 +196,8 @@ async function parseAgent(
       });
     }
     case "image": {
-      if (!instructions) throw new Error(`Missing instructions for image agent: ${path}`);
+      if (!instructions)
+        throw new Error(`Missing required instructions for image agent at path: ${path}`);
 
       return ImageAgent.from({
         ...baseOptions,

--- a/packages/core/src/loader/index.ts
+++ b/packages/core/src/loader/index.ts
@@ -56,10 +56,7 @@ export async function load(path: string, options: LoadOptions = {}): Promise<AIG
   );
   const allAgents: { [path: string]: Agent } = Object.fromEntries(
     await Promise.all(
-      Array.from(allAgentPaths).map(async (path) => [
-        path,
-        await loadAgent(path, { ...options, rootDir }),
-      ]),
+      Array.from(allAgentPaths).map(async (path) => [path, await loadAgent(path, options)]),
     ),
   );
 
@@ -89,7 +86,7 @@ export async function load(path: string, options: LoadOptions = {}): Promise<AIG
 
 export async function loadAgent(
   path: string,
-  options?: LoadOptions & { rootDir?: string },
+  options?: LoadOptions,
   agentOptions?: AgentOptions,
 ): Promise<Agent> {
   if ([".js", ".mjs", ".ts", ".mts"].includes(nodejs.path.extname(path))) {
@@ -110,7 +107,7 @@ export async function loadAgent(
 async function loadNestAgent(
   path: string,
   agent: NestAgentSchema,
-  options?: LoadOptions & { rootDir?: string },
+  options?: LoadOptions,
 ): Promise<Agent> {
   return typeof agent === "object" && "type" in agent
     ? parseAgent(path, agent, options)
@@ -125,7 +122,7 @@ async function loadNestAgent(
 async function parseHooks(
   path: string,
   hooks?: HooksSchema | HooksSchema[],
-  options?: LoadOptions & { rootDir?: string },
+  options?: LoadOptions,
 ): Promise<AgentHooks[] | undefined> {
   hooks = [hooks].flat().filter(isNonNullable);
   if (!hooks.length) return undefined;
@@ -155,11 +152,9 @@ async function parseHooks(
 async function parseAgent(
   path: string,
   agent: Awaited<ReturnType<typeof loadAgentFromYamlFile>>,
-  options?: LoadOptions & { rootDir?: string },
+  options?: LoadOptions,
   agentOptions?: AgentOptions,
 ): Promise<Agent> {
-  const workingDir = options?.rootDir ?? nodejs.path.dirname(path);
-
   const skills =
     "skills" in agent
       ? agent.skills &&
@@ -186,17 +181,26 @@ async function parseAgent(
     ],
   };
 
+  let instructions: PromptBuilder | undefined;
+  if ("instructions" in agent && agent.instructions) {
+    instructions = PromptBuilder.from(agent.instructions.content, {
+      workingDir: nodejs.path.dirname(agent.instructions.path),
+    });
+  }
+
   switch (agent.type) {
     case "ai": {
       return AIAgent.from({
         ...baseOptions,
-        instructions: agent.instructions && PromptBuilder.from(agent.instructions, { workingDir }),
+        instructions,
       });
     }
     case "image": {
+      if (!instructions) throw new Error(`Missing instructions for image agent: ${path}`);
+
       return ImageAgent.from({
         ...baseOptions,
-        instructions: PromptBuilder.from(agent.instructions, { workingDir }),
+        instructions,
       });
     }
     case "mcp": {

--- a/packages/core/test-agents/prompts/nested/prompt-c.md
+++ b/packages/core/test-agents/prompts/nested/prompt-c.md
@@ -1,0 +1,1 @@
+This is content of prompt-c.md

--- a/packages/core/test-agents/prompts/nested/prompt-d.md
+++ b/packages/core/test-agents/prompts/nested/prompt-d.md
@@ -1,0 +1,1 @@
+This is content of prompt-d.md

--- a/packages/core/test-agents/prompts/prompt-b.md
+++ b/packages/core/test-agents/prompts/prompt-b.md
@@ -1,1 +1,4 @@
 Please output in native English
+
+{% include "./nested/prompt-c.md" %}
+{% include "nested/prompt-d.md" %}

--- a/packages/core/test/loader/loader.test.ts
+++ b/packages/core/test/loader/loader.test.ts
@@ -257,6 +257,11 @@ test("loadAgent should support nested relative prompt paths", async () => {
 
     Please output in native English
 
+    This is content of prompt-c.md
+
+    This is content of prompt-d.md
+
+
     "
     ,
           "name": undefined,


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(core): improve nested prompt file resolution
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

**Release Notes**

Refactor: Simplified Agent Configuration System
- Refactor: Streamlined instruction handling for AI and image agents with improved path resolution
- Refactor: Enhanced error handling for missing image agent instructions
- Refactor: Simplified prompt template resolution with direct file path construction
- Test: Added verification for nested prompt file resolution

These changes improve the reliability and maintainability of agent configurations while maintaining backward compatibility. Users should experience more predictable behavior when specifying instruction paths and working with prompt templates.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->