### PR TITLE
fix(gemini): return reasoningEffort in model options for gemini-3

### DIFF
--- a/models/gemini/src/gemini-chat-model.ts
+++ b/models/gemini/src/gemini-chat-model.ts
@@ -379,7 +379,9 @@ export class GeminiChatModel extends ChatModel {
           usage,
           files: files.length ? files : undefined,
           modelOptions: {
-            reasoningEffort: parameters.config?.thinkingConfig?.thinkingBudget,
+            reasoningEffort:
+              parameters.config?.thinkingConfig?.thinkingLevel ||
+              parameters.config?.thinkingConfig?.thinkingBudget,
           },
         },
       },


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(gemini): return reasoningEffort in model options for gemini-3
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**Bug Fix**
- Fixed Gemini chat model configuration to properly prioritize `thinkingLevel` over `thinkingBudget` when setting reasoning effort parameters, ensuring more predictable model behavior for users configuring Gemini-3 models.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->