### PR TITLE
fix(gemini): use StructuredOutputError to trigger retry for missing JSON response

### DIFF
--- a/models/gemini/src/gemini-chat-model.ts
+++ b/models/gemini/src/gemini-chat-model.ts
@@ -207,7 +207,7 @@ export class GeminiChatModel extends ChatModel {
       } else if (text) {
         yield { delta: { json: { json: safeParseJSON(text) } } };
       } else if (!toolCalls.length) {
-        throw new Error("No JSON response from the model");
+        throw new StructuredOutputError("No JSON response from the model");
       }
     } else if (!toolCalls.length) {
       // NOTE: gemini-2.5-pro sometimes returns an empty response,


### PR DESCRIPTION


## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

- Bug Fix: Improved error handling in Gemini chat model by providing more specific error messages when JSON responses are missing. This enhancement helps developers better understand and troubleshoot issues when working with structured outputs from Gemini.

The change makes error messages more descriptive and helps maintain data consistency when using Gemini's chat functionality.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->