### PR TITLE
feat: add user context support to prompt template variables

### DIFF
--- a/packages/core/src/agents/image-agent.ts
+++ b/packages/core/src/agents/image-agent.ts
@@ -67,7 +67,11 @@ export class ImageAgent<I extends Message = any, O extends ImageModelOutput = an
     const imageModel = this.imageModel || options.imageModel || options.context.imageModel;
     if (!imageModel) throw new Error("image model is required to run ImageAgent");
 
-    const { prompt, image } = await this.instructions.buildImagePrompt({ input, agent: this });
+    const { prompt, image } = await this.instructions.buildImagePrompt({
+      ...options,
+      input,
+      agent: this,
+    });
 
     return (await this.invokeChildAgent(
       imageModel,


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

1. feat: add user context support to prompt template variables
```yaml
type: ai
instructions: |
  Test instructions

  question: {{question}}

  name (from userContext): {{name}}

  userContext.name: {{userContext.name}}
```

<!--
  @example:
    1. Fixed xxx
    3. Improved xxx
    4. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
