### PR TITLE
fix(core): disable session manger for compactor and memory extractor

### DIFF
--- a/packages/core/src/prompt/compact/compactor.ts
+++ b/packages/core/src/prompt/compact/compactor.ts
@@ -46,6 +46,9 @@ export class AISessionCompactor extends AIAgent<CompactorInput, CompactContent> 
       }),
       instructions: COMPACTOR_INSTRUCTIONS,
       ...omitBy(options ?? {}, (v) => isNil(v)),
+      session: {
+        mode: "disabled",
+      },
     });
   }
 }

--- a/packages/core/src/prompt/compact/session-memory-extractor.ts
+++ b/packages/core/src/prompt/compact/session-memory-extractor.ts
@@ -150,6 +150,9 @@ export class AISessionMemoryExtractor extends AIAgent<MemoryExtractorInput, Memo
       }),
       instructions: EXTRACTOR_INSTRUCTIONS,
       ...omitBy(options ?? {}, (v) => isNil(v)),
+      session: {
+        mode: "disabled",
+      },
     });
   }
 }

--- a/packages/core/src/prompt/compact/user-memory-extractor.ts
+++ b/packages/core/src/prompt/compact/user-memory-extractor.ts
@@ -132,6 +132,9 @@ export class AIUserMemoryExtractor extends AIAgent<
       }),
       instructions: EXTRACTOR_INSTRUCTIONS,
       ...omitBy(options ?? {}, (v) => isNil(v)),
+      session: {
+        mode: "disabled",
+      },
     });
   }
 }


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

### Bug Fix
- Fixed session management configuration in AI compactor and memory extractor components to properly disable session tracking and persistence functionality

### Chore
- Standardized session configuration across `AISessionCompactor`, `AISessionMemoryExtractor`, and `AIUserMemoryExtractor` classes

**Note**: The PR title contains a spelling error ("session manger" should be "session manager") that should be corrected for clarity and professionalism in the commit history.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->