### PR TITLE
fix(examples): use separate SQLite databases for each AFS memory module

### DIFF
--- a/examples/afs-memory/README.md
+++ b/examples/afs-memory/README.md
@@ -128,7 +128,7 @@ This example uses two complementary memory modules that work together to provide
 $ pnpm start --input "I'm Bob, and I like blue color"
 Response: Nice to meet you, Bob — I've saved that your favorite color is blue...
 
-# The conversation is automatically saved to /history/{uuid}
+# The conversation is automatically saved to history.sqlite3
 ```
 
 ### 2. UserProfileMemory Module - User Information Extraction
@@ -139,7 +139,7 @@ Response: Nice to meet you, Bob — I've saved that your favorite color is blue.
 1. **Listens** to conversation history events
 2. **Analyzes** each conversation using AI to identify user information
 3. **Extracts** relevant details (name, interests, location, family, projects, etc.)
-4. **Stores** in a structured JSON profile at `/user-profile-memory`
+4. **Stores** in a structured JSON profile in user_profile.sqlite3
 5. **Updates** incrementally using JSON Patch operations
 
 **What it remembers**:

--- a/examples/afs-memory/index.ts
+++ b/examples/afs-memory/index.ts
@@ -8,11 +8,12 @@ import { AIAgent } from "@aigne/core";
 
 const aigne = await loadAIGNEWithCmdOptions();
 
-const sharedStorage = { url: "file:./memory.sqlite3" };
-
-const afs = new AFS()
-  .mount(new AFSHistory({ storage: sharedStorage }))
-  .mount(new UserProfileMemory({ storage: sharedStorage, context: aigne.newContext() }));
+const afs = new AFS().mount(new AFSHistory({ storage: { url: "file:./history.sqlite3" } })).mount(
+  new UserProfileMemory({
+    storage: { url: "file:./user_profile.sqlite3" },
+    context: aigne.newContext(),
+  }),
+);
 
 const agent = AIAgent.from({
   instructions: "You are a friendly chatbot",


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(examples): use separate SQLite databases for each AFS memory module
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [x] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**Refactor:**
- Separated AFS memory storage into dedicated databases for improved data isolation and organization
- History data now stored in `history.sqlite3` instead of shared `memory.sqlite3`
- User profile data now stored in `user_profile.sqlite3` for better module separation

This change enhances data management by providing distinct storage for different memory components, reducing potential conflicts and improving maintainability of the AFS memory system.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->