### PR TITLE
fix(afs): always respect ignore option for local-fs

### DIFF
--- a/afs/local-fs/src/index.ts
+++ b/afs/local-fs/src/index.ts
@@ -363,7 +363,6 @@ export class LocalFS implements AFSModule {
     checkPath: string,
   ): Promise<{ ig: ReturnType<typeof ignore>; gitRoot: string | null } | null> {
     const ig = ignore();
-    let hasRules = false;
 
     // Find git root by searching upwards
     let gitRoot: string | null = null;
@@ -421,7 +420,6 @@ export class LocalFS implements AFSModule {
         const gitignorePath = join(dirPath, ".gitignore");
         const gitignoreContent = await readFile(gitignorePath, "utf8");
         ig.add(gitignoreContent);
-        hasRules = true;
       } catch {
         // .gitignore doesn't exist at this level, continue
       }
@@ -430,6 +428,6 @@ export class LocalFS implements AFSModule {
     ig.add(".git");
     ig.add(this.options.ignore || []);
 
-    return hasRules ? { ig, gitRoot } : null;
+    return { ig, gitRoot };
   }
 }


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(afs): always respect ignore option for local-fs
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**Bug Fix:**
- Fixed LocalFS ignore rules handling to consistently return ignore objects even when no `.gitignore` files are present, ensuring custom ignore patterns work reliably in all scenarios

**Test:**
- Added comprehensive test coverage for ignore pattern functionality when no `.gitignore` file exists, validating that default `.git` directory exclusion and custom patterns are properly respected

This change improves the reliability of file filtering operations in LocalFS by ensuring ignore rules are always available for processing.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->