### PR TITLE
fix(core): order history entries by time in ascending order

### DIFF
--- a/packages/core/src/prompt/prompt-builder.ts
+++ b/packages/core/src/prompt/prompt-builder.ts
@@ -215,7 +215,9 @@ export class PromptBuilder {
         }
 
         memories.push(
-          ...history.list.filter((i): i is Required<AFSEntry> => isNonNullable(i.content)),
+          ...history.list
+            .reverse()
+            .filter((i): i is Required<AFSEntry> => isNonNullable(i.content)),
         );
       }
     }

--- a/packages/core/test/prompt/prompt-builder.test.ts
+++ b/packages/core/test/prompt/prompt-builder.test.ts
@@ -487,12 +487,12 @@ test("PromptBuilder should build with afs correctly", async () => {
       {
         id: "1",
         path: "/history/1",
-        content: { input: { message: "Hello" }, output: { message: "Hello, How can I help you?" } },
+        content: { input: { message: "I'm Bob" }, output: { message: "Hello, Bob!" } },
       },
       {
         id: "1",
         path: "/history/1",
-        content: { input: { message: "I'm Bob" }, output: { message: "Hello, Bob!" } },
+        content: { input: { message: "Hello" }, output: { message: "Hello, How can I help you?" } },
       },
     ],
   });


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(core): order history entries by time in ascending order
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**Bug Fix:**
- Fixed chronological ordering of history entries in PromptBuilder to display in ascending order (oldest to newest) instead of descending order

This change ensures that conversation history is presented in a more intuitive chronological sequence, improving the user experience when reviewing past interactions.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->