### PR TITLE
fix(system-fs): auto-install ripgrep when binary is missing

### DIFF
--- a/afs/system-fs/src/utils/ripgrep.ts
+++ b/afs/system-fs/src/utils/ripgrep.ts
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { rm, stat } from "node:fs/promises";
+import { dirname } from "node:path";
 import { rgPath } from "@vscode/ripgrep";
 
 export interface RipgrepMatch {
@@ -17,6 +19,8 @@ export interface RipgrepMatch {
 }
 
 export async function searchWithRipgrep(basePath: string, query: string): Promise<RipgrepMatch[]> {
+  await ensureNativeDependenciesInstalled();
+
   return new Promise((resolve, reject) => {
     const args = ["--json", "--no-heading", "--with-filename", query, basePath];
 
@@ -54,4 +58,58 @@ export async function searchWithRipgrep(basePath: string, query: string): Promis
       reject(new Error(`Failed to spawn ripgrep: ${error}`));
     });
   });
+}
+
+let installPromise: Promise<void> | null = null;
+
+async function ensureNativeDependenciesInstalled() {
+  if (installPromise) return installPromise;
+
+  installPromise = (async () => {
+    if (await isFileExists(rgPath)) {
+      return;
+    }
+
+    // Remove the existing bin folder to ensure a clean install
+    const binFolder = dirname(rgPath);
+    await rm(binFolder, { recursive: true, force: true });
+
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn("npm", ["run", "postinstall"], {
+        cwd: dirname(binFolder),
+        stdio: "pipe",
+        shell: process.platform === "win32",
+      });
+
+      let stderr = "";
+      child.stderr.on("data", (data) => {
+        const str = data.toString();
+        stderr += str;
+      });
+
+      child.on("error", (error) => reject(error));
+
+      child.on("exit", (code) => {
+        if (code === 0) resolve();
+        else reject(new Error(`npm install failed with code ${code} ${stderr}`));
+      });
+    });
+  })().catch((error) => {
+    console.error(`Failed to install native dependencies: ${error}`);
+    installPromise = null;
+  });
+
+  return installPromise;
+}
+
+async function isFileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
