### PR TITLE
fix(models): correct doubao image model name

### DIFF
--- a/models/doubao/src/doubao-image-model.ts
+++ b/models/doubao/src/doubao-image-model.ts
@@ -115,7 +115,7 @@ export class DoubaoImageModel extends ImageModel<DoubaoImageModelInput, DoubaoIm
         "responseFormat",
         "watermark",
       ],
-      "doubao-seedream-3.0-t2i": [
+      "doubao-seedream-3-0-t2i": [
         "model",
         "prompt",
         "size",
@@ -124,7 +124,7 @@ export class DoubaoImageModel extends ImageModel<DoubaoImageModelInput, DoubaoIm
         "responseFormat",
         "watermark",
       ],
-      "doubao-seededit-3.0-i2i": [
+      "doubao-seededit-3-0-i2i": [
         "model",
         "prompt",
         "image",


### PR DESCRIPTION
## Related Issue
https://team.arcblock.io/task/task/622566876047736832
<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
support the correct 3.0 model
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots
<img width="1366" height="938" alt="image" src="https://github.com/user-attachments/assets/0f7d5d77-9a42-4fd5-a9e6-8ba7944d5285" />
<img width="1536" height="906" alt="image" src="https://github.com/user-attachments/assets/91ea491b-a228-4de0-9d7a-de182c5ba3e3" />

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->


<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

- Chore: Updated model name formatting in Doubao image models, replacing dots with hyphens in version numbers (e.g., "3.0" to "3-0") for consistent naming conventions

This is a minor technical change that standardizes model naming patterns but has no functional impact on end users.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->