### PR TITLE
fix(cli): prevent terminal input text overflow and corruption

### DIFF
--- a/packages/cli/src/ui/utils/terminal-input.tsx
+++ b/packages/cli/src/ui/utils/terminal-input.tsx
@@ -91,7 +91,7 @@ function Input(props: {
       <Text>
         {PREFIX[status]} {!inline && label}
       </Text>
-      <Box flexShrink={1} flexGrow={1} marginLeft={inline ? 0 : 2}>
+      <Box flexShrink={1} flexGrow={1} marginLeft={inline ? 0 : 2} marginRight={1}>
         <Text>
           {!!label && inline && `${label} `}
           {lines.join("\n")}


### PR DESCRIPTION
Add right margin to terminal input container to prevent text wrapping issues that were causing display corruption when input exceeded terminal width.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
