### PR TITLE
fix(core): add `include_input_in_output` option for agent definition

### DIFF
--- a/packages/core/src/loader/agent-yaml.ts
+++ b/packages/core/src/loader/agent-yaml.ts
@@ -42,6 +42,7 @@ export interface BaseAgentSchema {
   inputSchema?: ZodType<Record<string, any>>;
   defaultInput?: Record<string, any>;
   outputSchema?: ZodType<Record<string, any>>;
+  includeInputInOutput?: boolean;
   skills?: NestAgentSchema[];
   hooks?: HooksSchema | HooksSchema[];
   memory?:
@@ -147,6 +148,7 @@ export async function parseAgentFile(path: string, data: any): Promise<AgentSche
       outputSchema: optionalize(inputOutputSchema({ path })).transform((v) =>
         v ? jsonSchemaToZod(v) : undefined,
       ) as unknown as ZodType<BaseAgentSchema["outputSchema"]>,
+      includeInputInOutput: optionalize(z.boolean()),
       hooks: optionalize(z.union([hooksSchema, z.array(hooksSchema)])),
       skills: optionalize(z.array(nestAgentSchema)),
       memory: optionalize(

--- a/packages/core/test-agents/chat.yaml
+++ b/packages/core/test-agents/chat.yaml
@@ -12,3 +12,4 @@ input_key: message
 memory: true
 skills:
   - sandbox.js
+include_input_in_output: true

--- a/packages/core/test/loader/__snapshots__/agent-yaml.test.ts.snap
+++ b/packages/core/test/loader/__snapshots__/agent-yaml.test.ts.snap
@@ -7,6 +7,7 @@ exports[`loadAgentFromYaml should load AIAgent correctly 1`] = `
     "bot",
   ],
   "description": "Chat agent",
+  "includeInputInOutput": true,
   "instructions": 
 "system: You are a helpful assistant that can answer questions and provide information on a wide range of topics.
 Your goal is to assist users in finding the information they need and to engage in friendly conversation.

--- a/packages/core/test/loader/agent-yaml.test.ts
+++ b/packages/core/test/loader/agent-yaml.test.ts
@@ -40,6 +40,7 @@ test("loadAgentFromYaml should load AIAgent correctly", async () => {
       output_schema: zodToJsonSchema(skill.outputSchema),
       default_input: skill.defaultInput,
     })),
+    includeInputInOutput: agent.includeInputInOutput,
   }).toMatchSnapshot();
 });
 


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(core): add `include_input_in_output` option for agent definition

```yaml
type: ai
name: chat
include_input_in_output: true

```
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

**Release Notes**

- New Feature: Added `includeInputInOutput` configuration option for agents, allowing developers to control whether the original input text should be included in agent responses
- Test: Updated test suite to verify new configuration behavior

This enhancement gives developers more granular control over agent output formatting, helping to streamline response handling and reduce redundancy when input repetition isn't needed.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->