### PR TITLE
fix: load aigne hub api url for image model correctly

### DIFF
--- a/packages/cli/src/utils/aigne-hub/model.ts
+++ b/packages/cli/src/utils/aigne-hub/model.ts
@@ -149,6 +149,7 @@ export async function loadImageModel(
 
   return match.create({
     ...credential,
+    baseURL: credential?.url,
     model,
     modelOptions: options && omit(options, "model", "aigneHubUrl", "inquirerPromptFn"),
   });


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

Bug Fix: Updated model configuration to correctly set baseURL
- Fixed model initialization in CLI by properly configuring the base URL for image model API endpoints
- Ensures proper communication between the CLI and image processing services
- Improves reliability of image-related operations through the command line interface

This change addresses a configuration issue that could affect image model functionality, providing more stable and predictable behavior for users working with image processing features through the CLI.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->