### PR TITLE
fix(gemini): include thoughts token count in output token usage

### DIFF
--- a/models/gemini/src/gemini-chat-model.ts
+++ b/models/gemini/src/gemini-chat-model.ts
@@ -196,8 +196,10 @@ export class GeminiChatModel extends ChatModel {
       if (chunk.usageMetadata) {
         if (chunk.usageMetadata.promptTokenCount)
           usage.inputTokens = chunk.usageMetadata.promptTokenCount;
-        if (chunk.usageMetadata.candidatesTokenCount)
-          usage.outputTokens = chunk.usageMetadata.candidatesTokenCount;
+        if (chunk.usageMetadata.candidatesTokenCount || chunk.usageMetadata.thoughtsTokenCount)
+          usage.outputTokens =
+            (chunk.usageMetadata.candidatesTokenCount || 0) +
+            (chunk.usageMetadata.thoughtsTokenCount || 0);
       }
     }
 

--- a/models/gemini/test/gemini-chat-model.test.ts
+++ b/models/gemini/test/gemini-chat-model.test.ts
@@ -142,7 +142,7 @@ test("GeminiChatModel.invoke should use tool result correctly", async () => {
       "model": "gemini-2.5-flash",
       "usage": {
         "inputTokens": 116,
-        "outputTokens": 25,
+        "outputTokens": 96,
       },
     }
   `);
@@ -402,7 +402,7 @@ What is the weather in New York?
       "model": "gemini-2.5-flash",
       "usage": {
         "inputTokens": 39,
-        "outputTokens": 16,
+        "outputTokens": 113,
       },
     }
   `);


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

Bug Fix: Corrected token usage calculation in Gemini chat model
- Fixed token count reporting to accurately include both candidate responses and thought process tokens in the output metrics
- Provides more accurate usage tracking and billing calculations for Gemini chat interactions
- Ensures token consumption is properly monitored and reported for system resource management

This change improves accuracy in tracking API usage and helps users better understand their actual token consumption when using the Gemini chat model.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->