### PR TITLE
fix(cli): add chat aliases for interactive option

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -53,6 +53,7 @@ export function createRunCommand({
           describe: "Run in interactive chat mode",
           type: "boolean",
           default: false,
+          alias: ["chat"],
         })
         .help(false)
         .version(false)

--- a/packages/cli/src/utils/yargs.ts
+++ b/packages/cli/src/utils/yargs.ts
@@ -44,6 +44,7 @@ export const withRunAgentCommonOptions = (yargs: Argv) =>
       describe: "Run in interactive chat mode",
       type: "boolean",
       default: false,
+      alias: ["chat"],
     })
     .option("session-id", {
       describe: "Session ID for chat-based agents to maintain context across interactions",

--- a/packages/cli/test/commands/__snapshots__/aigne.test.ts.snap
+++ b/packages/cli/test/commands/__snapshots__/aigne.test.ts.snap
@@ -33,9 +33,9 @@ Positionals:
   entry-agent  Name of the agent to run (defaults to the entry agent if not specified)  [string]
 
 Options:
-      --help         Show help
-  -v, --version      Show version number  [boolean]
-      --interactive  Run in interactive chat mode  [boolean] [default: false]"
+      --help                 Show help
+  -v, --version              Show version number  [boolean]
+      --interactive, --chat  Run in interactive chat mode  [boolean] [default: false]"
 ,
   ],
 ]

--- a/packages/cli/test/commands/app/app.test.ts
+++ b/packages/cli/test/commands/app/app.test.ts
@@ -100,24 +100,28 @@ test("app command should register doc-smith to yargs", async () => {
                                agent definitions or models.                 [string]
 
     Options:
-          --interactive  Run in interactive chat mode     [boolean] [default: false]
-          --session-id   Session ID for chat-based agents to maintain context across
-                         interactions                                       [string]
-      -i, --input        Input to the agent, use @<file> to read from a file [array]
-          --input-file   Input files to the agent                            [array]
-          --format       Input format for the agent (available: text, json, yaml
-                         default: text)   [string] [choices: "text", "json", "yaml"]
-      -o, --output       Output file to save the result (default: stdout)   [string]
-          --output-key   Key in the result to save to the output file
-                                                       [string] [default: "message"]
-          --force        Truncate the output file if it exists, and create directory
-                         if the output path does not exists
+          --interactive, --chat  Run in interactive chat mode
                                                           [boolean] [default: false]
-          --log-level    Log level for detailed debugging information. Values:
-                         silent, error, warn, info, debug
+          --session-id           Session ID for chat-based agents to maintain
+                                 context across interactions                [string]
+      -i, --input                Input to the agent, use @<file> to read from a file
+                                                                             [array]
+          --input-file           Input files to the agent                    [array]
+          --format               Input format for the agent (available: text, json,
+                                 yaml default: text)
+                                          [string] [choices: "text", "json", "yaml"]
+      -o, --output               Output file to save the result (default: stdout)
+                                                                            [string]
+          --output-key           Key in the result to save to the output file
+                                                       [string] [default: "message"]
+          --force                Truncate the output file if it exists, and create
+                                 directory if the output path does not exists
+                                                          [boolean] [default: false]
+          --log-level            Log level for detailed debugging information.
+                                 Values: silent, error, warn, info, debug
                                                         [string] [default: "silent"]
-      -v, --version      Show version number                               [boolean]
-      -h, --help         Show help                                         [boolean]"
+      -v, --version              Show version number                       [boolean]
+      -h, --help                 Show help                                 [boolean]"
   `);
 
   const runWithAIGNESpy = spyOn(runWithAIGNE, "runAgentWithAIGNE").mockReturnValueOnce(
@@ -152,6 +156,7 @@ test("app command should register doc-smith to yargs", async () => {
         "_": [
           "generate",
         ],
+        "chat": false,
         "force": false,
         "input": {
           "title": "test title to generate",

--- a/packages/cli/test/commands/run.test.ts
+++ b/packages/cli/test/commands/run.test.ts
@@ -247,24 +247,28 @@ test("run command should register commands correctly", async () => {
                                agent definitions or models.                 [string]
 
     Options:
-          --interactive  Run in interactive chat mode     [boolean] [default: false]
-          --session-id   Session ID for chat-based agents to maintain context across
-                         interactions                                       [string]
-      -i, --input        Input to the agent, use @<file> to read from a file [array]
-          --input-file   Input files to the agent                            [array]
-          --format       Input format for the agent (available: text, json, yaml
-                         default: text)   [string] [choices: "text", "json", "yaml"]
-      -o, --output       Output file to save the result (default: stdout)   [string]
-          --output-key   Key in the result to save to the output file
-                                                       [string] [default: "message"]
-          --force        Truncate the output file if it exists, and create directory
-                         if the output path does not exists
+          --interactive, --chat  Run in interactive chat mode
                                                           [boolean] [default: false]
-          --log-level    Log level for detailed debugging information. Values:
-                         silent, error, warn, info, debug
+          --session-id           Session ID for chat-based agents to maintain
+                                 context across interactions                [string]
+      -i, --input                Input to the agent, use @<file> to read from a file
+                                                                             [array]
+          --input-file           Input files to the agent                    [array]
+          --format               Input format for the agent (available: text, json,
+                                 yaml default: text)
+                                          [string] [choices: "text", "json", "yaml"]
+      -o, --output               Output file to save the result (default: stdout)
+                                                                            [string]
+          --output-key           Key in the result to save to the output file
+                                                       [string] [default: "message"]
+          --force                Truncate the output file if it exists, and create
+                                 directory if the output path does not exists
+                                                          [boolean] [default: false]
+          --log-level            Log level for detailed debugging information.
+                                 Values: silent, error, warn, info, debug
                                                         [string] [default: "silent"]
-      -h, --help         Show help                                         [boolean]
-      -v, --version      Show version number                               [boolean]"
+      -h, --help                 Show help                                 [boolean]
+      -v, --version              Show version number                       [boolean]"
     ,
     ]
   `);


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
1. fix(cli): add chat aliases for interactive option
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**New Feature:**
- Added `--chat` alias for the existing `--interactive` CLI option, providing users with an alternative and more intuitive command name to enable interactive chat mode functionality

**Test:**
- Updated test suites and snapshots to verify the new `--chat` alias works correctly alongside the existing `--interactive` option

This enhancement improves user experience by offering a more descriptive command alias while maintaining full backward compatibility with existing workflows.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->