### PR TITLE
fix(cli): improve hub status display for non-default hubs

### DIFF
--- a/packages/cli/src/commands/hub.ts
+++ b/packages/cli/src/commands/hub.ts
@@ -61,7 +61,7 @@ function printHubStatus(data: {
   console.log(`${chalk.bold("Hub:".padEnd(10))} ${data.hub}`);
   console.log(
     `${chalk.bold("Status:".padEnd(10))} ${
-      data.status === "Connected" ? chalk.green(`${data.status} ✅`) : chalk.gray(`${data.status}`)
+      data.status === "Connected" ? chalk.green(`${data.status} ✅`) : `${data.status}`
     }`,
   );
   console.log("");


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
- Change status text from "Not connected" to "Not Used"
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots
<img width="910" height="367" alt="image" src="https://github.com/user-attachments/assets/d388dc49-c902-449f-8ea9-68dd99f3cb61" />

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [x] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [x] This change adds dependencies, and they are placed in dependencies and devDependencies
- [x] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**Style:**
- Updated CLI hub status display for non-default hubs from "Not connected" to "Not Used" with improved visual styling (gray text instead of red with X emoji)

This change provides clearer messaging to users about hub status, distinguishing between hubs that are simply not the default versus those that have connection issues.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->