### PR TITLE
feat(cli): add web-smith command to @aigne/cli

### DIFF
--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -27,6 +27,11 @@ const builtinApps = [
     describe: "Generate and maintain project docs — powered by agents.",
     aliases: ["docsmith", "doc"],
   },
+  {
+    name: "web-smith",
+    describe: "Generate and maintain project website pages — powered by agents.",
+    aliases: ["websmith", "web"],
+  },
 ];
 
 export function createAppCommands(): CommandModule[] {
@@ -35,7 +40,9 @@ export function createAppCommands(): CommandModule[] {
     describe: app.describe,
     aliases: app.aliases,
     builder: async (yargs) => {
-      const { aigne, dir, version, isCache } = await loadApplication({ name: app.name });
+      const { aigne, dir, version, isCache } = await loadApplication({
+        name: app.name,
+      });
 
       yargs
         .option("model", {
@@ -44,10 +51,20 @@ export function createAppCommands(): CommandModule[] {
             "Model to use for the application, example: openai:gpt-4.1 or google:gemini-2.5-flash",
         })
         .command(serveMcpCommandModule({ name: app.name, dir }))
-        .command(upgradeCommandModule({ name: app.name, dir, isLatest: !isCache, version }));
+        .command(
+          upgradeCommandModule({
+            name: app.name,
+            dir,
+            isLatest: !isCache,
+            version,
+          }),
+        );
 
       if (aigne.cli.chat) {
-        yargs.command({ ...agentCommandModule({ dir, agent: aigne.cli.chat }), command: "$0" });
+        yargs.command({
+          ...agentCommandModule({ dir, agent: aigne.cli.chat }),
+          command: "$0",
+        });
       }
 
       for (const agent of aigne.cli.agents) {

--- a/packages/cli/test/commands/__snapshots__/aigne.test.ts.snap
+++ b/packages/cli/test/commands/__snapshots__/aigne.test.ts.snap
@@ -1,4 +1,4 @@
-// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+// Bun Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`aigne command should print help if no any subcommand 1`] = `
 [
@@ -23,6 +23,7 @@ Commands:
   aigne serve-mcp                 Serve the agents in the specified directory as a MCP server (streamable http)
   aigne observe                   Start the observability server
   aigne doc-smith                 Generate and maintain project docs — powered by agents.  [aliases: docsmith, doc]
+  aigne web-smith                 Generate and maintain project website pages — powered by agents.  [aliases: websmith, web]
   aigne hub <command>             Manage AIGNE Hub connections
   aigne deploy                    Deploy an aigne application
 

--- a/packages/cli/test/commands/app.test.ts
+++ b/packages/cli/test/commands/app.test.ts
@@ -26,6 +26,8 @@ test("app command should register applications to yargs", async () => {
     Commands:
       aigne doc-smith  Generate and maintain project docs — powered by agents.
                                                             [aliases: docsmith, doc]
+      aigne web-smith  Generate and maintain project website pages — powered by
+                       agents.                              [aliases: websmith, web]
 
     Options:
       --help     Show help                                                 [boolean]

--- a/packages/cli/test/tracer/__snapshots__/terminal.test.ts.snap
+++ b/packages/cli/test/tracer/__snapshots__/terminal.test.ts.snap
@@ -1,4 +1,4 @@
-// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+// Bun Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TerminalTracer should work correctly 1`] = `
 {


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist


- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts


<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

Release Notes:

- New Feature: Added "web-smith" command to CLI with aliases "websmith" and "web" for generating and maintaining project website pages using agents
- Test: Updated test snapshots and coverage for new web-smith command
- Chore: Updated URL reference in test snapshot documentation from bun.sh to goo.gl

These changes expand the CLI's website management capabilities, providing users with a dedicated command for website-related tasks alongside existing features like doc-smith and deploy.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->