### PR TITLE
fix: improve model name parsing to handle complex model identifiers

### DIFF
--- a/models/aigne-hub/src/utils/model.ts
+++ b/models/aigne-hub/src/utils/model.ts
@@ -208,7 +208,8 @@ export function findImageModel(provider: string): {
 }
 
 export const parseModel = (model: string) => {
-  model = model.replace(":", "/");
+  // replace first ':' with '/' to compatible with `provider:model-name` format
+  model = model.replace(/^(\w+)(:)/, "$1/");
   const { provider, name } = model.match(/(?<provider>[^/]*)(\/(?<name>.*))?/)?.groups ?? {};
   return { provider: provider?.replace(/-/g, ""), model: name };
 };

--- a/models/aigne-hub/test/utils/model.test.ts
+++ b/models/aigne-hub/test/utils/model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { findImageModel, findModel } from "../../src/utils/model.js";
+import { findImageModel, findModel, parseModel } from "../../src/utils/model.js";
 
 describe("findModel", async () => {
   describe("findModel function", () => {
@@ -214,5 +214,55 @@ describe("findImageModel", async () => {
         ]
       `);
     });
+  });
+});
+
+describe("parseModel", () => {
+  test("should parse model with provider and name", () => {
+    expect(parseModel("openai:gpt-4")).toMatchInlineSnapshot(`
+      {
+        "model": "gpt-4",
+        "provider": "openai",
+      }
+    `);
+  });
+
+  test("should parse model with only provider", () => {
+    expect(parseModel("openai")).toMatchInlineSnapshot(`
+      {
+        "model": undefined,
+        "provider": "openai",
+      }
+    `);
+  });
+
+  test("should handle complex model names", () => {
+    expect(parseModel("anthropic:claude-3-sonnet-20240229-v1:0")).toMatchInlineSnapshot(`
+      {
+        "model": "claude-3-sonnet-20240229-v1:0",
+        "provider": "anthropic",
+      }
+    `);
+    expect(parseModel("anthropic/claude-3-sonnet-20240229-v1:0")).toMatchInlineSnapshot(`
+      {
+        "model": "claude-3-sonnet-20240229-v1:0",
+        "provider": "anthropic",
+      }
+    `);
+  });
+
+  test("should handle model names with special characters", () => {
+    expect(parseModel("bedrock:anthropic.claude-3-sonnet-20240229-v1:0")).toMatchInlineSnapshot(`
+      {
+        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "provider": "bedrock",
+      }
+    `);
+    expect(parseModel("bedrock/anthropic.claude-3-sonnet-20240229-v1:0")).toMatchInlineSnapshot(`
+      {
+        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "provider": "bedrock",
+      }
+    `);
   });
 });

--- a/packages/cli/src/utils/aigne-hub/model.ts
+++ b/packages/cli/src/utils/aigne-hub/model.ts
@@ -4,6 +4,7 @@ import {
   AIGNE_HUB_URL,
   findImageModel,
   findModel,
+  parseModel,
 } from "@aigne/aigne-hub";
 import type {
   ChatModel,
@@ -26,17 +27,11 @@ export function maskApiKey(apiKey?: string) {
   return `${start}${"*".repeat(8)}${end}`;
 }
 
-export const parseModelOption = (model: string) => {
-  model = model.replace(":", "/");
-  const { provider, name } = model.match(/(?<provider>[^/]*)(\/(?<name>.*))?/)?.groups ?? {};
-  return { provider: provider?.replace(/-/g, ""), model: name };
-};
-
 export const formatModelName = async (
   model: string,
   inquirerPrompt: NonNullable<LoadCredentialOptions["inquirerPromptFn"]>,
 ): Promise<{ provider: string; model?: string }> => {
-  let { provider, model: name } = parseModelOption(model);
+  let { provider, model: name } = parseModel(model);
   provider ||= AIGNE_HUB_PROVIDER;
 
   const { match, all } = findModel(provider);

--- a/packages/cli/test/commands/app.test.ts
+++ b/packages/cli/test/commands/app.test.ts
@@ -189,6 +189,11 @@ test("app command should register doc-smith to yargs", async () => {
         "title": "test title to generate",
         "topic": "test topic to generate",
       },
+      "metadata": {
+        "appName": "doc-smith",
+        "appVersion": "1.1.1",
+        "cliVersion": "1.52.0-beta",
+      },
       "parent": undefined,
     }
   `,
@@ -244,6 +249,10 @@ test("app command should support serve-mcp subcommand", async () => {
       ],
       "dir": Any<String>,
       "host": "localhost",
+      "metadata": {
+        "appName": "doc-smith",
+        "appVersion": "1.1.1",
+      },
       "pathname": "/mcp",
     }
   `,

--- a/packages/cli/test/utils/aigne-hub/model.test.ts
+++ b/packages/cli/test/utils/aigne-hub/model.test.ts
@@ -5,7 +5,6 @@ import {
   formatModelName,
   loadChatModel as loadModel,
   maskApiKey,
-  parseModelOption,
 } from "@aigne/cli/utils/aigne-hub/model.js";
 import { stringify } from "yaml";
 import { createHonoServer } from "../../_mocks_/server.js";
@@ -27,36 +26,6 @@ describe("maskApiKey", () => {
   test("should mask api key", () => {
     const result = maskApiKey("123");
     expect(result).toBe("123");
-  });
-});
-
-describe("parseModelOption", () => {
-  test("should parse model with provider and name", () => {
-    const result = parseModelOption("openai:gpt-4");
-
-    expect(result.provider).toBe("openai");
-    expect(result.model).toBe("gpt-4");
-  });
-
-  test("should parse model with only provider", () => {
-    const result = parseModelOption("openai");
-
-    expect(result.provider).toBe("openai");
-    expect(result.model).toBeUndefined();
-  });
-
-  test("should handle complex model names", () => {
-    const result = parseModelOption("anthropic:claude-3-sonnet-20240229-v1:0");
-
-    expect(result.provider).toBe("anthropic");
-    expect(result.model).toBe("claude-3-sonnet-20240229-v1:0");
-  });
-
-  test("should handle model names with special characters", () => {
-    const result = parseModelOption("bedrock:anthropic.claude-3-sonnet-20240229-v1:0");
-
-    expect(result.provider).toBe("bedrock");
-    expect(result.model).toBe("anthropic.claude-3-sonnet-20240229-v1:0");
   });
 });
 


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

Release Notes:

- Bug Fix: Improved model identifier parsing to better handle provider:model formats while preserving special characters and version numbers in model names
- Refactor: Consolidated model parsing logic by using a shared implementation across packages
- Test: Enhanced test coverage for model identifier parsing with additional test cases
- Test: Added application metadata fields to CLI test cases

These changes improve the reliability of model name handling throughout the system, particularly when working with provider-specific model identifiers. Users should experience more consistent behavior when referencing models using either colon or forward slash notation.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->