### PR TITLE
fix(gemini): properly handle thinking level for gemini 3.x models

### DIFF
--- a/models/gemini/test/__snapshots__/gemini-chat-model.test.ts.snap
+++ b/models/gemini/test/__snapshots__/gemini-chat-model.test.ts.snap
@@ -16,6 +16,7 @@ exports[`GeminiChatModel.invoke should use tool result correctly 1`] = `
       "thinkingConfig": {
         "includeThoughts": true,
         "thinkingBudget": undefined,
+        "thinkingLevel": undefined,
       },
       "toolConfig": {
         "functionCallingConfig": {
@@ -110,4 +111,262 @@ exports[`GeminiChatModel.invoke should use tool result correctly 1`] = `
     "model": "gemini-2.5-flash",
   },
 ]
+`;
+
+exports[`GeminiChatModel should handle model options correctly for {
+  model: "gemini-3-pro-preview",
+} 1`] = `
+{
+  "frequencyPenalty": undefined,
+  "presencePenalty": undefined,
+  "responseModalities": undefined,
+  "temperature": undefined,
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingBudget": undefined,
+    "thinkingLevel": "THINKING_LEVEL_UNSPECIFIED",
+  },
+  "toolConfig": {
+    "functionCallingConfig": undefined,
+  },
+  "tools": [],
+  "topP": undefined,
+}
+`;
+
+exports[`GeminiChatModel should handle model options correctly for {
+  model: "gemini-3-pro-preview",
+  reasoningEffort: "high",
+} 1`] = `
+{
+  "frequencyPenalty": undefined,
+  "presencePenalty": undefined,
+  "responseModalities": undefined,
+  "temperature": undefined,
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingBudget": undefined,
+    "thinkingLevel": "HIGH",
+  },
+  "toolConfig": {
+    "functionCallingConfig": undefined,
+  },
+  "tools": [],
+  "topP": undefined,
+}
+`;
+
+exports[`GeminiChatModel should handle model options correctly for {
+  model: "gemini-3-pro-preview",
+  reasoningEffort: "medium",
+} 1`] = `
+{
+  "frequencyPenalty": undefined,
+  "presencePenalty": undefined,
+  "responseModalities": undefined,
+  "temperature": undefined,
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingBudget": undefined,
+    "thinkingLevel": "HIGH",
+  },
+  "toolConfig": {
+    "functionCallingConfig": undefined,
+  },
+  "tools": [],
+  "topP": undefined,
+}
+`;
+
+exports[`GeminiChatModel should handle model options correctly for {
+  model: "gemini-3-pro-preview",
+  reasoningEffort: "low",
+} 1`] = `
+{
+  "frequencyPenalty": undefined,
+  "presencePenalty": undefined,
+  "responseModalities": undefined,
+  "temperature": undefined,
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingBudget": undefined,
+    "thinkingLevel": "LOW",
+  },
+  "toolConfig": {
+    "functionCallingConfig": undefined,
+  },
+  "tools": [],
+  "topP": undefined,
+}
+`;
+
+exports[`GeminiChatModel should handle model options correctly for {
+  model: "gemini-3-pro-preview",
+  reasoningEffort: "minimal",
+} 1`] = `
+{
+  "frequencyPenalty": undefined,
+  "presencePenalty": undefined,
+  "responseModalities": undefined,
+  "temperature": undefined,
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingBudget": undefined,
+    "thinkingLevel": "LOW",
+  },
+  "toolConfig": {
+    "functionCallingConfig": undefined,
+  },
+  "tools": [],
+  "topP": undefined,
+}
+`;
+
+exports[`GeminiChatModel should handle model options correctly for {
+  model: "gemini-3-pro-preview",
+  reasoningEffort: 10000,
+} 1`] = `
+{
+  "frequencyPenalty": undefined,
+  "presencePenalty": undefined,
+  "responseModalities": undefined,
+  "temperature": undefined,
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingBudget": undefined,
+    "thinkingLevel": "HIGH",
+  },
+  "toolConfig": {
+    "functionCallingConfig": undefined,
+  },
+  "tools": [],
+  "topP": undefined,
+}
+`;
+
+exports[`GeminiChatModel should handle model options correctly for {
+  model: "gemini-2.5-pro",
+} 1`] = `
+{
+  "frequencyPenalty": undefined,
+  "presencePenalty": undefined,
+  "responseModalities": undefined,
+  "temperature": undefined,
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingBudget": undefined,
+    "thinkingLevel": undefined,
+  },
+  "toolConfig": {
+    "functionCallingConfig": undefined,
+  },
+  "tools": [],
+  "topP": undefined,
+}
+`;
+
+exports[`GeminiChatModel should handle model options correctly for {
+  model: "gemini-2.5-pro",
+  reasoningEffort: "high",
+} 1`] = `
+{
+  "frequencyPenalty": undefined,
+  "presencePenalty": undefined,
+  "responseModalities": undefined,
+  "temperature": undefined,
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingBudget": 32768,
+    "thinkingLevel": undefined,
+  },
+  "toolConfig": {
+    "functionCallingConfig": undefined,
+  },
+  "tools": [],
+  "topP": undefined,
+}
+`;
+
+exports[`GeminiChatModel should handle model options correctly for {
+  model: "gemini-2.5-pro",
+  reasoningEffort: "medium",
+} 1`] = `
+{
+  "frequencyPenalty": undefined,
+  "presencePenalty": undefined,
+  "responseModalities": undefined,
+  "temperature": undefined,
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingBudget": 10000,
+    "thinkingLevel": undefined,
+  },
+  "toolConfig": {
+    "functionCallingConfig": undefined,
+  },
+  "tools": [],
+  "topP": undefined,
+}
+`;
+
+exports[`GeminiChatModel should handle model options correctly for {
+  model: "gemini-2.5-pro",
+  reasoningEffort: "low",
+} 1`] = `
+{
+  "frequencyPenalty": undefined,
+  "presencePenalty": undefined,
+  "responseModalities": undefined,
+  "temperature": undefined,
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingBudget": 5000,
+    "thinkingLevel": undefined,
+  },
+  "toolConfig": {
+    "functionCallingConfig": undefined,
+  },
+  "tools": [],
+  "topP": undefined,
+}
+`;
+
+exports[`GeminiChatModel should handle model options correctly for {
+  model: "gemini-2.5-pro",
+  reasoningEffort: "minimal",
+} 1`] = `
+{
+  "frequencyPenalty": undefined,
+  "presencePenalty": undefined,
+  "responseModalities": undefined,
+  "temperature": undefined,
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingBudget": 200,
+    "thinkingLevel": undefined,
+  },
+  "toolConfig": {
+    "functionCallingConfig": undefined,
+  },
+  "tools": [],
+  "topP": undefined,
+}
+`;
+
+exports[`GeminiChatModel should handle model options correctly for {
+  model: "gemini-1.5-pro",
+  reasoningEffort: "high",
+} 1`] = `
+{
+  "frequencyPenalty": undefined,
+  "presencePenalty": undefined,
+  "responseModalities": undefined,
+  "temperature": undefined,
+  "thinkingConfig": undefined,
+  "toolConfig": {
+    "functionCallingConfig": undefined,
+  },
+  "tools": [],
+  "topP": undefined,
+}
 `;


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(gemini): properly handle thinking level for gemini 3.x models
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**New Feature:**
- Added thinking level handling for Gemini 3.x models, enabling advanced reasoning capabilities with configurable effort levels (HIGH, LOW, UNSPECIFIED)

**Enhancement:**
- Improved Gemini model support by implementing version-specific thinking configurations across different model generations (1.5, 2.5, and 3.x)

**Test:**
- Added comprehensive test coverage for thinking level functionality across all supported Gemini model versions

This update enhances the AI reasoning capabilities for users working with the latest Gemini 3.x models.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->