### PR TITLE
fix(core): support custom `catchToolsError` in yaml agent definition

### DIFF
--- a/packages/core/src/loader/agent-yaml.ts
+++ b/packages/core/src/loader/agent-yaml.ts
@@ -278,6 +278,7 @@ export async function parseAgentFile(path: string, data: any): Promise<AgentSche
             toolChoice: optionalize(z.nativeEnum(AIAgentToolChoice)),
             toolCallsConcurrency: optionalize(z.number().int().min(0)),
             keepTextInToolUses: optionalize(z.boolean()),
+            catchToolsError: optionalize(z.boolean()),
             structuredStreamMode: optionalize(z.boolean()),
           })
           .extend(baseAgentSchema.shape),

--- a/packages/core/test-agents/chat.yaml
+++ b/packages/core/test-agents/chat.yaml
@@ -20,3 +20,4 @@ skills:
   - sandbox.js
 include_input_in_output: true
 tool_calls_concurrency: 3
+catch_tools_error: false

--- a/packages/core/test/loader/__snapshots__/agent-yaml.test.ts.snap
+++ b/packages/core/test/loader/__snapshots__/agent-yaml.test.ts.snap
@@ -8,6 +8,7 @@ exports[`loadAgentFromYaml should load AIAgent correctly 1`] = `
   ],
   "auto_merge_system_messages": true,
   "auto_reorder_system_messages": true,
+  "catch_tools_error": false,
   "description": "Chat agent",
   "includeInputInOutput": true,
   "input_file_key": "message_file",

--- a/packages/core/test/loader/agent-yaml.test.ts
+++ b/packages/core/test/loader/agent-yaml.test.ts
@@ -41,6 +41,7 @@ test("loadAgentFromYaml should load AIAgent correctly", async () => {
     input_file_key: agent.inputFileKey,
     output_file_key: agent.outputFileKey,
     keep_text_in_tool_uses: agent.keepTextInToolUses,
+    catch_tools_error: agent.catchToolsError,
     skills: agent.skills.map((skill) => ({
       name: skill.name,
       description: skill.description,


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(core): support custom catchToolsError in yaml agent definition

```yaml
type: ai
name: chat
skills:
  ...
catch_tools_error: false
```
<!--
  @example:
    1. Fixed xxx
    3. Improved xxx
    4. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
