### PR TITLE
fix(models): support cache the last message for anthropic chat model

### DIFF
--- a/models/anthropic/src/anthropic-chat-model.ts
+++ b/models/anthropic/src/anthropic-chat-model.ts
@@ -401,7 +401,8 @@ async function convertMessages({
   const msgs: MessageParam[] = [];
 
   // Extract cache configuration with defaults
-  const { shouldCache, ttl, strategy, autoBreakpoints } = parseCacheConfig(modelOptions);
+  const { shouldCache, strategy, autoBreakpoints, ...cacheConfig } = parseCacheConfig(modelOptions);
+  const ttl = cacheConfig.ttl === "1h" ? "1h" : undefined;
 
   for (const msg of messages) {
     if (msg.role === "system") {
@@ -460,12 +461,31 @@ async function convertMessages({
   }
 
   // Apply cache_control to the last system block if auto strategy is enabled
-  if (shouldCache && strategy === "auto" && autoBreakpoints.system && systemBlocks.length > 0) {
-    const lastBlock = systemBlocks[systemBlocks.length - 1];
-    if (lastBlock) {
-      lastBlock.cache_control = { type: "ephemeral" };
-      if (ttl === "1h") {
-        lastBlock.cache_control = { type: "ephemeral", ttl: "1h" };
+  if (shouldCache && strategy === "auto") {
+    if (autoBreakpoints.system && systemBlocks.length > 0) {
+      const lastBlock = systemBlocks[systemBlocks.length - 1];
+      if (lastBlock) {
+        lastBlock.cache_control = { type: "ephemeral", ttl };
+      }
+    }
+
+    if (autoBreakpoints.lastMessage) {
+      const lastMsg = msgs[msgs.length - 1];
+      if (lastMsg) {
+        if (typeof lastMsg.content === "string") {
+          lastMsg.content = [
+            { type: "text", text: lastMsg.content, cache_control: { type: "ephemeral", ttl } },
+          ];
+        } else if (Array.isArray(lastMsg.content)) {
+          const lastBlock = lastMsg.content[lastMsg.content.length - 1];
+          if (
+            lastBlock &&
+            lastBlock.type !== "thinking" &&
+            lastBlock.type !== "redacted_thinking"
+          ) {
+            lastBlock.cache_control = { type: "ephemeral", ttl };
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(models): support cache the last message for anthropic chat model

before:
```
✔ docsmith (model: claude-sonnet-4-5-20250929, 1093244 input tokens, 201472 cached, 6296 cache write, 28675 output tokens)

(1,093,244 ÷ 1,000,000 × 3)        // base input tokens
+ (201,472 ÷ 1,000,000 × 0.30)     // cache read tokens (0.1 × input price)
+ (6,296 ÷ 1,000,000 × 3.75)       // cache write tokens (1.25 × input price, 5m)
+ (28,675 ÷ 1,000,000 × 15)        // output tokens
= $3.79
```

after:
```
✔ docsmith (model: claude-sonnet-4-5-20250929, 443 input tokens, 699921 cached, 48989 cache write, 27842 output tokens)

(443 ÷ 1,000,000 × 3)              // base input tokens
+ (699,921 ÷ 1,000,000 × 0.30)     // cache read tokens
+ (48,989 ÷ 1,000,000 × 3.75)      // cache write tokens
+ (27,842 ÷ 1,000,000 × 15)        // output tokens
= $0.81
```
<!--
  @example:
    1. Fixed xxx
    3. Improved xxx
    4. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**New Feature:**
- Added automatic caching support for the last message in Anthropic chat model conversations
- Introduced `autoBreakpoints.lastMessage` configuration option to enable intelligent message caching
- Enhanced caching logic to exclude thinking-related content blocks from cache optimization

**Performance:**
- Improved response times through strategic caching of conversation context
- Reduced API costs by leveraging Anthropic's cache control features for frequently accessed message content

These changes provide better performance and cost efficiency for applications using the Anthropic chat model with minimal configuration required.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->