### PR TITLE
fix(agent-library): set default instructions for agent skill manager

### DIFF
--- a/packages/agent-library/src/agent-skill-manager/index.ts
+++ b/packages/agent-library/src/agent-skill-manager/index.ts
@@ -1,4 +1,11 @@
-import { AIAgent, type AIAgentOptions, type Message } from "@aigne/core";
+import {
+  type Agent,
+  AIAgent,
+  type AIAgentOptions,
+  type AIAgentToolChoice,
+  type Message,
+} from "@aigne/core";
+import { type Instructions, instructionsToPromptBuilder } from "@aigne/core/loader/schema.js";
 import { AgentSkillManagerSystemPrompt } from "./prompt.js";
 
 export interface AgentSkillManagerOptions<I extends Message = Message, O extends Message = Message>
@@ -8,10 +15,36 @@ export default class AgentSkillManagerAgent<
   I extends Message = Message,
   O extends Message = Message,
 > extends AIAgent<I, O> {
+  static override async load<I extends Message = any, O extends Message = any>(options: {
+    filepath: string;
+    parsed: object;
+  }): Promise<Agent<I, O>> {
+    interface AIAgentLoadSchema {
+      instructions?: Instructions;
+      autoReorderSystemMessages?: boolean;
+      autoMergeSystemMessages?: boolean;
+      inputKey?: string;
+      inputFileKey?: string;
+      outputKey?: string;
+      outputFileKey?: string;
+      toolChoice?: AIAgentToolChoice;
+      toolCallsConcurrency?: number;
+      keepTextInToolUses?: boolean;
+    }
+
+    const schema = AIAgent.schema<AIAgentLoadSchema>(options);
+    const valid = await schema.parseAsync(options.parsed);
+    return new AgentSkillManagerAgent<I, O>({
+      ...options.parsed,
+      ...valid,
+      instructions: valid.instructions && instructionsToPromptBuilder(valid.instructions),
+    });
+  }
+
   constructor(options: AgentSkillManagerOptions<I, O>) {
     super({
-      instructions: AgentSkillManagerSystemPrompt,
       ...options,
+      instructions: options.instructions || AgentSkillManagerSystemPrompt,
     });
   }
 }


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(agent-library): set default instructions for agent skill manager
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**New Feature:**
- Added static `load` method to `AgentSkillManagerAgent` class for loading agent configurations from parsed objects
- Enhanced constructor flexibility with fallback instruction handling for improved configuration management

**Refactor:**
- Improved agent initialization process with better default instruction handling and backward compatibility support

These changes provide developers with more flexible ways to instantiate and configure agent skill managers while maintaining existing functionality.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->