### PR TITLE
fix(core): agent should not emit error event if retried

### DIFF
--- a/packages/core/src/agents/agent.ts
+++ b/packages/core/src/agents/agent.ts
@@ -926,9 +926,12 @@ export abstract class Agent<I extends Message = any, O extends Message = any> {
     options: AgentInvokeOptions,
   ): Promise<{ retry?: boolean; error?: Error }> {
     logger.error("Invoke agent %s failed with error: %O", this.name, error);
-    if (!this.disableEvents) options.context.emit("agentFailed", { agent: this, error });
 
     const res = (await this.callHooks(["onError", "onEnd"], { input, error }, options)) ?? {};
+
+    if (!res.retry) {
+      if (!this.disableEvents) options.context.emit("agentFailed", { agent: this, error });
+    }
 
     return { ...res };
   }

--- a/packages/core/test/agents/agent.test.ts
+++ b/packages/core/test/agents/agent.test.ts
@@ -1,4 +1,4 @@
-import { expect, spyOn, test } from "bun:test";
+import { expect, mock, spyOn, test } from "bun:test";
 import assert from "node:assert";
 import { inspect } from "node:util";
 import {
@@ -876,4 +876,98 @@ test("Agent should support custom retry condition", async () => {
 
   expect(agent.invoke({})).rejects.toThrow("Network error");
   expect(await agent.invoke({})).toEqual({ result: "success" });
+});
+
+test("Agent should not emit agentFailed event if error is handled and is being retried", async () => {
+  const model = new OpenAIChatModel();
+  const aigne = new AIGNE({ model });
+
+  const context = aigne.newContext();
+
+  const onAgentField = mock();
+
+  context.on("agentFailed", onAgentField);
+
+  const getWeather = FunctionAgent.from({
+    name: "getWeather",
+    inputSchema: z.object({
+      location: z.string(),
+    }),
+    outputSchema: z.object({
+      forecast: z.string(),
+    }),
+    process: ({ location }: { location: string }) => {
+      return { location, forecast: `Sunny in ${location}` };
+    },
+  });
+
+  const agent = AIAgent.from({
+    skills: [getWeather],
+    inputKey: "message",
+  });
+
+  const modelSpy = spyOn(model, "process");
+
+  // 1. should emit agentFailed event if error is not handled
+  modelSpy
+    .mockReturnValueOnce(
+      Promise.resolve({
+        toolCalls: [createToolCallResponse("getWeather", { location: "New York" })],
+      }),
+    )
+    .mockRejectedValueOnce(new Error("Model failed during second call") as never)
+    .mockReturnValueOnce(
+      Promise.resolve(stringToAgentResponseStream("The weather in New York is Sunny.")),
+    );
+
+  const result1 = context.invoke(
+    agent,
+    { message: "How's the weather in New York?" },
+    { newContext: false },
+  );
+
+  expect(result1).rejects.toThrowErrorMatchingInlineSnapshot(`"Model failed during second call"`);
+  expect(onAgentField.mock.calls.length).toBe(2);
+  expect(onAgentField.mock.calls.map((i) => i.at(0).error)).toMatchInlineSnapshot(`
+    [
+      [Error: Model failed during second call],
+      [Error: Model failed during second call],
+    ]
+  `);
+
+  modelSpy.mockReset();
+  onAgentField.mockReset();
+
+  // 2. should not emit agentFailed event if error is handled and is being retried
+  modelSpy
+    .mockReturnValueOnce(
+      Promise.resolve({
+        toolCalls: [createToolCallResponse("getWeather", { location: "New York" })],
+      }),
+    )
+    .mockRejectedValueOnce(new Error("Model failed during second call") as never)
+    .mockReturnValueOnce(
+      Promise.resolve(stringToAgentResponseStream("The weather in New York is Sunny.")),
+    );
+
+  const result = await context.invoke(
+    agent,
+    { message: "How's the weather in New York?" },
+    {
+      newContext: false,
+      hooks: {
+        onError({ error }) {
+          if (error.message === "Model failed during second call") return { retry: true };
+        },
+      },
+    },
+  );
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "message": "The weather in New York is Sunny.",
+    }
+  `);
+
+  expect(onAgentField.mock.calls.length).toBe(0);
 });

--- a/packages/core/test/agents/agent.test.ts
+++ b/packages/core/test/agents/agent.test.ts
@@ -884,9 +884,9 @@ test("Agent should not emit agentFailed event if error is handled and is being r
 
   const context = aigne.newContext();
 
-  const onAgentField = mock();
+  const onAgentFailed = mock();
 
-  context.on("agentFailed", onAgentField);
+  context.on("agentFailed", onAgentFailed);
 
   const getWeather = FunctionAgent.from({
     name: "getWeather",
@@ -927,8 +927,8 @@ test("Agent should not emit agentFailed event if error is handled and is being r
   );
 
   expect(result1).rejects.toThrowErrorMatchingInlineSnapshot(`"Model failed during second call"`);
-  expect(onAgentField.mock.calls.length).toBe(2);
-  expect(onAgentField.mock.calls.map((i) => i.at(0).error)).toMatchInlineSnapshot(`
+  expect(onAgentFailed.mock.calls.length).toBe(2);
+  expect(onAgentFailed.mock.calls.map((i) => i.at(0).error)).toMatchInlineSnapshot(`
     [
       [Error: Model failed during second call],
       [Error: Model failed during second call],
@@ -936,7 +936,7 @@ test("Agent should not emit agentFailed event if error is handled and is being r
   `);
 
   modelSpy.mockReset();
-  onAgentField.mockReset();
+  onAgentFailed.mockReset();
 
   // 2. should not emit agentFailed event if error is handled and is being retried
   modelSpy
@@ -969,5 +969,5 @@ test("Agent should not emit agentFailed event if error is handled and is being r
     }
   `);
 
-  expect(onAgentField.mock.calls.length).toBe(0);
+  expect(onAgentFailed.mock.calls.length).toBe(0);
 });


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(core): agent should not emit error event if retried
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

Bug Fix: Improved Agent Error Handling
- Fixed incorrect error event emission in Agent class to prevent duplicate error notifications
- Now only emits "agentFailed" event when retry attempts are exhausted, providing more accurate error state reporting
- Ensures applications using the Agent class receive proper error signals for handling failures

Test:
- Added comprehensive test coverage for Agent error handling scenarios

This change improves reliability and predictability of error handling behavior for applications using the Agent framework.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->