### PR TITLE
fix: standardize AFS skills return format with status and metadata

### DIFF
--- a/packages/core/src/prompt/skills/afs.ts
+++ b/packages/core/src/prompt/skills/afs.ts
@@ -19,7 +19,14 @@ export async function getAFSSkills(afs: AFS): Promise<Agent[]> {
           .optional(),
       }),
       process: async (input) => {
-        return afs.list(input.path, input.options);
+        const result = await afs.list(input.path, input.options);
+
+        return {
+          status: "success",
+          tool: "afs_list",
+          options: input.options,
+          ...result,
+        };
       },
     }),
     FunctionAgent.from({
@@ -40,7 +47,15 @@ export async function getAFSSkills(afs: AFS): Promise<Agent[]> {
           .optional(),
       }),
       process: async (input) => {
-        return afs.search(input.path, input.query, input.options);
+        const result = await afs.search(input.path, input.query, input.options);
+
+        return {
+          status: "success",
+          tool: "afs_search",
+          query: input.query,
+          options: input.options,
+          ...result,
+        };
       },
     }),
     FunctionAgent.from({
@@ -55,9 +70,13 @@ export async function getAFSSkills(afs: AFS): Promise<Agent[]> {
           ),
       }),
       process: async (input) => {
-        const file = await afs.read(input.path);
+        const result = await afs.read(input.path);
+
         return {
-          file,
+          status: "success",
+          tool: "afs_read",
+          path: input.path,
+          ...result,
         };
       },
     }),
@@ -74,11 +93,16 @@ export async function getAFSSkills(afs: AFS): Promise<Agent[]> {
         content: z.string().describe("The text content to write to the file"),
       }),
       process: async (input) => {
-        const file = await afs.write(input.path, {
+        const result = await afs.write(input.path, {
           content: input.content,
         });
 
-        return { file };
+        return {
+          status: "success",
+          tool: "afs_write",
+          path: input.path,
+          ...result,
+        };
       },
     }),
   ];

--- a/packages/core/test/prompt/skills/afs.test.ts
+++ b/packages/core/test/prompt/skills/afs.test.ts
@@ -165,6 +165,11 @@ test("AFS'skill list should invoke afs.list", async () => {
   expect(await list.invoke({ path: "/foo/bar", options: { maxDepth: 2 } })).toMatchInlineSnapshot(`
     {
       "list": [],
+      "options": {
+        "maxDepth": 2,
+      },
+      "status": "success",
+      "tool": "afs_list",
     }
   `);
 
@@ -192,13 +197,14 @@ test("AFS'skill read should invoke afs.read", async () => {
   assert(read);
   expect(await read.invoke({ path: "/foo" })).toMatchInlineSnapshot(`
     {
-      "file": {
-        "result": {
-          "content": "bar",
-          "id": "foo",
-          "path": "/foo",
-        },
+      "path": "/foo",
+      "result": {
+        "content": "bar",
+        "id": "foo",
+        "path": "/foo",
       },
+      "status": "success",
+      "tool": "afs_read",
     }
   `);
 
@@ -227,13 +233,14 @@ test("AFS'skill write should invoke afs.write", async () => {
   assert(write);
   expect(await write.invoke({ path: "/foo", content: "bar" })).toMatchInlineSnapshot(`
     {
-      "file": {
-        "result": {
-          "content": "bar",
-          "id": "foo",
-          "path": "/foo",
-        },
+      "path": "/foo",
+      "result": {
+        "content": "bar",
+        "id": "foo",
+        "path": "/foo",
       },
+      "status": "success",
+      "tool": "afs_write",
     }
   `);
 


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

**Refactor**: Standardized Abstract File System (AFS) Skills Response Format

- Refactor: Unified response format across all AFS operations (list, search, read, write) for more consistent API interaction
- Refactor: Added standardized metadata fields including operation status and tool identification
- Refactor: Simplified response structure with flatter object hierarchy for easier data access

These changes improve API predictability and make it easier for developers to work with AFS operations by providing a more consistent interface.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->