### PR TITLE
feat(cli): support using beta apps with environments

### DIFF
--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -241,7 +241,6 @@ export async function loadApplication({
           const info = await getNpmTgzInfo(name);
           Object.assign(ctx, info);
 
-          // Update task title to show if beta version is being used
           const useBeta = shouldUseBetaApps();
           if (useBeta && ctx.version.includes("beta")) {
             task.title = `Fetching ${name} metadata (using beta version)`;
@@ -252,11 +251,7 @@ export async function loadApplication({
         title: `Downloading ${name}`,
         skip: (ctx) => ctx.version === check?.version,
         task: async (ctx, task) => {
-          // Update task title to show version being downloaded
-          const versionInfo = ctx.version.includes("beta")
-            ? ` (beta v${ctx.version})`
-            : ` (v${ctx.version})`;
-          task.title = `Downloading ${name}${versionInfo}`;
+          task.title = `Downloading ${name}(v${ctx.version})`;
 
           await rm(dir, { force: true, recursive: true });
           await mkdir(dir, { recursive: true });

--- a/packages/cli/test/commands/app.test.ts
+++ b/packages/cli/test/commands/app.test.ts
@@ -382,3 +382,85 @@ test("loadApplication should load doc-smith correctly", async () => {
 
   await fs.rm(tmp, { recursive: true, force: true });
 }, 60e3);
+
+test("beta version support should work with AIGNE_USE_BETA_APPS environment variable", async () => {
+  // Mock fetch to return package info with beta version
+  const mockFetch = mock().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({
+      "dist-tags": {
+        latest: "1.0.0",
+        beta: "1.1.0-beta.1"
+      },
+      versions: {
+        "1.0.0": {
+          dist: { tarball: "https://registry.npmjs.org/@aigne/doc-smith/-/doc-smith-1.0.0.tgz" }
+        },
+        "1.1.0-beta.1": {
+          dist: { tarball: "https://registry.npmjs.org/@aigne/doc-smith/-/doc-smith-1.1.0-beta.1.tgz" }
+        }
+      }
+    })
+  });
+
+  global.fetch = mockFetch as any;
+
+  // Test without beta flag - should use latest
+  delete process.env.AIGNE_USE_BETA_APPS;
+  const { getNpmTgzInfo } = await import("@aigne/cli/commands/app");
+  const latestInfo = await getNpmTgzInfo("@aigne/doc-smith");
+  expect(latestInfo.version).toBe("1.0.0");
+  expect(latestInfo.url).toContain("doc-smith-1.0.0.tgz");
+
+  // Test with beta flag set to "true" - should use beta
+  process.env.AIGNE_USE_BETA_APPS = "true";
+  // Need to reimport to pick up environment variable change
+  delete require.cache[require.resolve("@aigne/cli/commands/app")];
+  const { getNpmTgzInfo: getNpmTgzInfoBeta } = await import("@aigne/cli/commands/app");
+  const betaInfo = await getNpmTgzInfoBeta("@aigne/doc-smith");
+  expect(betaInfo.version).toBe("1.1.0-beta.1");
+  expect(betaInfo.url).toContain("doc-smith-1.1.0-beta.1.tgz");
+
+  // Test with beta flag set to "1" - should use beta
+  process.env.AIGNE_USE_BETA_APPS = "1";
+  delete require.cache[require.resolve("@aigne/cli/commands/app")];
+  const { getNpmTgzInfo: getNpmTgzInfoOne } = await import("@aigne/cli/commands/app");
+  const betaInfo2 = await getNpmTgzInfoOne("@aigne/doc-smith");
+  expect(betaInfo2.version).toBe("1.1.0-beta.1");
+
+  // Cleanup
+  delete process.env.AIGNE_USE_BETA_APPS;
+  mockFetch.mockRestore();
+});
+
+test("beta version support should fallback to latest when no beta available", async () => {
+  // Mock fetch to return package info without beta version
+  const mockFetch = mock().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({
+      "dist-tags": {
+        latest: "1.0.0"
+        // No beta tag
+      },
+      versions: {
+        "1.0.0": {
+          dist: { tarball: "https://registry.npmjs.org/@aigne/doc-smith/-/doc-smith-1.0.0.tgz" }
+        }
+      }
+    })
+  });
+
+  global.fetch = mockFetch as any;
+
+  // Test with beta flag but no beta version available - should fallback to latest
+  process.env.AIGNE_USE_BETA_APPS = "true";
+  delete require.cache[require.resolve("@aigne/cli/commands/app")];
+  const { getNpmTgzInfo } = await import("@aigne/cli/commands/app");
+  const info = await getNpmTgzInfo("@aigne/doc-smith");
+  expect(info.version).toBe("1.0.0");
+  expect(info.url).toContain("doc-smith-1.0.0.tgz");
+
+  // Cleanup
+  delete process.env.AIGNE_USE_BETA_APPS;
+  mockFetch.mockRestore();
+});

--- a/packages/cli/test/commands/app.test.ts
+++ b/packages/cli/test/commands/app.test.ts
@@ -387,20 +387,23 @@ test("beta version support should work with AIGNE_USE_BETA_APPS environment vari
   // Mock fetch to return package info with beta version
   const mockFetch = mock().mockResolvedValue({
     ok: true,
-    json: () => Promise.resolve({
-      "dist-tags": {
-        latest: "1.0.0",
-        beta: "1.1.0-beta.1"
-      },
-      versions: {
-        "1.0.0": {
-          dist: { tarball: "https://registry.npmjs.org/@aigne/doc-smith/-/doc-smith-1.0.0.tgz" }
+    json: () =>
+      Promise.resolve({
+        "dist-tags": {
+          latest: "1.0.0",
+          beta: "1.1.0-beta.1",
         },
-        "1.1.0-beta.1": {
-          dist: { tarball: "https://registry.npmjs.org/@aigne/doc-smith/-/doc-smith-1.1.0-beta.1.tgz" }
-        }
-      }
-    })
+        versions: {
+          "1.0.0": {
+            dist: { tarball: "https://registry.npmjs.org/@aigne/doc-smith/-/doc-smith-1.0.0.tgz" },
+          },
+          "1.1.0-beta.1": {
+            dist: {
+              tarball: "https://registry.npmjs.org/@aigne/doc-smith/-/doc-smith-1.1.0-beta.1.tgz",
+            },
+          },
+        },
+      }),
   });
 
   global.fetch = mockFetch as any;
@@ -437,17 +440,18 @@ test("beta version support should fallback to latest when no beta available", as
   // Mock fetch to return package info without beta version
   const mockFetch = mock().mockResolvedValue({
     ok: true,
-    json: () => Promise.resolve({
-      "dist-tags": {
-        latest: "1.0.0"
-        // No beta tag
-      },
-      versions: {
-        "1.0.0": {
-          dist: { tarball: "https://registry.npmjs.org/@aigne/doc-smith/-/doc-smith-1.0.0.tgz" }
-        }
-      }
-    })
+    json: () =>
+      Promise.resolve({
+        "dist-tags": {
+          latest: "1.0.0",
+          // No beta tag
+        },
+        versions: {
+          "1.0.0": {
+            dist: { tarball: "https://registry.npmjs.org/@aigne/doc-smith/-/doc-smith-1.0.0.tgz" },
+          },
+        },
+      }),
   });
 
   global.fetch = mockFetch as any;


### PR DESCRIPTION
## Related Issue

We need to support beta version apps (DocSmith, WebSmith)

### Major Changes

1. Support using beta version of sub apps by using AIGNE_USE_BETA_APPS

### Screenshots

<img width="677" height="215" alt="Screenshot 2025-09-16 at 11 40 44" src="https://github.com/user-attachments/assets/3b8484a3-7e9e-48ef-b57a-56244aae1601" />

### Test Plan

- [x] Unit tests
- [x] Manual tests

### Checklist

- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

**Release Notes**

- New Feature: Added support for beta application versions through the `AIGNE_USE_BETA_APPS` environment variable, allowing developers to test pre-release versions of applications
- Test: Enhanced test coverage for beta version selection and fallback behavior

This update enables developers to opt into beta versions of applications by setting an environment variable, while maintaining stable release access as the default behavior. The system automatically falls back to stable versions if beta versions are unavailable.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->