### PR TITLE
feat(core): add json/yaml stringify filters for prompt template

### DIFF
--- a/packages/core/src/prompt/filters/index.ts
+++ b/packages/core/src/prompt/filters/index.ts
@@ -1,0 +1,12 @@
+import type { Environment } from "nunjucks";
+import { stringify } from "yaml";
+
+export function setupFilters(env: Environment) {
+  env.addFilter("yaml.stringify", (obj: unknown) => {
+    return stringify(obj);
+  });
+
+  env.addFilter("json.stringify", (obj: unknown, ...args: any[]) => {
+    return JSON.stringify(obj, ...args);
+  });
+}

--- a/packages/core/src/prompt/template.ts
+++ b/packages/core/src/prompt/template.ts
@@ -7,6 +7,7 @@ import type {
   ChatModelOutputToolCall,
 } from "../agents/chat-model.js";
 import { isNil, omitBy } from "../utils/type-utils.js";
+import { setupFilters } from "./filters/index.js";
 
 (nunjucks.runtime as any).suppressValue = (v: unknown) => {
   if (isNil(v)) return "";
@@ -30,6 +31,8 @@ export class PromptTemplate {
     if (options?.workingDir) {
       env = new nunjucks.Environment(new CustomLoader({ workingDir: options.workingDir }));
     }
+
+    setupFilters(env);
 
     return new Promise((resolve, reject) =>
       env.renderString(this.template, variables, (err, res) => {

--- a/packages/core/test/prompt/template.test.ts
+++ b/packages/core/test/prompt/template.test.ts
@@ -179,3 +179,24 @@ test("safeParseChatMessages should correctly parse valid chat messages with role
     },
   ]);
 });
+
+test("PromptTemplate should support yaml.stringify filter", async () => {
+  const prompt = new PromptTemplate("Data in YAML:\n{{ data | yaml.stringify }}");
+  const result = await prompt.format({ data: { key: "value" } });
+  expect(result).toMatchInlineSnapshot(`
+    "Data in YAML:
+    key: value
+    "
+  `);
+});
+
+test("PromptTemplate should support json.stringify filter", async () => {
+  const prompt = new PromptTemplate("Data in JSON:\n{{ data | json.stringify(null, 2) }}");
+  const result = await prompt.format({ data: { key: "value" } });
+  expect(result).toMatchInlineSnapshot(`
+    "Data in JSON:
+    {
+      "key": "value"
+    }"
+  `);
+});


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. feat(core): add json/yaml stringify filters for prompt template

usage:

```yaml
type: ai
instructions: |
  Data in YAML:\n{{ data | yaml.stringify }}
input_schema:
  type: object
  properties:
    data:
      type: array
      items:
        type: string
```

```yaml
type: ai
instructions: |
  Data in YAML:\n{{ data | json.stringify(null, 2) }}
input_schema:
  type: object
  properties:
    data:
      type: array
      items:
        type: string
```
<!--
  @example:
    1. Fixed xxx
    3. Improved xxx
    4. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
