### PR TITLE
fix(core): invoke afs methods with aigne context

### DIFF
--- a/packages/core/src/prompt/skills/afs/delete.ts
+++ b/packages/core/src/prompt/skills/afs/delete.ts
@@ -55,11 +55,12 @@ Usage:
     });
   }
 
-  async process(input: AFSDeleteInput, _options: AgentInvokeOptions): Promise<AFSDeleteOutput> {
+  async process(input: AFSDeleteInput, options: AgentInvokeOptions): Promise<AFSDeleteOutput> {
     if (!this.afs) throw new Error("AFS is not configured for this agent.");
 
     const result = await this.afs.delete(input.path, {
       recursive: input.recursive ?? false,
+      context: options.context,
     });
 
     return {

--- a/packages/core/src/prompt/skills/afs/edit.ts
+++ b/packages/core/src/prompt/skills/afs/edit.ts
@@ -67,7 +67,7 @@ Usage:
     });
   }
 
-  async process(input: AFSEditInput, _options: AgentInvokeOptions): Promise<AFSEditOutput> {
+  async process(input: AFSEditInput, options: AgentInvokeOptions): Promise<AFSEditOutput> {
     if (!this.afs) throw new Error("AFS is not configured for this agent.");
 
     const { path, oldString, newString, replaceAll = false } = input;
@@ -76,7 +76,7 @@ Usage:
       throw new Error("oldString and newString must be different");
     }
 
-    const readResult = await this.afs.read(path);
+    const readResult = await this.afs.read(path, { context: options.context });
     if (!readResult.data?.content || typeof readResult.data.content !== "string") {
       throw new Error(`Cannot read file content from: ${path}`);
     }
@@ -103,9 +103,7 @@ Usage:
       ? originalContent.split(oldString).join(newString)
       : originalContent.replace(oldString, newString);
 
-    await this.afs.write(path, {
-      content: updatedContent,
-    });
+    await this.afs.write(path, { content: updatedContent }, { context: options.context });
 
     // Generate snippet around the edit location
     const snippet = this.extractSnippet(updatedContent, firstOccurrenceIndex, newString.length);

--- a/packages/core/src/prompt/skills/afs/exec.ts
+++ b/packages/core/src/prompt/skills/afs/exec.ts
@@ -53,7 +53,7 @@ Usage:
     if (!this.afs) throw new Error("AFS is not configured for this agent.");
 
     return {
-      ...(await this.afs.exec(input.path, JSON.parse(input.args), options)),
+      ...(await this.afs.exec(input.path, JSON.parse(input.args), { context: options.context })),
     };
   }
 }

--- a/packages/core/src/prompt/skills/afs/list.ts
+++ b/packages/core/src/prompt/skills/afs/list.ts
@@ -89,12 +89,13 @@ Usage:
     return super.formatOutput(output);
   }
 
-  async process(input: AFSListInput, _options: AgentInvokeOptions): Promise<AFSListOutput> {
+  async process(input: AFSListInput, options: AgentInvokeOptions): Promise<AFSListOutput> {
     if (!this.afs) throw new Error("AFS is not configured for this agent.");
 
     const { data, message } = await this.afs.list(input.path, {
       ...input.options,
       format: "simple-list",
+      context: options.context,
     });
 
     return {

--- a/packages/core/src/prompt/skills/afs/read.ts
+++ b/packages/core/src/prompt/skills/afs/read.ts
@@ -83,10 +83,10 @@ Usage:
     return super.formatOutput({ ...output, data: output.data || null });
   }
 
-  async process(input: AFSReadInput, _options: AgentInvokeOptions): Promise<AFSReadOutput> {
+  async process(input: AFSReadInput, options: AgentInvokeOptions): Promise<AFSReadOutput> {
     if (!this.afs) throw new Error("AFS is not configured for this agent.");
 
-    const result = await this.afs.read(input.path);
+    const result = await this.afs.read(input.path, { context: options.context });
 
     if (!result.data?.content || typeof result.data.content !== "string") {
       return {

--- a/packages/core/src/prompt/skills/afs/rename.ts
+++ b/packages/core/src/prompt/skills/afs/rename.ts
@@ -61,11 +61,12 @@ Usage:
     });
   }
 
-  async process(input: AFSRenameInput, _options: AgentInvokeOptions): Promise<AFSRenameOutput> {
+  async process(input: AFSRenameInput, options: AgentInvokeOptions): Promise<AFSRenameOutput> {
     if (!this.afs) throw new Error("AFS is not configured for this agent.");
 
     const result = await this.afs.rename(input.oldPath, input.newPath, {
       overwrite: input.overwrite ?? false,
+      context: options.context,
     });
 
     return {

--- a/packages/core/src/prompt/skills/afs/search.ts
+++ b/packages/core/src/prompt/skills/afs/search.ts
@@ -79,10 +79,13 @@ Usage:
     });
   }
 
-  async process(input: AFSSearchInput, _options: AgentInvokeOptions): Promise<AFSSearchOutput> {
+  async process(input: AFSSearchInput, options: AgentInvokeOptions): Promise<AFSSearchOutput> {
     if (!this.afs) throw new Error("AFS is not configured for this agent.");
 
-    const result = await this.afs.search(input.path, input.query, input.options);
+    const result = await this.afs.search(input.path, input.query, {
+      ...input.options,
+      context: options.context,
+    });
 
     return {
       status: "success",

--- a/packages/core/src/prompt/skills/afs/write.ts
+++ b/packages/core/src/prompt/skills/afs/write.ts
@@ -63,7 +63,7 @@ Usage:
     });
   }
 
-  async process(input: AFSWriteInput, _options: AgentInvokeOptions): Promise<AFSWriteOutput> {
+  async process(input: AFSWriteInput, options: AgentInvokeOptions): Promise<AFSWriteOutput> {
     if (!this.afs) throw new Error("AFS is not configured for this agent.");
 
     const _result = await this.afs.write(
@@ -73,6 +73,7 @@ Usage:
       },
       {
         append: input.append ?? false,
+        context: options.context,
       },
     );
 

--- a/packages/core/test/prompt/prompts/afs-builtin-prompt.test.ts
+++ b/packages/core/test/prompt/prompts/afs-builtin-prompt.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { AFS } from "@aigne/afs";
 import { AFSHistory } from "@aigne/afs-history";
-import { getAFSSystemPrompt } from "@aigne/core/prompt/prompts/afs-builtin-prompt";
+import { getAFSSystemPrompt } from "@aigne/core/prompt/prompts/afs-builtin-prompt.js";
 
 test("getAFSSystemPrompt should inject afs modules to the system prompt", async () => {
   const afs = new AFS({}).mount(new AFSHistory());

--- a/packages/core/test/prompt/skills/afs/afs.test.ts
+++ b/packages/core/test/prompt/skills/afs/afs.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { AFS } from "@aigne/afs";
-import { getAFSSkills } from "@aigne/core/prompt/skills/afs";
+import { getAFSSkills } from "@aigne/core/prompt/skills/afs/index.js";
 import zodToJsonSchema from "zod-to-json-schema";
 
 test("getAFSSkills should return all AFS skills", async () => {

--- a/packages/core/test/prompt/skills/afs/delete.test.ts
+++ b/packages/core/test/prompt/skills/afs/delete.test.ts
@@ -1,7 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
 import assert from "node:assert";
 import { AFS } from "@aigne/afs";
-import { getAFSSkills } from "@aigne/core/prompt/skills/afs";
+import { getAFSSkills } from "@aigne/core/prompt/skills/afs/index.js";
 
 test("AFS'skill delete should invoke afs.delete", async () => {
   const afs = new AFS();
@@ -22,16 +22,12 @@ test("AFS'skill delete should invoke afs.delete", async () => {
     }
   `);
 
-  expect(deleteSpy.mock.calls).toMatchInlineSnapshot(`
-    [
-      [
-        "/foo/bar",
-        {
-          "recursive": false,
-        },
-      ],
-    ]
-  `);
+  expect(deleteSpy.mock.calls.length).toBe(1);
+  expect(deleteSpy.mock.calls[0]?.[0]).toBe("/foo/bar");
+  expect(deleteSpy.mock.calls[0]?.[1]?.recursive).toBe(false);
+  expect(deleteSpy.mock.calls[0]?.[1]?.context).toBeDefined();
+  expect(deleteSpy.mock.calls[0]?.[1]?.context?.id).toMatch(/^[0-9a-f-]+$/);
+  expect(deleteSpy.mock.calls[0]?.[1]?.context?.internal?.userContext).toBeDefined();
 });
 
 test("AFS'skill delete should handle recursive option", async () => {
@@ -46,14 +42,11 @@ test("AFS'skill delete should handle recursive option", async () => {
   assert(deleteSkill);
   await deleteSkill.invoke({ path: "/foo/bar", recursive: true });
 
-  expect(deleteSpy.mock.lastCall).toMatchInlineSnapshot(`
-    [
-      "/foo/bar",
-      {
-        "recursive": true,
-      },
-    ]
-  `);
+  expect(deleteSpy.mock.lastCall?.[0]).toBe("/foo/bar");
+  expect(deleteSpy.mock.lastCall?.[1]?.recursive).toBe(true);
+  expect(deleteSpy.mock.lastCall?.[1]?.context).toBeDefined();
+  expect(deleteSpy.mock.lastCall?.[1]?.context?.id).toMatch(/^[0-9a-f-]+$/);
+  expect(deleteSpy.mock.lastCall?.[1]?.context?.internal?.userContext).toBeDefined();
 });
 
 test("AFS'skill delete should delete file by default (non-recursive)", async () => {

--- a/packages/core/test/prompt/skills/afs/edit.test.ts
+++ b/packages/core/test/prompt/skills/afs/edit.test.ts
@@ -1,7 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
 import assert from "node:assert";
 import { AFS } from "@aigne/afs";
-import { getAFSSkills } from "@aigne/core/prompt/skills/afs";
+import { getAFSSkills } from "@aigne/core/prompt/skills/afs/index.js";
 
 test("AFS edit should replace oldString with newString", async () => {
   const afs = new AFS();
@@ -38,13 +38,11 @@ test("AFS edit should replace oldString with newString", async () => {
        4| line 4"
   `);
 
-  expect(readSpy.mock.calls).toMatchInlineSnapshot(`
-    [
-      [
-        "/foo/test.txt",
-      ],
-    ]
-  `);
+  expect(readSpy.mock.calls.length).toBe(1);
+  expect(readSpy.mock.calls[0]?.[0]).toBe("/foo/test.txt");
+  expect(readSpy.mock.calls[0]?.[1]?.context).toBeDefined();
+  expect(readSpy.mock.calls[0]?.[1]?.context?.id).toMatch(/^[0-9a-f-]+$/);
+  expect(readSpy.mock.calls[0]?.[1]?.context?.internal?.userContext).toBeDefined();
 
   expect(writeSpy.mock.calls[0]?.[0]).toBe("/foo/test.txt");
   expect(writeSpy.mock.calls[0]?.[1]).toMatchObject({

--- a/packages/core/test/prompt/skills/afs/exec.test.ts
+++ b/packages/core/test/prompt/skills/afs/exec.test.ts
@@ -1,7 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
 import assert from "node:assert";
 import { AFS } from "@aigne/afs";
-import { getAFSSkills } from "@aigne/core/prompt/skills/afs";
+import { getAFSSkills } from "@aigne/core/prompt/skills/afs/index.js";
 
 test("AFS'skill exec should invoke afs.exec", async () => {
   const afs = new AFS();

--- a/packages/core/test/prompt/skills/afs/index.test.ts
+++ b/packages/core/test/prompt/skills/afs/index.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { AFS } from "@aigne/afs";
-import { getAFSSkills } from "@aigne/core/prompt/skills/afs";
+import { getAFSSkills } from "@aigne/core/prompt/skills/afs/index.js";
 
 test("AFS's skills should have correct tag", async () => {
   const skills = await getAFSSkills(new AFS());

--- a/packages/core/test/prompt/skills/afs/list.test.ts
+++ b/packages/core/test/prompt/skills/afs/list.test.ts
@@ -1,7 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
 import assert from "node:assert";
 import { AFS, type AFSEntry } from "@aigne/afs";
-import { getAFSSkills } from "@aigne/core/prompt/skills/afs";
+import { getAFSSkills } from "@aigne/core/prompt/skills/afs/index.js";
 
 test("AFS'skill list should invoke afs.list", async () => {
   const afs = new AFS();
@@ -23,17 +23,13 @@ test("AFS'skill list should invoke afs.list", async () => {
     }
   `);
 
-  expect(listSpy.mock.calls).toMatchInlineSnapshot(`
-    [
-      [
-        "/foo/bar",
-        {
-          "format": "simple-list",
-          "maxDepth": 2,
-        },
-      ],
-    ]
-  `);
+  expect(listSpy.mock.calls.length).toBe(1);
+  expect(listSpy.mock.calls[0]?.[0]).toBe("/foo/bar");
+  expect(listSpy.mock.calls[0]?.[1]?.format).toBe("simple-list");
+  expect(listSpy.mock.calls[0]?.[1]?.maxDepth).toBe(2);
+  expect(listSpy.mock.calls[0]?.[1]?.context).toBeDefined();
+  expect(listSpy.mock.calls[0]?.[1]?.context?.id).toMatch(/^[0-9a-f-]+$/);
+  expect(listSpy.mock.calls[0]?.[1]?.context?.internal?.userContext).toBeDefined();
 });
 
 test("AFS'skill list should use default maxDepth when not provided", async () => {
@@ -46,14 +42,11 @@ test("AFS'skill list should use default maxDepth when not provided", async () =>
   assert(list);
   await list.invoke({ path: "/foo/bar" });
 
-  expect(listSpy.mock.calls[0]).toMatchInlineSnapshot(`
-    [
-      "/foo/bar",
-      {
-        "format": "simple-list",
-      },
-    ]
-  `);
+  expect(listSpy.mock.calls[0]?.[0]).toBe("/foo/bar");
+  expect(listSpy.mock.calls[0]?.[1]?.format).toBe("simple-list");
+  expect(listSpy.mock.calls[0]?.[1]?.context).toBeDefined();
+  expect(listSpy.mock.calls[0]?.[1]?.context?.id).toMatch(/^[0-9a-f-]+$/);
+  expect(listSpy.mock.calls[0]?.[1]?.context?.internal?.userContext).toBeDefined();
 });
 
 test("AFS'skill list should return formatted tree structure", async () => {

--- a/packages/core/test/prompt/skills/afs/read.test.ts
+++ b/packages/core/test/prompt/skills/afs/read.test.ts
@@ -1,7 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
 import assert from "node:assert";
 import { AFS } from "@aigne/afs";
-import { getAFSSkills } from "@aigne/core/prompt/skills/afs";
+import { getAFSSkills } from "@aigne/core/prompt/skills/afs/index.js";
 
 test("AFS'skill read should invoke afs.read", async () => {
   const afs = new AFS();
@@ -30,13 +30,11 @@ test("AFS'skill read should invoke afs.read", async () => {
     }
   `);
 
-  expect(readSpy.mock.calls).toMatchInlineSnapshot(`
-    [
-      [
-        "/foo",
-      ],
-    ]
-  `);
+  expect(readSpy.mock.calls.length).toBe(1);
+  expect(readSpy.mock.calls[0]?.[0]).toBe("/foo");
+  expect(readSpy.mock.calls[0]?.[1]?.context).toBeDefined();
+  expect(readSpy.mock.calls[0]?.[1]?.context?.id).toMatch(/^[0-9a-f-]+$/);
+  expect(readSpy.mock.calls[0]?.[1]?.context?.internal?.userContext).toBeDefined();
 });
 
 test("AFS'skill read should handle file not found", async () => {

--- a/packages/core/test/prompt/skills/afs/rename.test.ts
+++ b/packages/core/test/prompt/skills/afs/rename.test.ts
@@ -1,7 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
 import assert from "node:assert";
 import { AFS } from "@aigne/afs";
-import { getAFSSkills } from "@aigne/core/prompt/skills/afs";
+import { getAFSSkills } from "@aigne/core/prompt/skills/afs/index.js";
 
 test("AFS'skill rename should invoke afs.rename", async () => {
   const afs = new AFS();
@@ -25,17 +25,13 @@ test("AFS'skill rename should invoke afs.rename", async () => {
     }
   `);
 
-  expect(renameSpy.mock.calls).toMatchInlineSnapshot(`
-    [
-      [
-        "/foo/old.txt",
-        "/foo/new.txt",
-        {
-          "overwrite": false,
-        },
-      ],
-    ]
-  `);
+  expect(renameSpy.mock.calls.length).toBe(1);
+  expect(renameSpy.mock.calls[0]?.[0]).toBe("/foo/old.txt");
+  expect(renameSpy.mock.calls[0]?.[1]).toBe("/foo/new.txt");
+  expect(renameSpy.mock.calls[0]?.[2]?.overwrite).toBe(false);
+  expect(renameSpy.mock.calls[0]?.[2]?.context).toBeDefined();
+  expect(renameSpy.mock.calls[0]?.[2]?.context?.id).toMatch(/^[0-9a-f-]+$/);
+  expect(renameSpy.mock.calls[0]?.[2]?.context?.internal?.userContext).toBeDefined();
 });
 
 test("AFS'skill rename should handle overwrite option", async () => {
@@ -54,15 +50,12 @@ test("AFS'skill rename should handle overwrite option", async () => {
     overwrite: true,
   });
 
-  expect(renameSpy.mock.lastCall).toMatchInlineSnapshot(`
-    [
-      "/foo/old.txt",
-      "/foo/new.txt",
-      {
-        "overwrite": true,
-      },
-    ]
-  `);
+  expect(renameSpy.mock.lastCall?.[0]).toBe("/foo/old.txt");
+  expect(renameSpy.mock.lastCall?.[1]).toBe("/foo/new.txt");
+  expect(renameSpy.mock.lastCall?.[2]?.overwrite).toBe(true);
+  expect(renameSpy.mock.lastCall?.[2]?.context).toBeDefined();
+  expect(renameSpy.mock.lastCall?.[2]?.context?.id).toMatch(/^[0-9a-f-]+$/);
+  expect(renameSpy.mock.lastCall?.[2]?.context?.internal?.userContext).toBeDefined();
 });
 
 test("AFS'skill rename should not overwrite by default", async () => {

--- a/packages/core/test/prompt/skills/afs/search.test.ts
+++ b/packages/core/test/prompt/skills/afs/search.test.ts
@@ -1,7 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
 import assert from "node:assert";
 import { AFS, type AFSEntry } from "@aigne/afs";
-import { getAFSSkills } from "@aigne/core/prompt/skills/afs";
+import { getAFSSkills } from "@aigne/core/prompt/skills/afs/index.js";
 
 test("AFS'skill search should invoke afs.search", async () => {
   const afs = new AFS();
@@ -37,15 +37,12 @@ test("AFS'skill search should invoke afs.search", async () => {
     }
   `);
 
-  expect(searchSpy.mock.calls).toMatchInlineSnapshot(`
-    [
-      [
-        "/foo/bar",
-        "test",
-        undefined,
-      ],
-    ]
-  `);
+  expect(searchSpy.mock.calls.length).toBe(1);
+  expect(searchSpy.mock.calls[0]?.[0]).toBe("/foo/bar");
+  expect(searchSpy.mock.calls[0]?.[1]).toBe("test");
+  expect(searchSpy.mock.calls[0]?.[2]?.context).toBeDefined();
+  expect(searchSpy.mock.calls[0]?.[2]?.context?.id).toMatch(/^[0-9a-f-]+$/);
+  expect(searchSpy.mock.calls[0]?.[2]?.context?.internal?.userContext).toBeDefined();
 });
 
 test("AFS'skill search should handle case-sensitive option", async () => {

--- a/packages/core/test/prompt/skills/afs/write.test.ts
+++ b/packages/core/test/prompt/skills/afs/write.test.ts
@@ -1,7 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
 import assert from "node:assert";
 import { AFS } from "@aigne/afs";
-import { getAFSSkills } from "@aigne/core/prompt/skills/afs";
+import { getAFSSkills } from "@aigne/core/prompt/skills/afs/index.js";
 
 test("AFS'skill write should invoke afs.write", async () => {
   const afs = new AFS();
@@ -26,19 +26,13 @@ test("AFS'skill write should invoke afs.write", async () => {
     }
   `);
 
-  expect(writeSpy.mock.calls).toMatchInlineSnapshot(`
-    [
-      [
-        "/foo",
-        {
-          "content": "bar",
-        },
-        {
-          "append": false,
-        },
-      ],
-    ]
-  `);
+  expect(writeSpy.mock.calls.length).toBe(1);
+  expect(writeSpy.mock.calls[0]?.[0]).toBe("/foo");
+  expect(writeSpy.mock.calls[0]?.[1]).toMatchObject({ content: "bar" });
+  expect(writeSpy.mock.calls[0]?.[2]?.append).toBe(false);
+  expect(writeSpy.mock.calls[0]?.[2]?.context).toBeDefined();
+  expect(writeSpy.mock.calls[0]?.[2]?.context?.id).toMatch(/^[0-9a-f-]+$/);
+  expect(writeSpy.mock.calls[0]?.[2]?.context?.internal?.userContext).toBeDefined();
 });
 
 test("AFS'skill write should handle append mode", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,7 +463,7 @@ importers:
         version: 13.0.1
       '@arcblock/did-connect-react':
         specifier: ^3.4.7
-        version: 3.4.7(@arcblock/ux@3.4.7(f817d3be148b587f81e890d67408cbb8))(@blocklet/js-sdk@1.17.7)(@blocklet/theme@3.4.7)(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 3.4.7(af74acdb56a11b7a065af97d2fa1ae51)
       '@arcblock/ux':
         specifier: ^3.4.7
         version: 3.4.7(f817d3be148b587f81e890d67408cbb8)
@@ -826,6 +826,31 @@ importers:
       '@aigne/cli':
         specifier: workspace:^
         version: link:../../packages/cli
+
+  examples/game-multiplayer:
+    dependencies:
+      '@aigne/cli':
+        specifier: workspace:^
+        version: link:../../packages/cli
+      '@aigne/core':
+        specifier: workspace:^
+        version: link:../../packages/core
+      '@aigne/default-memory':
+        specifier: workspace:^
+        version: link:../../memory/default
+      '@aigne/openai':
+        specifier: workspace:^
+        version: link:../../models/openai
+      zod:
+        specifier: ^3.25.67
+        version: 3.25.67
+    devDependencies:
+      '@aigne/test-utils':
+        specifier: workspace:^
+        version: link:../../packages/test-utils
+      '@types/bun':
+        specifier: ^1.2.22
+        version: 1.2.22(@types/react@19.1.13)
 
   examples/mcp-blocklet:
     dependencies:
@@ -1974,7 +1999,7 @@ importers:
         version: 13.0.1
       '@arcblock/did-connect-react':
         specifier: ^3.4.7
-        version: 3.4.7(@arcblock/ux@3.4.7(f817d3be148b587f81e890d67408cbb8))(@blocklet/js-sdk@1.17.7)(@blocklet/theme@3.4.7)(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 3.4.7(af74acdb56a11b7a065af97d2fa1ae51)
       '@arcblock/ux':
         specifier: ^3.4.7
         version: 3.4.7(f817d3be148b587f81e890d67408cbb8)
@@ -13279,7 +13304,7 @@ snapshots:
       '@ocap/wallet': 1.28.5
       archiver: 7.0.1
       axios: 1.12.2(debug@4.4.3)
-      axios-mock-adapter: 2.1.0(axios@1.12.2(debug@4.4.3))
+      axios-mock-adapter: 2.1.0(axios@1.12.2)
       axon: 2.0.3
       chalk: 4.1.2
       cookie: 1.0.2
@@ -13445,7 +13470,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@arcblock/did-connect-react@3.4.7(@arcblock/ux@3.4.7(f817d3be148b587f81e890d67408cbb8))(@blocklet/js-sdk@1.17.7)(@blocklet/theme@3.4.7)(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@arcblock/did-connect-react@3.4.7(af74acdb56a11b7a065af97d2fa1ae51)':
     dependencies:
       '@arcblock/bridge': 3.4.7
       '@arcblock/did': 1.28.5
@@ -14915,10 +14940,10 @@ snapshots:
       - tedious
       - utf-8-validate
 
-  '@blocklet/did-space-react@1.2.15(@arcblock/did-connect-react@3.4.7(@arcblock/ux@3.4.7(f817d3be148b587f81e890d67408cbb8))(@blocklet/js-sdk@1.17.7)(@blocklet/theme@3.4.7)(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@arcblock/ux@3.4.7(f817d3be148b587f81e890d67408cbb8))(@blocklet/js-sdk@1.17.7)(@blocklet/sdk@1.17.7)(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@blocklet/did-space-react@1.2.15(36edbd27fa0b642e84bf58ac70a575e8)':
     dependencies:
       '@arcblock/did': 1.28.5
-      '@arcblock/did-connect-react': 3.4.7(@arcblock/ux@3.4.7(f817d3be148b587f81e890d67408cbb8))(@blocklet/js-sdk@1.17.7)(@blocklet/theme@3.4.7)(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@arcblock/did-connect-react': 3.4.7(af74acdb56a11b7a065af97d2fa1ae51)
       '@arcblock/ux': 3.4.7(f817d3be148b587f81e890d67408cbb8)
       '@blocklet/js-sdk': 1.17.7
       '@blocklet/sdk': 1.17.7
@@ -15216,12 +15241,12 @@ snapshots:
       '@abtnode/constant': 1.17.7
       '@abtnode/util': 1.17.7
       '@arcblock/bridge': 3.4.7
-      '@arcblock/did-connect-react': 3.4.7(@arcblock/ux@3.4.7(f817d3be148b587f81e890d67408cbb8))(@blocklet/js-sdk@1.17.7)(@blocklet/theme@3.4.7)(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@arcblock/did-connect-react': 3.4.7(af74acdb56a11b7a065af97d2fa1ae51)
       '@arcblock/icons': 3.4.7(react@19.1.1)
       '@arcblock/react-hooks': 3.4.7
       '@arcblock/ux': 3.4.7(f817d3be148b587f81e890d67408cbb8)
       '@arcblock/ws': 1.28.5
-      '@blocklet/did-space-react': 1.2.15(@arcblock/did-connect-react@3.4.7(@arcblock/ux@3.4.7(f817d3be148b587f81e890d67408cbb8))(@blocklet/js-sdk@1.17.7)(@blocklet/theme@3.4.7)(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@arcblock/ux@3.4.7(f817d3be148b587f81e890d67408cbb8))(@blocklet/js-sdk@1.17.7)(@blocklet/sdk@1.17.7)(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@blocklet/did-space-react': 1.2.15(36edbd27fa0b642e84bf58ac70a575e8)
       '@blocklet/js-sdk': 1.17.7
       '@emotion/react': 11.14.0(@types/react@19.1.13)(react@19.1.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1)
@@ -18971,12 +18996,6 @@ snapshots:
   await-to-js@3.0.0: {}
 
   awesome-phonenumber@7.5.0: {}
-
-  axios-mock-adapter@2.1.0(axios@1.12.2(debug@4.4.3)):
-    dependencies:
-      axios: 1.12.2(debug@4.4.3)
-      fast-deep-equal: 3.1.3
-      is-buffer: 2.0.5
 
   axios-mock-adapter@2.1.0(axios@1.12.2):
     dependencies:


### PR DESCRIPTION
## Summary
- Pass AIGNEContext to AFS skill operations (read, write, edit, list, delete, rename, search, exec) so that userId, sessionId, and other context identifiers flow through to AFS methods
- Fix test import paths to use explicit `.js` extension for ESM compatibility
- Replace unstable inline snapshots containing dynamic UUIDs with stable assertions that verify context structure without checking exact ID values

## Test plan
- [x] Run `bun test test/prompt/skills/afs/` - all 56 tests pass
- [x] Run `bun test test/prompt/prompts/afs-builtin-prompt.test.ts` - passes
<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**Refactor:**
- Enhanced AFS (Agent File System) operations to properly utilize AIGNE context, enabling better session and user tracking across file system interactions

**Test:**
- Improved test suite ESM compatibility with explicit `.js` extensions
- Updated AFS skill tests to verify proper context propagation instead of relying on unstable snapshots

**Note:** This change improves internal context handling for file operations, ensuring proper user session management and traceability within the AIGNE system.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->