### PR TITLE
fix: handle absolute paths in agent YAML prompt URLs

### DIFF
--- a/packages/core/src/loader/agent-yaml.ts
+++ b/packages/core/src/loader/agent-yaml.ts
@@ -178,6 +178,7 @@ export async function parseAgentFile(path: string, data: object): Promise<AgentS
             inputKey: optionalize(z.string()),
             outputKey: optionalize(z.string()),
             toolChoice: optionalize(z.nativeEnum(AIAgentToolChoice)),
+            structuredStreamMode: optionalize(z.boolean()),
           })
           .extend(baseAgentSchema.shape),
         z

--- a/packages/core/src/loader/agent-yaml.ts
+++ b/packages/core/src/loader/agent-yaml.ts
@@ -160,7 +160,11 @@ export async function parseAgentFile(path: string, data: object): Promise<AgentS
       .transform((v) =>
         typeof v === "string"
           ? { content: v, path }
-          : Promise.resolve(nodejs.path.join(nodejs.path.dirname(path), v.url)).then((path) =>
+          : Promise.resolve(
+              nodejs.path.isAbsolute(v.url)
+                ? v.url
+                : nodejs.path.join(nodejs.path.dirname(path), v.url),
+            ).then((path) =>
               nodejs.fs.readFile(path, "utf8").then((content) => ({ content, path })),
             ),
       ) as unknown as ZodType<Instructions>;


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix: handle absolute paths in agent YAML prompt URLs
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

Bug Fix: Improved path handling for agent YAML prompt URLs

- Bug Fix: Fixed handling of absolute file paths in agent YAML configurations, ensuring both absolute and relative paths work correctly when loading prompt files
- Impact: Users can now specify either absolute or relative paths in their agent YAML files without path resolution issues

This change makes the system more flexible and reliable when working with different file path formats in agent configurations.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->