### PR TITLE
feat(afs): add configurable history injection to AFS system

### DIFF
--- a/packages/core/src/agents/agent.ts
+++ b/packages/core/src/agents/agent.ts
@@ -182,6 +182,8 @@ export interface AgentOptions<I extends Message = Message, O extends Message = M
 
   afs?: true | AFSOptions | AFS | ((afs: AFS) => AFS);
 
+  afsConfig?: AFSConfig;
+
   asyncMemoryRecord?: boolean;
 
   /**
@@ -192,6 +194,11 @@ export interface AgentOptions<I extends Message = Message, O extends Message = M
   hooks?: AgentHooks<I, O> | AgentHooks<I, O>[];
 
   retryOnError?: Agent<I, O>["retryOnError"] | boolean;
+}
+
+export interface AFSConfig {
+  injectHistory?: boolean;
+  historyWindowSize?: number;
 }
 
 const hooksSchema = z.object({
@@ -342,6 +349,7 @@ export abstract class Agent<I extends Message = any, O extends Message = any> {
           : options.afs instanceof AFS
             ? options.afs
             : new AFS(options.afs);
+    this.afsConfig = options.afsConfig;
     this.asyncMemoryRecord = options.asyncMemoryRecord;
 
     this.maxRetrieveMemoryCount = options.maxRetrieveMemoryCount;
@@ -364,6 +372,8 @@ export abstract class Agent<I extends Message = any, O extends Message = any> {
   readonly memories: MemoryAgent[] = [];
 
   afs?: AFS;
+
+  afsConfig?: AFSConfig;
 
   asyncMemoryRecord?: boolean;
 

--- a/packages/core/src/loader/agent-yaml.ts
+++ b/packages/core/src/loader/agent-yaml.ts
@@ -3,7 +3,7 @@ import { jsonSchemaToZod } from "@aigne/json-schema-to-zod";
 import { nodejs } from "@aigne/platform-helpers/nodejs/index.js";
 import { parse } from "yaml";
 import { type ZodType, z } from "zod";
-import type { AgentHooks, FunctionAgentFn, TaskRenderMode } from "../agents/agent.js";
+import type { AFSConfig, AgentHooks, FunctionAgentFn, TaskRenderMode } from "../agents/agent.js";
 import { AIAgentToolChoice } from "../agents/ai-agent.js";
 import { type Role, roleSchema } from "../agents/chat-model.js";
 import { ProcessMode, type ReflectionMode } from "../agents/team-agent.js";
@@ -64,6 +64,7 @@ export interface BaseAgentSchema {
     | (Omit<AFSOptions, "modules"> & {
         modules?: AFSModuleSchema[];
       });
+  afsConfig?: AFSConfig;
 }
 
 export type Instructions = { role: Exclude<Role, "tool">; content: string; path: string }[];
@@ -202,6 +203,14 @@ export async function parseAgentFile(path: string, data: any): Promise<AgentSche
             }),
           ),
         ]),
+      ),
+      afsConfig: optionalize(
+        camelizeSchema(
+          z.object({
+            injectHistory: optionalize(z.boolean()),
+            historyWindowSize: optionalize(z.number().int().min(1)),
+          }),
+        ),
       ),
     });
 

--- a/packages/core/test-agents/test-afs.yaml
+++ b/packages/core/test-agents/test-afs.yaml
@@ -1,0 +1,5 @@
+type: ai
+afs: true
+afs_config:
+  inject_history: true
+  history_window_size: 5

--- a/packages/core/test/loader/agent-yaml.test.ts
+++ b/packages/core/test/loader/agent-yaml.test.ts
@@ -1,6 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
 import assert from "node:assert";
 import { join } from "node:path";
+import { AFS } from "@aigne/afs";
 import {
   type Agent,
   AIAgent,
@@ -291,3 +292,17 @@ function extractInstructions(builder: PromptBuilder): string {
   if (typeof builder.instructions === "string") return builder.instructions;
   return builder.instructions?.messages.map((i) => `${i.role}: ${i.content}`).join("\n\n") || "";
 }
+
+test("loadAgentFromYaml should load AIAgent with AFS correctly", async () => {
+  const agent = await loadAgent(join(import.meta.dirname, "../../test-agents/test-afs.yaml"));
+
+  assert(agent instanceof AIAgent, "agent should be an instance of AIAgent");
+
+  expect(agent.afs).toBeInstanceOf(AFS);
+  expect(agent.afsConfig).toMatchInlineSnapshot(`
+    {
+      "historyWindowSize": 5,
+      "injectHistory": true,
+    }
+  `);
+});


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. feat(afs): add configurable history injection to AFS system

usage

```yaml
type: ai
afs: true
afs_config:
  # inject histories into messages
  inject_history: true
  history_window_size: 5

```
<!--
  @example:
    1. Fixed xxx
    3. Improved xxx
    4. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
