### PR TITLE
fix: prevent template rendering for agent and tool messages

### DIFF
--- a/packages/core/src/prompt/template.ts
+++ b/packages/core/src/prompt/template.ts
@@ -151,9 +151,12 @@ export class AgentMessageTemplate extends ChatMessageTemplate {
     super("agent", content, name, options);
   }
 
-  override async format(variables?: Record<string, unknown>, options?: FormatOptions) {
+  override async format(_variables?: Record<string, unknown>, _options?: FormatOptions) {
     return {
-      ...(await super.format(variables, options)),
+      role: this.role,
+      name: this.name,
+      // NOTE: agent message should not rendered by template
+      content: this.content,
       toolCalls: this.toolCalls,
     };
   }
@@ -187,9 +190,12 @@ export class ToolMessageTemplate extends ChatMessageTemplate {
     );
   }
 
-  override async format(variables?: Record<string, unknown>, options?: FormatOptions) {
+  override async format(_variables?: Record<string, unknown>, _options?: FormatOptions) {
     return {
-      ...(await super.format(variables, options)),
+      role: this.role,
+      name: this.name,
+      // NOTE: tool result should not rendered by template
+      content: this.content,
       toolCallId: this.toolCallId,
     };
   }

--- a/packages/core/test/prompt/template.test.ts
+++ b/packages/core/test/prompt/template.test.ts
@@ -28,12 +28,14 @@ test("AgentMessageTemplate", async () => {
   const prompt = await AgentMessageTemplate.from("Hello, {{name}}!", undefined, "AgentA").format({
     name: "Alice",
   });
-  expect(prompt).toEqual({
-    role: "agent",
-    content: "Hello, Alice!",
-    toolCalls: undefined,
-    name: "AgentA",
-  });
+  expect(prompt).toMatchInlineSnapshot(`
+    {
+      "content": "Hello, {{name}}!",
+      "name": "AgentA",
+      "role": "agent",
+      "toolCalls": undefined,
+    }
+  `);
 
   const toolCallsPrompt = await AgentMessageTemplate.from(
     undefined,
@@ -49,57 +51,68 @@ test("AgentMessageTemplate", async () => {
     ],
     "AgentA",
   ).format();
-  expect(toolCallsPrompt).toEqual({
-    role: "agent",
-    content: undefined,
-    toolCalls: [
-      {
-        id: "tool1",
-        type: "function",
-        function: {
-          name: "plus",
-          arguments: { a: 1, b: 2 },
+  expect(toolCallsPrompt).toMatchInlineSnapshot(`
+    {
+      "content": undefined,
+      "name": "AgentA",
+      "role": "agent",
+      "toolCalls": [
+        {
+          "function": {
+            "arguments": {
+              "a": 1,
+              "b": 2,
+            },
+            "name": "plus",
+          },
+          "id": "tool1",
+          "type": "function",
         },
-      },
-    ],
-    name: "AgentA",
-  });
+      ],
+    }
+  `);
 });
 
 test("ToolMessageTemplate", async () => {
   const prompt = await ToolMessageTemplate.from("Hello, {{name}}!", "tool1", "AgentA").format({
     name: "Alice",
   });
-  expect(prompt).toEqual({
-    role: "tool",
-    toolCallId: "tool1",
-    content: "Hello, Alice!",
-    name: "AgentA",
-  });
+  expect(prompt).toMatchInlineSnapshot(`
+    {
+      "content": "Hello, {{name}}!",
+      "name": "AgentA",
+      "role": "tool",
+      "toolCallId": "tool1",
+    }
+  `);
 
   const objectPrompt = await ToolMessageTemplate.from(
     { result: { content: "call tool success" } },
     "tool1",
     "AgentA",
   ).format();
-  expect(objectPrompt).toEqual({
-    role: "tool",
-    toolCallId: "tool1",
-    content: JSON.stringify({ result: { content: "call tool success" } }),
-    name: "AgentA",
-  });
+  expect(objectPrompt).toMatchInlineSnapshot(`
+    {
+      "content": "{"result":{"content":"call tool success"}}",
+      "name": "AgentA",
+      "role": "tool",
+      "toolCallId": "tool1",
+    }
+  `);
 
   const bigintPrompt = await ToolMessageTemplate.from(
     { result: { content: 1234567890n } },
     "tool1",
     "AgentA",
   ).format();
-  expect(bigintPrompt).toEqual({
-    role: "tool",
-    toolCallId: "tool1",
-    content: JSON.stringify({ result: { content: "1234567890" } }),
-    name: "AgentA",
-  });
+  expect(bigintPrompt).toMatchInlineSnapshot(`
+    {
+      "content": "{"result":{"content":"1234567890"}}",
+      "name": "AgentA",
+      "role": "tool",
+      "toolCallId": "tool1",
+    }
+  `);
 });
 
 test("safeParseChatMessages should correctly parse valid chat messages with roles and names", async () => {


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix: prevent template rendering for agent and tool messages
<!--
  @example:
    1. Fixed xxx
    3. Improved xxx
    4. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
