### PR TITLE
fix: correct flat import, remove default import error

### DIFF
--- a/blocklets/aigne-runtime/src/locales/en.tsx
+++ b/blocklets/aigne-runtime/src/locales/en.tsx
@@ -1,6 +1,6 @@
-import flat from "flat";
+import { flatten } from "flat";
 
-export default flat({
-  reference_links: "Reference Links",
-  ask_anything: "Please enter your question",
+export default flatten({
+	reference_links: "Reference Links",
+	ask_anything: "Please enter your question",
 });

--- a/blocklets/aigne-runtime/src/locales/en.tsx
+++ b/blocklets/aigne-runtime/src/locales/en.tsx
@@ -1,6 +1,6 @@
 import { flatten } from "flat";
 
 export default flatten({
-	reference_links: "Reference Links",
-	ask_anything: "Please enter your question",
+  reference_links: "Reference Links",
+  ask_anything: "Please enter your question",
 });

--- a/blocklets/aigne-runtime/src/locales/zh.tsx
+++ b/blocklets/aigne-runtime/src/locales/zh.tsx
@@ -1,6 +1,6 @@
-import flat from "flat";
+import { flatten } from "flat";
 
-export default flat({
-  ask_anything: "请输入您的问题",
-  reference_links: "参考链接",
+export default flatten({
+	ask_anything: "请输入您的问题",
+	reference_links: "参考链接",
 });

--- a/blocklets/aigne-runtime/src/locales/zh.tsx
+++ b/blocklets/aigne-runtime/src/locales/zh.tsx
@@ -1,6 +1,6 @@
 import { flatten } from "flat";
 
 export default flatten({
-	ask_anything: "请输入您的问题",
-	reference_links: "参考链接",
+  ask_anything: "请输入您的问题",
+  reference_links: "参考链接",
 });


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
correct flat import, remove default import error
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

**Chore**: 
- Updated internationalization (i18n) module imports to use the correct named import `flatten` instead of `flat`

This is a minor internal maintenance change that updates how the localization files handle their dependencies. There is no impact on end-users or the application's functionality, as both English and Chinese language support continue to work as before.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->