### PR TITLE
fix(core): support access agent instance by `this` in function agent

### DIFF
--- a/packages/core/src/agents/agent.ts
+++ b/packages/core/src/agents/agent.ts
@@ -1721,7 +1721,7 @@ export class FunctionAgent<I extends Message = Message, O extends Message = Mess
    * @returns Processing result
    */
   process(input: I, options: AgentInvokeOptions) {
-    return this._process(input, options);
+    return this._process.apply(this, [input, options]);
   }
 }
 
@@ -1736,10 +1736,11 @@ export class FunctionAgent<I extends Message = Message, O extends Message = Mess
  * @param context Execution context
  * @returns Processing result, can be synchronous or asynchronous
  */
-export type FunctionAgentFn<I extends Message = any, O extends Message = any> = (
-  input: I,
-  options: AgentInvokeOptions,
-) => PromiseOrValue<AgentProcessResult<O>>;
+export type FunctionAgentFn<
+  I extends Message = any,
+  O extends Message = any,
+  A extends FunctionAgent<I, O> = FunctionAgent<I, O>,
+> = (this: A, input: I, options: AgentInvokeOptions) => PromiseOrValue<AgentProcessResult<O>>;
 
 function functionToAgent<I extends Message, O extends Message>(
   agent: FunctionAgentFn<I, O>,

--- a/packages/core/src/agents/user-agent.ts
+++ b/packages/core/src/agents/user-agent.ts
@@ -59,7 +59,7 @@ export class UserAgent<I extends Message = Message, O extends Message = Message>
 
   async process(input: I, options: AgentInvokeOptions): Promise<AgentProcessResult<O>> {
     if (this._process) {
-      return this._process(input, options);
+      return this._process.apply(this as any, [input, options]);
     }
 
     if (this.activeAgent) {

--- a/packages/core/src/memory/recorder.ts
+++ b/packages/core/src/memory/recorder.ts
@@ -113,6 +113,6 @@ export class MemoryRecorder extends Agent<MemoryRecorderInput, MemoryRecorderOut
     if (!this._process) {
       throw new Error("MemoryRecorder process function is not defined.");
     }
-    return this._process(input, options);
+    return this._process.apply(this as any, [input, options]);
   }
 }

--- a/packages/core/src/memory/retriever.ts
+++ b/packages/core/src/memory/retriever.ts
@@ -114,6 +114,6 @@ export class MemoryRetriever extends Agent<MemoryRetrieverInput, MemoryRetriever
       throw new Error("MemoryRetriever process function is not implemented.");
     }
 
-    return this._process(input, options);
+    return this._process.apply(this as any, [input, options]);
   }
 }

--- a/packages/core/test/agents/function-agent.test.ts
+++ b/packages/core/test/agents/function-agent.test.ts
@@ -22,3 +22,24 @@ test("FunctionAgent from FunctionAgentOptions", async () => {
 
   expect(result).toEqual({ sum: 3 });
 });
+
+test("FunctionAgent should support access agent by this in process function", async () => {
+  const plus = FunctionAgent.from({
+    name: "TestFunctionAgent",
+    description: "A test function agent",
+    process() {
+      const { name, description } = this;
+
+      return { name, description };
+    },
+  });
+
+  const result = await plus.invoke({});
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "description": "A test function agent",
+      "name": "TestFunctionAgent",
+    }
+  `);
+});


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

Usage:

```JavaScript

export default async function testAFSTool() {
  return { msg: await this.afs.list("/modules/workspace") };
}

testAFSTool.afs = {
  modules: [{
    module: "local-fs",
    options: {
      name: "workspace",
      localPath: "."
    }
  }]
}

```

export default async function testAFSTool() {
  return { msg: await this.afs.list("/modules/workspace") };
}

testAFSTool.afs = {
  modules: [{
    module: "local-fs",
    options: {
      name: "workspace",
      localPath: "."
    }
  }]
}


<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**Breaking Changes:**
- Modified `FunctionAgentFn` type signature to support accessing agent instance via `this` parameter

**New Feature:**
- Function agents can now access their agent instance through `this` context, enabling access to agent properties like `name` and `description` within the process function

**Test:**
- Added test coverage for `this` context access in function agents

This enhancement allows function agents to be more self-aware and access their own metadata during execution.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->