### PR TITLE
fix: upload to different Blocklet store based on version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,13 +81,20 @@ jobs:
         run: |
           if git diff HEAD~1 HEAD -- observability/blocklet/package.json | grep '"version"'; then
             echo "changed=true" >> $GITHUB_OUTPUT
+            TAG=$(node -p "require('./observability/blocklet/package.json').version.includes('beta') ? 'beta' : 'latest'")
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Blocklet workflow for observability
-        if: ${{ steps.release.outputs.release_created && steps.blocklets-observability-version-check.outputs.changed == 'true'  }}
+        if: ${{ steps.release.outputs.release_created && steps.blocklets-observability-version-check.outputs.changed == 'true' }}
         env:
+          TAG: ${{ steps.blocklets-observability-version-check.outputs.tag }}
+          STORE_ENDPOINT_TEST: ${{ secrets.STORE_ENDPOINT_TEST }}
+          STORE_ACCESS_TOKEN_TEST: ${{ secrets.STORE_ACCESS_TOKEN_TEST }}
+          STORE_ENDPOINT_PROD: ${{ secrets.STORE_ENDPOINT_PROD }}
+          STORE_ACCESS_TOKEN_PROD: ${{ secrets.STORE_ACCESS_TOKEN_PROD }}
           COMPONENT_STORE_URL: ${{ secrets.STORE_ENDPOINT_PROD }}
         uses: blocklet/action-workflow@v1
         with:
@@ -98,8 +105,8 @@ jobs:
           skip-release: true
           working-directory: observability/blocklet
           bundle-command: pnpm bundle
-          store-endpoint: ${{ secrets.STORE_ENDPOINT_PROD }}
-          store-access-token: ${{ secrets.STORE_ACCESS_TOKEN_PROD }}
+          store-endpoint: ${{ env.TAG == 'beta' && env.STORE_ENDPOINT_TEST || env.STORE_ENDPOINT_PROD }}
+          store-access-token: ${{ env.TAG == 'beta' && env.STORE_ACCESS_TOKEN_TEST || env.STORE_ACCESS_TOKEN_PROD }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
 


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->


<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

- Chore: Enhanced GitHub Actions release workflow to support beta version deployments
- Chore: Added automatic detection and routing of releases between test and production Blocklet stores based on version tags
- Chore: Improved deployment configuration management with dynamic store endpoint selection

This update streamlines the release process by automatically handling different deployment environments. Beta versions are now properly routed to the test store, while stable releases go to production, ensuring a more reliable and organized release pipeline.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->