### PR TITLE
fix(cli): options.prompts should always available

### DIFF
--- a/packages/core/src/aigne/context.ts
+++ b/packages/core/src/aigne/context.ts
@@ -6,14 +6,13 @@ import { Emitter } from "strict-event-emitter";
 import { v7 } from "uuid";
 import { z } from "zod";
 import {
-  type Agent,
+  Agent,
   type AgentHooks,
   type AgentInvokeOptions,
   type AgentProcessAsyncGenerator,
   type AgentResponse,
   type AgentResponseChunk,
   type AgentResponseStream,
-  type FunctionAgentFn,
   isAgentResponseDelta,
   isEmptyChunk,
   type Message,
@@ -761,7 +760,7 @@ async function* withAbortSignal<T extends Message>(
 }
 
 const aigneContextInvokeArgsSchema = z.object({
-  agent: z.union([z.custom<FunctionAgentFn>(), z.custom<Agent>()]),
+  agent: z.union([z.function(), z.instanceof(Agent)]),
   message: z.union([z.record(z.string(), z.unknown()), z.string()]).optional(),
   options: z.object({ returnActiveAgent: z.boolean().optional() }).optional(),
 });


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(cli): options.prompts should always available
2. refactor: check parameters for context.invoke strictly
<!--
  @example:
    1. Fixed xxx
    3. Improved xxx
    4. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
