### PR TITLE
fix(afs): check module existence on normalized path

### DIFF
--- a/afs/core/src/afs.ts
+++ b/afs/core/src/afs.ts
@@ -38,11 +38,11 @@ export class AFS extends Emitter<AFSRootEvents> implements AFSRoot {
       throw new Error(`Invalid mount path: ${path}. Must start with '/' and contain no other '/'`);
     }
 
+    path = joinURL(MODULES_ROOT_DIR, path);
+
     if (this.modules.has(path)) {
       throw new Error(`Module already mounted at path: ${path}`);
     }
-
-    path = joinURL(MODULES_ROOT_DIR, path);
 
     this.modules.set(path, module);
     module.onMount?.(this);


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
Moved path normalization before the module.has() check to ensure the existence check is performed on the normalized path rather than the raw input path.
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [x] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [x] This change adds dependencies, and they are placed in dependencies and devDependencies
- [x] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**Bug Fix:**
- Fixed duplicate module detection in AFS mount method to work correctly with normalized paths, preventing potential issues where modules could be incorrectly identified as duplicates or allowed when they shouldn't be

This change ensures the file system properly validates module paths before mounting, improving reliability and preventing unexpected behavior during module registration.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->