### PR TITLE
fix(core): improve checkArguments error messages and refactor optional schemas

### DIFF
--- a/packages/core/test/utils/type-utils.test.ts
+++ b/packages/core/test/utils/type-utils.test.ts
@@ -5,6 +5,7 @@ import {
   createAccessorArray,
   duplicates,
   flat,
+  get,
   isEmpty,
   isNil,
   isNonNullable,
@@ -128,6 +129,11 @@ test("type-utils.omitByDeep", async () => {
   ]);
 });
 
+test("type-utils.get", async () => {
+  expect(get({ foo: { bar: { baz: 1 } } }, ["foo", "bar", "baz"])).toBe(1);
+  expect(get({ foo: {} }, ["foo", "bar", "qux"])).toBeUndefined();
+});
+
 test("type-utils.flat", async () => {
   expect(flat(1)).toEqual([1]);
   expect(flat([1, 2, 3])).toEqual([1, 2, 3]);
@@ -148,7 +154,9 @@ test("type-utils.createAccessorArray", async () => {
 test("type-utils.checkArguments should throw an error if the arguments do not match the schema", async () => {
   expect(() => {
     checkArguments("test", z.object({ foo: z.string() }), { foo: 1 } as unknown);
-  }).toThrow("test check arguments error: foo: Expected string, received number");
+  }).toThrowErrorMatchingInlineSnapshot(
+    `"test check arguments error: foo: Expected string, received number"`,
+  );
 });
 
 test("type-utils.checkArguments should throw an error if the arguments do not match the union schema", async () => {
@@ -156,7 +164,9 @@ test("type-utils.checkArguments should throw an error if the arguments do not ma
     checkArguments("test", z.object({ foo: z.union([z.string(), z.boolean()]) }), {
       foo: 1,
     } as unknown);
-  }).toThrow("test check arguments error: foo: Expected string or boolean, received number");
+  }).toThrowErrorMatchingInlineSnapshot(
+    `"test check arguments error: foo: Invalid input expect string,boolean got 1"`,
+  );
 
   expect(() => {
     checkArguments(
@@ -164,7 +174,9 @@ test("type-utils.checkArguments should throw an error if the arguments do not ma
       z.object({ agent: z.union([z.function() as ZodType<FunctionAgentFn>, z.instanceof(Agent)]) }),
       { agent: 1 } as unknown,
     );
-  }).toThrow("test check arguments error: agent: Input not instance of Agent");
+  }).toThrowErrorMatchingInlineSnapshot(
+    `"test check arguments error: agent: Invalid input expect function got 1"`,
+  );
 });
 
 test("type-utils.tryOrThrow should return the value if the function succeeds", async () => {


### PR DESCRIPTION


## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**Refactor:**
- Standardized schema definition patterns across chat model configurations using new `optionalize()` helper function

**New Feature:**
- Added `get` utility function for safe nested object property access

**Bug Fix:**
- Improved error handling in argument validation with clearer error messages that include both expected types and actual received values

**Test:**
- Enhanced test coverage for type utility functions with comprehensive error message validation

These changes improve code maintainability and provide better debugging information when validation errors occur.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->