### PR TITLE
fix(afs): set AFS tag for all AFS's skills

### DIFF
--- a/packages/core/src/prompt/skills/afs/base.ts
+++ b/packages/core/src/prompt/skills/afs/base.ts
@@ -1,0 +1,8 @@
+import { Agent, type Message } from "../../../agents/agent.js";
+
+export abstract class AFSSkillBase<
+  I extends Message = Message,
+  O extends Message = Message,
+> extends Agent<I, O> {
+  override tag = "AFS";
+}

--- a/packages/core/src/prompt/skills/afs/delete.ts
+++ b/packages/core/src/prompt/skills/afs/delete.ts
@@ -1,10 +1,6 @@
 import { z } from "zod";
-import {
-  Agent,
-  type AgentInvokeOptions,
-  type AgentOptions,
-  type Message,
-} from "../../../agents/agent.js";
+import type { AgentInvokeOptions, AgentOptions, Message } from "../../../agents/agent.js";
+import { AFSSkillBase } from "./base.js";
 
 export interface AFSDeleteInput extends Message {
   path: string;
@@ -22,7 +18,7 @@ export interface AFSDeleteAgentOptions extends AgentOptions<AFSDeleteInput, AFSD
   afs: NonNullable<AgentOptions<AFSDeleteInput, AFSDeleteOutput>["afs"]>;
 }
 
-export class AFSDeleteAgent extends Agent<AFSDeleteInput, AFSDeleteOutput> {
+export class AFSDeleteAgent extends AFSSkillBase<AFSDeleteInput, AFSDeleteOutput> {
   constructor(options: AFSDeleteAgentOptions) {
     super({
       name: "afs_delete",

--- a/packages/core/src/prompt/skills/afs/edit.ts
+++ b/packages/core/src/prompt/skills/afs/edit.ts
@@ -1,10 +1,6 @@
 import { z } from "zod";
-import {
-  Agent,
-  type AgentInvokeOptions,
-  type AgentOptions,
-  type Message,
-} from "../../../agents/agent.js";
+import type { AgentInvokeOptions, AgentOptions, Message } from "../../../agents/agent.js";
+import { AFSSkillBase } from "./base.js";
 
 export interface Patch {
   start_line: number;
@@ -30,7 +26,7 @@ export interface AFSEditAgentOptions extends AgentOptions<AFSEditInput, AFSEditO
   afs: NonNullable<AgentOptions<AFSEditInput, AFSEditOutput>["afs"]>;
 }
 
-export class AFSEditAgent extends Agent<AFSEditInput, AFSEditOutput> {
+export class AFSEditAgent extends AFSSkillBase<AFSEditInput, AFSEditOutput> {
   constructor(options: AFSEditAgentOptions) {
     super({
       name: "afs_edit",

--- a/packages/core/src/prompt/skills/afs/exec.ts
+++ b/packages/core/src/prompt/skills/afs/exec.ts
@@ -1,10 +1,6 @@
 import { z } from "zod";
-import {
-  Agent,
-  type AgentInvokeOptions,
-  type AgentOptions,
-  type Message,
-} from "../../../agents/agent.js";
+import type { AgentInvokeOptions, AgentOptions, Message } from "../../../agents/agent.js";
+import { AFSSkillBase } from "./base.js";
 
 export interface AFSExecInput extends Message {
   path: string;
@@ -19,15 +15,17 @@ export interface AFSExecAgentOptions extends AgentOptions<AFSExecInput, AFSExecO
   afs: NonNullable<AgentOptions<AFSExecInput, AFSExecOutput>["afs"]>;
 }
 
-export class AFSExecAgent extends Agent<AFSExecInput, AFSExecOutput> {
+export class AFSExecAgent extends AFSSkillBase<AFSExecInput, AFSExecOutput> {
   constructor(options: AFSExecAgentOptions) {
     super({
       name: "afs_exec",
-      description:
-        "Execute functions or commands from AFS modules. Use when running operations provided by mounted modules.",
+      description: `
+Execute files marked as executable in the Agentic File System (AFS).
+Use this to run executable files registered at a given path with specified arguments.
+      `.trim(),
       ...options,
       inputSchema: z.object({
-        path: z.string().describe("Absolute path to the executable function in AFS"),
+        path: z.string().describe("Absolute path to the executable file in AFS"),
         args: z.string().describe("JSON string of arguments matching the function's input schema"),
       }),
       outputSchema: z.object({

--- a/packages/core/src/prompt/skills/afs/list.ts
+++ b/packages/core/src/prompt/skills/afs/list.ts
@@ -1,11 +1,7 @@
 import type { AFSListOptions } from "@aigne/afs";
 import { z } from "zod";
-import {
-  Agent,
-  type AgentInvokeOptions,
-  type AgentOptions,
-  type Message,
-} from "../../../agents/agent.js";
+import type { AgentInvokeOptions, AgentOptions, Message } from "../../../agents/agent.js";
+import { AFSSkillBase } from "./base.js";
 
 export interface AFSListInput extends Message {
   path: string;
@@ -25,7 +21,7 @@ export interface AFSListAgentOptions extends AgentOptions<AFSListInput, AFSListO
   afs: NonNullable<AgentOptions<AFSListInput, AFSListOutput>["afs"]>;
 }
 
-export class AFSListAgent extends Agent<AFSListInput, AFSListOutput> {
+export class AFSListAgent extends AFSSkillBase<AFSListInput, AFSListOutput> {
   constructor(options: AFSListAgentOptions) {
     super({
       name: "afs_list",

--- a/packages/core/src/prompt/skills/afs/read.ts
+++ b/packages/core/src/prompt/skills/afs/read.ts
@@ -1,11 +1,7 @@
 import type { AFSEntry } from "@aigne/afs";
 import { z } from "zod";
-import {
-  Agent,
-  type AgentInvokeOptions,
-  type AgentOptions,
-  type Message,
-} from "../../../agents/agent.js";
+import type { AgentInvokeOptions, AgentOptions, Message } from "../../../agents/agent.js";
+import { AFSSkillBase } from "./base.js";
 
 export interface AFSReadInput extends Message {
   path: string;
@@ -25,7 +21,7 @@ export interface AFSReadAgentOptions extends AgentOptions<AFSReadInput, AFSReadO
   afs: NonNullable<AgentOptions<AFSReadInput, AFSReadOutput>["afs"]>;
 }
 
-export class AFSReadAgent extends Agent<AFSReadInput, AFSReadOutput> {
+export class AFSReadAgent extends AFSSkillBase<AFSReadInput, AFSReadOutput> {
   constructor(options: AFSReadAgentOptions) {
     super({
       name: "afs_read",

--- a/packages/core/src/prompt/skills/afs/rename.ts
+++ b/packages/core/src/prompt/skills/afs/rename.ts
@@ -1,10 +1,6 @@
 import { z } from "zod";
-import {
-  Agent,
-  type AgentInvokeOptions,
-  type AgentOptions,
-  type Message,
-} from "../../../agents/agent.js";
+import type { AgentInvokeOptions, AgentOptions, Message } from "../../../agents/agent.js";
+import { AFSSkillBase } from "./base.js";
 
 export interface AFSRenameInput extends Message {
   oldPath: string;
@@ -24,7 +20,7 @@ export interface AFSRenameAgentOptions extends AgentOptions<AFSRenameInput, AFSR
   afs: NonNullable<AgentOptions<AFSRenameInput, AFSRenameOutput>["afs"]>;
 }
 
-export class AFSRenameAgent extends Agent<AFSRenameInput, AFSRenameOutput> {
+export class AFSRenameAgent extends AFSSkillBase<AFSRenameInput, AFSRenameOutput> {
   constructor(options: AFSRenameAgentOptions) {
     super({
       name: "afs_rename",

--- a/packages/core/src/prompt/skills/afs/search.ts
+++ b/packages/core/src/prompt/skills/afs/search.ts
@@ -1,11 +1,7 @@
 import type { AFSEntry, AFSSearchOptions } from "@aigne/afs";
 import { z } from "zod";
-import {
-  Agent,
-  type AgentInvokeOptions,
-  type AgentOptions,
-  type Message,
-} from "../../../agents/agent.js";
+import type { AgentInvokeOptions, AgentOptions, Message } from "../../../agents/agent.js";
+import { AFSSkillBase } from "./base.js";
 
 export interface AFSSearchInput extends Message {
   path: string;
@@ -27,7 +23,7 @@ export interface AFSSearchAgentOptions extends AgentOptions<AFSSearchInput, AFSS
   afs: NonNullable<AgentOptions<AFSSearchInput, AFSSearchOutput>["afs"]>;
 }
 
-export class AFSSearchAgent extends Agent<AFSSearchInput, AFSSearchOutput> {
+export class AFSSearchAgent extends AFSSkillBase<AFSSearchInput, AFSSearchOutput> {
   constructor(options: AFSSearchAgentOptions) {
     super({
       name: "afs_search",

--- a/packages/core/src/prompt/skills/afs/write.ts
+++ b/packages/core/src/prompt/skills/afs/write.ts
@@ -1,10 +1,6 @@
 import { z } from "zod";
-import {
-  Agent,
-  type AgentInvokeOptions,
-  type AgentOptions,
-  type Message,
-} from "../../../agents/agent.js";
+import type { AgentInvokeOptions, AgentOptions, Message } from "../../../agents/agent.js";
+import { AFSSkillBase } from "./base.js";
 
 export interface AFSWriteInput extends Message {
   path: string;
@@ -23,7 +19,7 @@ export interface AFSWriteAgentOptions extends AgentOptions<AFSWriteInput, AFSWri
   afs: NonNullable<AgentOptions<AFSWriteInput, AFSWriteOutput>["afs"]>;
 }
 
-export class AFSWriteAgent extends Agent<AFSWriteInput, AFSWriteOutput> {
+export class AFSWriteAgent extends AFSSkillBase<AFSWriteInput, AFSWriteOutput> {
   constructor(options: AFSWriteAgentOptions) {
     super({
       name: "afs_write",

--- a/packages/core/test/prompt/prompt-builder.test.ts
+++ b/packages/core/test/prompt/prompt-builder.test.ts
@@ -917,7 +917,10 @@ test("PromptBuilder should build with afs correctly", async () => {
         },
         {
           "function": {
-            "description": "Execute functions or commands from AFS modules. Use when running operations provided by mounted modules.",
+            "description": 
+    "Execute files marked as executable in the Agentic File System (AFS).
+    Use this to run executable files registered at a given path with specified arguments."
+    ,
             "name": "afs_exec",
             "parameters": {
               "$schema": "http://json-schema.org/draft-07/schema#",
@@ -928,7 +931,7 @@ test("PromptBuilder should build with afs correctly", async () => {
                   "type": "string",
                 },
                 "path": {
-                  "description": "Absolute path to the executable function in AFS",
+                  "description": "Absolute path to the executable file in AFS",
                   "type": "string",
                 },
               },
@@ -1134,8 +1137,11 @@ ${"```"}
       description: Rename or move files and directories. Use when reorganizing files,
         changing names, or moving to different locations.
     - name: afs_exec
-      description: Execute functions or commands from AFS modules. Use when running
-        operations provided by mounted modules.
+      description: >-
+        Execute files marked as executable in the Agentic File System (AFS).
+
+        Use this to run executable files registered at a given path with specified
+        arguments.
 
     \`\`\`
 

--- a/packages/core/test/prompt/skills/afs/afs.test.ts
+++ b/packages/core/test/prompt/skills/afs/afs.test.ts
@@ -456,7 +456,10 @@ test("getAFSSkills should return all AFS skills", async () => {
         },
       },
       {
-        "description": "Execute functions or commands from AFS modules. Use when running operations provided by mounted modules.",
+        "description": 
+    "Execute files marked as executable in the Agentic File System (AFS).
+    Use this to run executable files registered at a given path with specified arguments."
+    ,
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": true,
@@ -466,7 +469,7 @@ test("getAFSSkills should return all AFS skills", async () => {
               "type": "string",
             },
             "path": {
-              "description": "Absolute path to the executable function in AFS",
+              "description": "Absolute path to the executable file in AFS",
               "type": "string",
             },
           },

--- a/packages/core/test/prompt/skills/afs/index.test.ts
+++ b/packages/core/test/prompt/skills/afs/index.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "bun:test";
+import { AFS } from "@aigne/afs";
+import { getAFSSkills } from "@aigne/core/prompt/skills/afs";
+
+test("AFS's skills should have correct tag", async () => {
+  const skills = await getAFSSkills(new AFS());
+  expect(skills.every((skill) => skill.tag === "AFS")).toBe(true);
+});


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(afs): set AFS tag for all AFS's skills
<img width="1073" height="293" alt="Screenshot 2025-12-19 at 11 12 27" src="https://github.com/user-attachments/assets/3b3ba127-dc0c-4a67-bf72-5ebd33cb80ce" />

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**Refactor:**
- Standardized AFS (Agentic File System) skill architecture with unified base class for improved code organization and maintainability

**Documentation:**
- Clarified AFS exec functionality to specify it executes "files marked as executable" rather than "functions or commands" for better semantic accuracy

**Test:**
- Enhanced test coverage to verify proper AFS skill tagging and updated descriptions

These changes improve internal code structure and documentation clarity without affecting existing functionality or user-facing features.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->