### PR TITLE
fix: replace import.meta.dirname with Node 20 compatible dirname approach

### DIFF
--- a/.github/workflows/test-nodejs.yml
+++ b/.github/workflows/test-nodejs.yml
@@ -43,6 +43,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
 
+      - name: Fix Node 22 Windows npm issue
+        if: matrix.os == 'windows-latest' && matrix.node-version == '22.0'
+        run: |
+          corepack enable
+          corepack prepare npm@latest --activate
+
       - name: Install dependencies
         run: pnpm install
 

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,7 +1,8 @@
 import { existsSync, mkdirSync, readdirSync } from "node:fs";
 import { cp } from "node:fs/promises";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import inquirer from "inquirer";
+import { withoutProtocol } from "ufo";
 import type { CommandModule } from "yargs";
 
 interface CreateOptions {
@@ -70,7 +71,11 @@ export function createCreateCommand(): CommandModule<unknown, CreateOptions> {
 
       mkdirSync(path, { recursive: true });
 
-      const templatePath = join(import.meta.dirname, "../../templates", template);
+      const templatePath = join(
+        dirname(withoutProtocol(import.meta.url)),
+        "../../templates",
+        template,
+      );
 
       if (!existsSync(templatePath)) throw new Error(`Template "${template}" not found.`);
 

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -2,10 +2,11 @@ import { spawn } from "node:child_process";
 import { constants } from "node:fs";
 import { access, copyFile, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, isAbsolute, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { Listr } from "@aigne/listr2";
 import { input as inputInquirer, select as selectInquirer } from "@inquirer/prompts";
 import { ListrInquirerPromptAdapter } from "@listr2/prompt-adapter-inquirer";
+import { withoutProtocol } from "ufo";
 import { parse, stringify } from "yaml";
 import type { CommandModule } from "yargs";
 import { isTest } from "../utils/aigne-hub/constants.js";
@@ -144,7 +145,10 @@ export const deploy = async (path: string, endpoint: string) => {
 
           task.output = "Copying template files...";
 
-          const templatePath = join(import.meta.dirname, "../../templates/blocklet");
+          const templatePath = join(
+            dirname(withoutProtocol(import.meta.url)),
+            "../../templates/blocklet",
+          );
           await copyDir(templatePath, deployRoot);
 
           await copyDir(path, agentDest);

--- a/packages/cli/src/utils/workers/load-aigne.ts
+++ b/packages/cli/src/utils/workers/load-aigne.ts
@@ -1,12 +1,15 @@
 import { fork } from "node:child_process";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { AIGNE } from "@aigne/core";
+import { withoutProtocol } from "ufo";
 
 export async function safeLoadAIGNE(
   ...args: Parameters<typeof AIGNE.load>
 ): Promise<ReturnType<typeof AIGNE.load>> {
   await new Promise<void>((resolve, reject) => {
-    const child = fork(join(import.meta.dirname, "./load-aigne-worker.js"), { timeout: 600e3 });
+    const child = fork(join(dirname(withoutProtocol(import.meta.url)), "./load-aigne-worker.js"), {
+      timeout: 600e3,
+    });
 
     child.on(
       "message",

--- a/tests/nodejs/docsmith.test.ts
+++ b/tests/nodejs/docsmith.test.ts
@@ -12,4 +12,4 @@ test("AIGNE DocSmith should work", async () => {
     status: 0,
     stdout: expect.stringMatching(/\d+\.\d+\.\d+/),
   });
-}, 120e3);
+}, 240e3);


### PR DESCRIPTION


## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix: replace import.meta.dirname with Node 20 compatible dirname approach
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

Here are the concise release notes:

### Bug Fix
- Fixed Windows compatibility issues with npm when using Node.js 22.0
- Resolved Node.js 20 compatibility issues in CLI commands

### Chore
- Updated file path resolution mechanism to support newer Node.js versions

These changes ensure smoother operation across different Node.js versions and operating systems, particularly benefiting Windows users running Node.js 22.0. No changes to core functionality or user-facing features were made.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->