### PR TITLE
fix(afs): throw errors instead of logging in AFS module operations

### DIFF
--- a/afs/core/src/afs.ts
+++ b/afs/core/src/afs.ts
@@ -129,7 +129,7 @@ export class AFS extends Emitter<AFSRootEvents> implements AFSRoot {
           results.push(moduleEntry);
         }
       } catch (error) {
-        console.error(`Error listing from module at ${matched.modulePath}`, error);
+        throw new Error(`Error listing from module at ${matched.modulePath}: ${error.message}`);
       }
     }
 
@@ -297,7 +297,7 @@ export class AFS extends Emitter<AFSRootEvents> implements AFSRoot {
         );
         if (message) messages.push(message);
       } catch (error) {
-        console.error(`Error searching in module at ${modulePath}`, error);
+        throw new Error(`Error searching in module at ${modulePath}: ${error.message}`);
       }
     }
 


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**Bug Fix:**
- Improved error handling in AFS module by throwing exceptions instead of silently logging errors to console
- Module listing and search operations now properly propagate errors to calling code, enabling better error recovery and debugging

**Breaking Change:**
- Applications using AFS module operations must now handle thrown exceptions rather than relying on console error messages
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->