### PR TITLE
fix(afs): read method should not throw not found error

### DIFF
--- a/afs/core/src/type.ts
+++ b/afs/core/src/type.ts
@@ -36,12 +36,13 @@ export interface AFSSearchResult {
   message?: string;
 }
 
-export type AFSReadOptions = object;
+export interface AFSReadOptions {
+  context?: any;
+}
 
 export interface AFSReadResult {
   data?: AFSEntry;
   message?: string;
-  context?: any;
 }
 
 export interface AFSDeleteOptions {

--- a/afs/local-fs/test/index.test.ts
+++ b/afs/local-fs/test/index.test.ts
@@ -166,6 +166,20 @@ test("LocalFS should read a nested file", async () => {
   expect(data?.metadata?.type).toBe("file");
 });
 
+test("LocalFS should return error message instead of raising error", async () => {
+  expect(await localFS.read("FILE_NOT_EXIST.md")).toMatchInlineSnapshot(
+    {
+      message: expect.stringMatching("ENOENT: no such file or directory, stat"),
+    },
+    `
+    {
+      "data": undefined,
+      "message": StringMatching "ENOENT: no such file or directory, stat",
+    }
+  `,
+  );
+});
+
 // Write method tests
 test("LocalFS should write a new file", async () => {
   const entry = {


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(afs): read method should not throw not found error
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**Refactor:**
- Modified AFS (Abstract File System) error handling to return error objects instead of throwing exceptions
- Restructured `AFSReadOptions` interface to include optional `context` property

**Bug Fix:**
- Improved error handling for file read operations, providing consistent error responses for non-existent files

**Test:**
- Added test coverage for new error handling behavior in LocalFS implementation

These changes provide more predictable error handling for file system operations, making the API more reliable for applications using the AFS interface.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->